### PR TITLE
Return 200 instead of 409 when certificate exists on CSR resubmission

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -295,7 +295,7 @@ var _ = Describe("API Workflow", func() {
 			Expect(resp.State).To(Equal("revoked"))
 		})
 
-		It("should return 409 when submitting a CSR for a subject with an active certificate", func() {
+		It("should return 200 when submitting a CSR for a subject with an active certificate", func() {
 			subject := "conflict-node"
 			csrPEM, err := testutil.GenerateCSR(subject)
 			Expect(err).NotTo(HaveOccurred())
@@ -309,7 +309,9 @@ var _ = Describe("API Workflow", func() {
 			req := httptest.NewRequest("PUT", "/certificate_request/"+subject, bytes.NewReader(csrPEM2))
 			rr := httptest.NewRecorder()
 			mux.ServeHTTP(rr, req)
-			Expect(rr.Code).To(Equal(http.StatusConflict))
+			// 200 so the node continues to poll and retrieves its cert via GET
+			// rather than treating the re-submission as a fatal conflict.
+			Expect(rr.Code).To(Equal(http.StatusOK))
 		})
 	})
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -327,10 +327,14 @@ func (s *Server) handlePutRequest(w http.ResponseWriter, r *http.Request) {
 
 	signed, err := s.CA.SaveRequest(r.Context(), subject, csrPEM)
 	if err != nil {
-		slog.Warn("SaveRequest failed", "subject", subject, "error", err)
 		if errors.Is(err, ca.ErrCertExists) {
-			http.Error(w, err.Error(), http.StatusConflict)
+			// A signed certificate already exists for this subject. Return 200 so
+			// the node continues its poll loop and retrieves its cert via GET.
+			// Returning 409 here causes the node (e.g. openvox-agent) to treat the
+			// submission as fatal and abort the run entirely.
+			w.WriteHeader(http.StatusOK)
 		} else {
+			slog.Warn("SaveRequest failed", "subject", subject, "error", err)
 			http.Error(w, err.Error(), http.StatusBadRequest)
 		}
 		return

--- a/test/integration-compose.sh
+++ b/test/integration-compose.sh
@@ -573,11 +573,11 @@ assert_http 400 "PUT /certificate_status with malformed JSON → 400" \
     -d 'not-json' \
     "${CA_URL}/puppet-ca/v1/certificate_status/valid-node"
 
-# 409: second CSR for active cert
+# 200: second CSR for active cert (node continues polling, fetches cert via GET)
 _CONF="conflict-${RUN_ID}.example.com"
 submit_csr "$_CONF"
 $CTL sign --certname "$_CONF" >/dev/null 2>&1 || true
-assert_http 409 "Duplicate CSR for active cert → 409" \
+assert_http 200 "Duplicate CSR for active cert → 200" \
     -X PUT -H "Content-Type: text/plain" \
     --data-binary @"$WORK_DIR/${_CONF}.csr" \
     "${CA_URL}/puppet-ca/v1/certificate_request/${_CONF}"


### PR DESCRIPTION
When a node polls with --waitforcert and its CSR lands on a different replica than the one that signed the certificate, SaveRequest correctly detects ErrCertExists via evictRevokedLocked. The handler was converting this into HTTP 409 Conflict, which openvox-agent treats as a fatal error and aborts the run.

The existing comment already stated the intent: PUT /certificate_request always returns 200, regardless of outcome. A signed certificate already existing is a success from the node's perspective - it should proceed to fetch it via GET /certificate/{subject}. Return 200 for ErrCertExists so the node continues its poll loop rather than giving up.

Fixes #18