### PR TITLE
Remove SHA256: prefix from certificate fingerprints

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -496,7 +496,7 @@ func fingerprint(data []byte) string {
 	for i := 0; i < len(raw); i += 2 {
 		parts = append(parts, raw[i:i+2])
 	}
-	return "SHA256:" + strings.Join(parts, ":")
+	return strings.Join(parts, ":")
 }
 
 // noNilSlice returns s unchanged when non-nil, or an empty non-nil slice.


### PR DESCRIPTION
The fingerprint field was returning "SHA256:AA:BB:..." but should contain only the colon-separated hex nibbles without the algorithm prefix.