### PR TITLE
Add CN-to-SAN promotion option (default on)

### DIFF
--- a/cmd/puppet-ca/config.go
+++ b/cmd/puppet-ca/config.go
@@ -75,6 +75,9 @@ type serverConfig struct {
 	EncryptCAKey        bool   `yaml:"encrypt_ca_key"`         // encrypt the CA private key at rest (AES-256-GCM + Argon2id)
 	CAKeyPassphraseFile string `yaml:"ca_key_passphrase_file"` // path to file containing the CA key passphrase
 
+	// PromoteCNToSAN adds the CN as a DNS SAN when the CSR has no SANs (default: true).
+	PromoteCNToSAN bool `yaml:"promote_cn_to_san"`
+
 	// Storage backend selection. "filesystem" (default) stores all CA data
 	// under CADir; "etcd" keeps CA cert, key, CRL, inventory, serial, CSRs
 	// and signed certs in an etcd cluster; "redis" (alias "valkey") keeps
@@ -124,9 +127,10 @@ type serverConfig struct {
 // loading.
 func loadServerConfig(configFile string) (*serverConfig, error) {
 	cfg := &serverConfig{
-		Host:         "0.0.0.0",
-		Port:         8140,
-		CAPathLength: -1, // unconstrained; 0 = leaf-only, N = N levels of intermediates
+		Host:           "0.0.0.0",
+		Port:           8140,
+		CAPathLength:   -1,   // unconstrained; 0 = leaf-only, N = N levels of intermediates
+		PromoteCNToSAN: true, // RFC 2818: add CN as SAN when CSR has no SANs
 	}
 
 	if configFile != "" {
@@ -262,6 +266,11 @@ func applyServerEnv(cfg *serverConfig) {
 	if v := os.Getenv("PUPPET_CA_ENCRYPT_CA_KEY"); v != "" {
 		if b, err := strconv.ParseBool(v); err == nil {
 			cfg.EncryptCAKey = b
+		}
+	}
+	if v := os.Getenv("PUPPET_CA_PROMOTE_CN_TO_SAN"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.PromoteCNToSAN = b
 		}
 	}
 	if v := os.Getenv("PUPPET_CA_KEY_PASSPHRASE_FILE"); v != "" {

--- a/cmd/puppet-ca/main.go
+++ b/cmd/puppet-ca/main.go
@@ -172,6 +172,7 @@ func applyCAConfig(myCA *ca.CA, cfg *serverConfig) error {
 	myCA.CAValidityDays = cfg.CAValidityDays
 	myCA.LeafValidityDays = cfg.LeafValidityDays
 	myCA.EncryptCAKey = cfg.EncryptCAKey
+	myCA.PromoteCNToSAN = cfg.PromoteCNToSAN
 	myCA.KeyPassphrase = ca.KeyPassphraseConfig{
 		PassphraseFile: cfg.CAKeyPassphraseFile,
 	}

--- a/internal/ca/ca.go
+++ b/internal/ca/ca.go
@@ -97,6 +97,14 @@ type CA struct {
 	// When true, the key is encrypted using the resolved passphrase.
 	EncryptCAKey bool
 
+	// PromoteCNToSAN, when true (the default), adds the CSR's Common Name as a
+	// DNS Subject Alternative Name when the CSR carries no SANs. RFC 2818 §3.1
+	// deprecated CN-based hostname verification in favour of the SAN extension;
+	// modern TLS clients (Go stdlib, Chrome, etc.) ignore the CN entirely. Set
+	// to false only when issuing certificates to legacy clients that cannot
+	// handle the SAN extension.
+	PromoteCNToSAN bool
+
 	// ExternalSigner, when non-nil, is used instead of loading the CA private
 	// key from disk. This enables key isolation: the private key lives in a
 	// separate process and signing requests are proxied over IPC.
@@ -114,7 +122,8 @@ func New(s *storage.StorageService, autosignCfg AutosignConfig, hostname string)
 		Storage:        s,
 		AutosignConfig: autosignCfg,
 		Hostname:       hostname,
-		CAPathLength:   -1, // unconstrained by default
+		CAPathLength:   -1,   // unconstrained by default
+		PromoteCNToSAN: true, // on by default; RFC 2818 deprecates CN-only certs
 		serialIndex:    make(map[string]string),
 		ocspCache:      make(map[string]ocspCacheEntry),
 	}

--- a/internal/ca/ca_test.go
+++ b/internal/ca/ca_test.go
@@ -260,6 +260,58 @@ var _ = Describe("CA Lifecycle", func() {
 		})
 	})
 
+	Context("CN to SAN promotion", func() {
+		BeforeEach(func() {
+			err := myCA.Init(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		parseCert := func(certPEM []byte) *x509.Certificate {
+			block, _ := pem.Decode(certPEM)
+			Expect(block).NotTo(BeNil())
+			cert, err := x509.ParseCertificate(block.Bytes)
+			Expect(err).NotTo(HaveOccurred())
+			return cert
+		}
+
+		It("promotes CN to SAN when no SANs are present (default on)", func() {
+			csrPEM, err := testutil.GenerateCSR("test-node")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = myCA.SaveRequest(context.Background(), "test-node", csrPEM)
+			Expect(err).NotTo(HaveOccurred())
+			certPEM, err := myCA.Sign(context.Background(), "test-node")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(parseCert(certPEM).DNSNames).To(ConsistOf("test-node"))
+		})
+
+		It("does not promote CN when the CSR already carries SANs", func() {
+			key, _ := rsa.GenerateKey(rand.Reader, 2048)
+			tmpl := &x509.CertificateRequest{
+				Subject:  pkix.Name{CommonName: "test-node"},
+				DNSNames: []string{"alt.test-node"},
+			}
+			csrDER, _ := x509.CreateCertificateRequest(rand.Reader, tmpl, key)
+			csrPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER})
+
+			_, err := myCA.SaveRequest(context.Background(), "test-node", csrPEM)
+			Expect(err).NotTo(HaveOccurred())
+			certPEM, err := myCA.Sign(context.Background(), "test-node")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(parseCert(certPEM).DNSNames).To(ConsistOf("alt.test-node"))
+		})
+
+		It("does not promote CN when PromoteCNToSAN is false", func() {
+			myCA.PromoteCNToSAN = false
+			csrPEM, err := testutil.GenerateCSR("test-node")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = myCA.SaveRequest(context.Background(), "test-node", csrPEM)
+			Expect(err).NotTo(HaveOccurred())
+			certPEM, err := myCA.Sign(context.Background(), "test-node")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(parseCert(certPEM).DNSNames).To(BeEmpty())
+		})
+	})
+
 	Context("Negative Tests", func() {
 		BeforeEach(func() {
 			err := myCA.Init(context.Background())

--- a/internal/ca/signing.go
+++ b/internal/ca/signing.go
@@ -285,6 +285,13 @@ func (c *CA) signWithDuration(ctx context.Context, subject string, ttl time.Dura
 		DNSNames: csr.DNSNames,
 	}
 
+	// RFC 2818 §3.1: TLS clients match the server name against SANs, not the
+	// CN. When the CSR carries no SANs and promotion is enabled, add the CN as
+	// a DNS SAN so that the issued certificate works with modern TLS stacks.
+	if c.PromoteCNToSAN && len(template.DNSNames) == 0 && csr.Subject.CommonName != "" {
+		template.DNSNames = []string{csr.Subject.CommonName}
+	}
+
 	// CRL Distribution Points: embed CRL URL(s) when configured so that
 	// verifiers can automatically fetch the CRL (RFC 5280 §4.2.1.13).
 	if len(c.CRLURLs) > 0 {

--- a/test/integration-compose.sh
+++ b/test/integration-compose.sh
@@ -507,13 +507,16 @@ assert_json_field "$_san_body" '"dns_alt_names"' \
 assert_json_field "$_san_body" '"subject_alt_names"' \
     "Status response includes subject_alt_names field"
 
-# Both fields must exist and both should be empty arrays [] for a plain CSR
+# CN promotion is on by default: plain CSR should have the CN added as a DNS SAN.
+grep -qF "\"${_SAN}\"" <<< "$_san_body" \
+    && pass "dns_alt_names contains promoted CN for plain cert" \
+    || fail "dns_alt_names contains promoted CN for plain cert" "body: $_san_body"
 grep -qF '"dns_alt_names":[]' <<< "$_san_body" \
-    && pass "dns_alt_names is [] for plain cert (no SANs)" \
-    || fail "dns_alt_names is [] for plain cert (no SANs)" "body: $_san_body"
+    && fail "dns_alt_names must not be empty (CN should be promoted to SAN)" "body: $_san_body" \
+    || pass "dns_alt_names is non-empty (CN promoted)"
 grep -qF '"subject_alt_names":[]' <<< "$_san_body" \
-    && pass "subject_alt_names is [] for plain cert (matches dns_alt_names)" \
-    || fail "subject_alt_names is [] for plain cert (matches dns_alt_names)" "body: $_san_body"
+    && fail "subject_alt_names must not be empty (mirrors dns_alt_names)" "body: $_san_body" \
+    || pass "subject_alt_names is non-empty (mirrors dns_alt_names)"
 
 # GET /certificate_statuses must also have subject_alt_names
 _sts_body=$(curl -s "${CA_URL}/puppet-ca/v1/certificate_statuses/all?state=signed" 2>/dev/null) || true


### PR DESCRIPTION
RFC 2818 §3.1 deprecated using the CN for TLS hostname verification in favour of the Subject Alternative Names extension. Modern TLS clients (Go stdlib, Chrome, Firefox) ignore the CN entirely and require a DNS SAN to match the server name.

When a CSR carries no SANs and the new PromoteCNToSAN option is true (the default), signWithDuration copies the CN into the certificate's DNSNames. This ensures that every issued certificate is usable with current TLS stacks without requiring CSR authors to include an explicit SAN extension.

The option is configurable via:
  - CA struct field: PromoteCNToSAN (bool, default true)
  - Config file:     promote_cn_to_san: false
  - Environment:     PUPPET_CA_PROMOTE_CN_TO_SAN=false

Set to false to issue CN-only certificates for legacy clients that cannot handle the SAN extension.