### PR TITLE
Add Alpine-based multi-stage Dockerfile

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,34 @@
+# ---- Build Stage ----
+FROM golang:1.26.2 AS builder
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux \
+    go build -ldflags="-s -w" -o /puppet-ca     ./cmd/puppet-ca/ && \
+    go build -ldflags="-s -w" -o /puppet-ca-ctl ./cmd/puppet-ca-ctl/
+
+# ---- Runtime Stage ----
+FROM alpine:3.23.4
+
+# ca-certificates: system trust store for puppet-ca-ctl's HTTPS client
+# when invoked without --ca-cert against a publicly-trusted server.
+RUN apk add --no-cache ca-certificates && \
+    adduser -D -h /home/puppet puppet && \
+    mkdir -p /etc/puppetlabs/puppet/ssl/ca /data && \
+    chown -R puppet:puppet /etc/puppetlabs/puppet /data
+
+COPY --from=builder /puppet-ca     /usr/local/bin/puppet-ca
+COPY --from=builder /puppet-ca-ctl /usr/local/bin/puppet-ca-ctl
+
+USER puppet
+EXPOSE 8140
+
+# NOTE: autosign is OFF by default. Set --autosign-config=true only in
+# dev/test environments. Autosign lets any CSR submitter obtain a signed
+# certificate without operator review.
+ENTRYPOINT ["/usr/local/bin/puppet-ca"]
+CMD ["--cadir=/etc/puppetlabs/puppet/ssl/ca", \
+     "--verbosity=1"]


### PR DESCRIPTION
Build puppet-ca and puppet-ca-ctl with the official Golang image and ship them in an Alpine runtime. CGO is disabled so the resulting binary is statically linked and runs on Alpine regardless of the builder's libc. Produces a smaller runtime image than the CentOS Stream Dockerfile while keeping the same entrypoint, exposed port, non-root puppet user, and /etc/puppetlabs/puppet/ssl/ca layout.

Only ca-certificates is installed in the runtime: puppet-ca has no outbound HTTPS clients, and puppet-ca-ctl falls back to the system trust store when --ca-cert is not supplied. curl and openssl are not needed at runtime (crypto runs in-process via crypto/tls + crypto/x509).