### PR TITLE
Implement POST /certificate_renewal endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,14 @@ All endpoints are served under both the bare path and `/puppet-ca/v1/<path>`, so
 |--------|------|-------------|
 | `GET` | `/certificate/{subject}` | Retrieve a signed certificate PEM (`ca` returns the CA cert) |
 
+### Certificate renewal
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/certificate_renewal` | Renew an existing certificate; body: raw CSR PEM; returns new certificate PEM |
+
+Requires a valid CA-signed client certificate. The CSR Common Name must match the authenticated client CN — an agent can only renew its own certificate, not another's. The new certificate is issued immediately without entering the pending-CSR queue or autosign evaluation.
+
 ### Bulk signing
 
 | Method | Path | Description |
@@ -414,7 +422,7 @@ When mTLS is enabled (both `--tls-cert` and `--tls-key` set), each endpoint requ
 | Tier | Required client cert | Endpoints |
 |------|---------------------|-----------|
 | **Public** | None | `GET /healthz/*`, `GET /certificate/{subject}`, `GET /certificate_revocation_list/ca`, `PUT /certificate_request/{subject}`, `GET /expirations`, `POST /ocsp`, `GET /ocsp/{request}` |
-| **Any client** | Any CA-signed cert | `GET /certificate_status/{subject}` (public with `--allow-public-status`) |
+| **Any client** | Any CA-signed cert | `GET /certificate_status/{subject}` (public with `--allow-public-status`), `POST /certificate_renewal` |
 | **Self or admin** | Cert CN matches path subject, OR cert is admin | `GET /certificate_request/{subject}` |
 | **Admin** | Cert is admin (see below) | `PUT /certificate_status/{subject}`, `DELETE /certificate_status/{subject}`, `DELETE /certificate_request/{subject}`, `GET /certificate_statuses/*`, `POST /sign`, `POST /sign/all`, `POST /generate/{subject}`, `PUT /clean` |
 
@@ -637,7 +645,7 @@ mage test:bench
 mage test:puppet
 ```
 
-`test:integCompose` and `test:loadCompose` use `compose.yml`, the canonical integration test suite. It runs two containers on an isolated network (puppet-ca + test-runner) and exercises the full API in TAP format across 20 test groups:
+`test:integCompose` and `test:loadCompose` use `compose.yml`, the canonical integration test suite. It runs two containers on an isolated network (puppet-ca + test-runner) and exercises the full API in TAP format across 21 test groups:
 
 | Group | Coverage |
 |-------|----------|
@@ -661,6 +669,7 @@ mage test:puppet
 | 18 | `pp_cli_auth` mTLS: Phase 1 bootstraps certs (loopback HTTP); Phase 2 asserts pp_cli_auth cert reaches admin endpoints while plain cert is denied |
 | 19 | `puppet-ca-ctl` error paths: revoke/clean/sign/generate against non-existent or duplicate subjects; arg validation; `--dns` SAN delivery; full mTLS via `--ca-cert`/`--client-cert`/`--client-key`; unreachable server |
 | 20 | Migration from Puppet Server CA: import CA cert/key/CRL via `puppet-ca-ctl import`, copy pre-existing signed certs, verify fetch/sign/revoke/list all work on the migrated CA |
+| 21 | `POST /certificate_renewal` over mTLS: agent renews its own certificate; CN-mismatch renewal rejected |
 
 `test:bench` uses `compose-bench.yml` (autosign=true, k6 load runner).
 `test:puppet` uses `compose-puppet.yml`, a five-service stack that validates end-to-end catalog compilation, PuppetDB reporting, exported resources, and CRL revocation using a real OpenVox 8 agent and WEBrick puppet master. The CA runs with genuine TLS (a cert with CN=puppet-ca signed by the CA itself); all inter-service traffic verifies it.

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
@@ -1145,6 +1146,83 @@ var _ = Describe("API Workflow", func() {
 
 		It("returns 400 for malformed JSON", func() {
 			req := httptest.NewRequest("PUT", "/clean", bytes.NewReader([]byte("{bad")))
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+			Expect(rr.Code).To(Equal(http.StatusBadRequest))
+		})
+	})
+
+	Context("POST /certificate_renewal", func() {
+		var (
+			subject    string
+			clientCert *x509.Certificate
+		)
+
+		BeforeEach(func() {
+			subject = "renew-node"
+
+			// Submit and sign a certificate for the subject.
+			csrPEM, err := testutil.GenerateCSR(subject)
+			Expect(err).NotTo(HaveOccurred())
+			mux.ServeHTTP(httptest.NewRecorder(),
+				httptest.NewRequest("PUT", "/certificate_request/"+subject, bytes.NewReader(csrPEM)))
+			body, _ := json.Marshal(api.PutStatusBody{DesiredState: "signed"})
+			mux.ServeHTTP(httptest.NewRecorder(),
+				httptest.NewRequest("PUT", "/certificate_status/"+subject, bytes.NewReader(body)))
+
+			// Retrieve the signed cert so we can simulate mTLS with it.
+			certPEM, err := myCA.Storage.GetCert(context.Background(), subject)
+			Expect(err).NotTo(HaveOccurred())
+			block, _ := pem.Decode(certPEM)
+			Expect(block).NotTo(BeNil())
+			clientCert, err = x509.ParseCertificate(block.Bytes)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should renew the certificate and return PEM", func() {
+			renewCSR, err := testutil.GenerateCSR(subject)
+			Expect(err).NotTo(HaveOccurred())
+			req := httptest.NewRequest("POST", "/certificate_renewal", bytes.NewReader(renewCSR))
+			req.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{clientCert}}
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+			Expect(rr.Code).To(Equal(http.StatusOK))
+			Expect(rr.Body.String()).To(ContainSubstring("CERTIFICATE"))
+		})
+
+		It("should also work via the /puppet-ca/v1/certificate_renewal path", func() {
+			renewCSR, err := testutil.GenerateCSR(subject)
+			Expect(err).NotTo(HaveOccurred())
+			req := httptest.NewRequest("POST", "/puppet-ca/v1/certificate_renewal", bytes.NewReader(renewCSR))
+			req.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{clientCert}}
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+			Expect(rr.Code).To(Equal(http.StatusOK))
+		})
+
+		It("should return 403 when no client certificate is presented", func() {
+			renewCSR, err := testutil.GenerateCSR(subject)
+			Expect(err).NotTo(HaveOccurred())
+			req := httptest.NewRequest("POST", "/certificate_renewal", bytes.NewReader(renewCSR))
+			// No r.TLS — simulates plain HTTP or missing client cert.
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+			Expect(rr.Code).To(Equal(http.StatusForbidden))
+		})
+
+		It("should return 403 when the CSR CN does not match the client CN", func() {
+			mismatchCSR, err := testutil.GenerateCSR("other-node")
+			Expect(err).NotTo(HaveOccurred())
+			req := httptest.NewRequest("POST", "/certificate_renewal", bytes.NewReader(mismatchCSR))
+			req.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{clientCert}}
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+			Expect(rr.Code).To(Equal(http.StatusForbidden))
+		})
+
+		It("should return 400 for an invalid CSR body", func() {
+			req := httptest.NewRequest("POST", "/certificate_renewal", bytes.NewReader([]byte("not a csr")))
+			req.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{clientCert}}
 			rr := httptest.NewRecorder()
 			mux.ServeHTTP(rr, req)
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -1,4 +1,5 @@
 // Copyright (C) 2026 Trevor Vaughan
+// Copyright (C) 2026 Chris Boot
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -190,6 +191,12 @@ func lookupTier(method, path string, cfg *AuthConfig) authTier {
 	// Self or admin reads.
 	case method == "GET" && strings.HasPrefix(p, "/certificate_request/"):
 		return tierSelfOrAdmin
+
+	// Certificate renewal: any CA-signed client cert may renew itself.
+	// The handler enforces that the CSR CN matches the authenticated client CN,
+	// so an agent can only renew its own certificate.
+	case method == "POST" && p == "/certificate_renewal":
+		return tierAnyClient
 
 	// Admin only: all other operations.
 	default:

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1,4 +1,5 @@
 // Copyright (C) 2026 Trevor Vaughan
+// Copyright (C) 2026 Chris Boot
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -100,6 +101,7 @@ func (s *Server) Routes() http.Handler {
 		{"POST", "/sign/all", s.handlePostSignAll},
 		{"PUT", "/clean", s.handlePutClean},
 		{"POST", "/generate/{subject}", s.handlePostGenerate},
+		{"POST", "/certificate_renewal", s.handlePostCertificateRenewal},
 	}
 
 	prefixes := []string{"", "/puppet-ca/v1"}
@@ -723,6 +725,52 @@ func (s *Server) handlePostSign(w http.ResponseWriter, r *http.Request) {
 	result := s.signInBatches(r.Context(), body.Certnames)
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(result)
+}
+
+// --- Certificate renewal ---
+
+func (s *Server) handlePostCertificateRenewal(w http.ResponseWriter, r *http.Request) {
+	// Renewal requires an authenticated client cert to establish identity.
+	cn := clientCN(r)
+	if cn == "" {
+		http.Error(w, "client certificate required for renewal", http.StatusForbidden)
+		return
+	}
+	slog.Debug("POST certificate_renewal", "client", cn)
+
+	// SECURITY: Limit body to 1 MiB to prevent memory exhaustion.
+	// NIST 800-53: SC-5 (Denial-of-Service Protection)
+	csrPEM, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		http.Error(w, "failed to read body: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	csr, err := parseCSR(csrPEM)
+	if err != nil {
+		http.Error(w, "invalid CSR: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// SECURITY: CSR CN must match the authenticated client CN. Without this
+	// check an agent could renew another agent's certificate by sending a CSR
+	// with a different CN while authenticating as itself.
+	// NIST 800-53: IA-5(2) (PKI-Based Authentication)
+	if csr.Subject.CommonName != cn {
+		slog.Warn("Renewal rejected: CN mismatch", "client_cn", cn, "csr_cn", csr.Subject.CommonName)
+		http.Error(w, "CSR CN does not match authenticated client CN", http.StatusForbidden)
+		return
+	}
+
+	certPEM, err := s.CA.Renew(r.Context(), cn, csrPEM)
+	if err != nil {
+		slog.Warn("Renewal failed", "subject", cn, "error", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/plain")
+	w.Write(certPEM)
 }
 
 func (s *Server) handlePostSignAll(w http.ResponseWriter, r *http.Request) {

--- a/internal/ca/signing.go
+++ b/internal/ca/signing.go
@@ -588,3 +588,54 @@ func (c *CA) SaveRequest(ctx context.Context, subject string, csrPEM []byte) (bo
 	}
 	return autosigned, nil
 }
+
+// Renew issues a replacement certificate for subject from the provided CSR,
+// bypassing the pending-CSR queue and autosign check. The existing certificate
+// (if any) is replaced atomically under the per-subject distributed lock.
+//
+// The caller is responsible for verifying that the CSR CN matches the
+// authenticated client's CN before calling Renew; this method enforces that
+// invariant a second time as defence-in-depth.
+func (c *CA) Renew(ctx context.Context, subject string, csrPEM []byte) ([]byte, error) {
+	if err := ValidateSubject(subject); err != nil {
+		return nil, err
+	}
+
+	// Validate and parse the CSR before acquiring any lock.
+	block, _ := pem.Decode(csrPEM)
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode CSR PEM for %s", subject)
+	}
+	csr, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse CSR for %s: %w", subject, err)
+	}
+	// SECURITY: Verify the CSR's proof-of-possession signature.
+	// NIST 800-53: IA-5(2) (PKI-Based Authentication)
+	if err := csr.CheckSignature(); err != nil {
+		return nil, fmt.Errorf("invalid CSR signature for %s: %w", subject, err)
+	}
+	// SECURITY: CN must match subject — defence-in-depth; handler also checks.
+	// NIST 800-53: IA-5(2) (PKI-Based Authentication), SI-10 (Information Input Validation)
+	if csr.Subject.CommonName != subject {
+		return nil, fmt.Errorf("CSR CN %q does not match subject %q", csr.Subject.CommonName, subject)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, lockTimeout)
+	defer cancel()
+	var out []byte
+	err = c.Storage.WithLock(ctx, subjectLockName(subject), func() error {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		if err := c.Storage.SaveCSR(ctx, subject, csrPEM); err != nil {
+			return fmt.Errorf("saving renewal CSR: %w", err)
+		}
+		certPEM, err := c.signWithDuration(ctx, subject, 0)
+		if err != nil {
+			return err
+		}
+		out = certPEM
+		return nil
+	})
+	return out, err
+}

--- a/test/integration-compose.sh
+++ b/test/integration-compose.sh
@@ -1962,6 +1962,148 @@ kill "$_MIG_PID" 2>/dev/null; wait "$_MIG_PID" 2>/dev/null || true
 rm -rf "$_MIG_DIR" "$_MIG_OLD"
 
 # ═════════════════════════════════════════════════════════════════════════════
+# Group 21 -- POST /certificate_renewal (mTLS)
+#
+#   Starts a short-lived local puppet-ca on port 8145.
+#   Phase 1 (loopback HTTP, autosign=true): bootstrap CA, generate a TLS
+#   server cert, a node client cert, and a second node cert for CN-mismatch
+#   testing.
+#   Phase 2 (TLS): verify the renewal endpoint.
+# ═════════════════════════════════════════════════════════════════════════════
+printf '\n# Group 21 -- POST /certificate_renewal (mTLS)\n'
+
+_REN_PORT=8145
+_REN_DIR=$(mktemp -d)
+_REN_PID=""
+_REN_CA_URL="http://127.0.0.1:${_REN_PORT}"
+_REN_NODE="ren-node-${RUN_ID}"
+_REN_OTHER="ren-other-${RUN_ID}"
+
+_wait_ren_ca() {
+    local url="$1" n=60
+    while [ "$n" -gt 0 ]; do
+        curl -sfk "${url}/healthz/ready" -o /dev/null 2>/dev/null && return 0
+        sleep 0.3
+        n=$(( n - 1 ))
+    done
+    return 1
+}
+
+# --- Phase 1: loopback HTTP, autosign=true, generate all certs ---------------
+
+puppet-ca-ctl setup --cadir "$_REN_DIR" --hostname renewal-test-ca 2>/dev/null
+
+puppet-ca --cadir "$_REN_DIR" \
+    --host 127.0.0.1 --port "$_REN_PORT" \
+    --no-tls-required \
+    --autosign-config=true \
+    >/dev/null 2>&1 &
+_REN_PID=$!
+
+if _wait_ren_ca "$_REN_CA_URL"; then
+    pass "renewal: Phase 1 CA started (loopback HTTP, autosign=true)"
+
+    # TLS server cert (key saved to $_REN_DIR/renewal-test-ca_key.pem)
+    puppet-ca-ctl --server-url "$_REN_CA_URL" \
+        generate --certname renewal-test-ca --out-dir "$_REN_DIR" \
+        > "$_REN_DIR/tls-server.crt" 2>/dev/null
+
+    # Node client cert: key at $WORK_DIR/${_REN_NODE}_key.pem, cert to stdout
+    puppet-ca-ctl --server-url "$_REN_CA_URL" \
+        generate --certname "$_REN_NODE" --out-dir "$WORK_DIR" \
+        > "$WORK_DIR/ren-node.crt" 2>/dev/null
+
+    # Second node cert for CN-mismatch testing
+    puppet-ca-ctl --server-url "$_REN_CA_URL" \
+        generate --certname "$_REN_OTHER" --out-dir "$WORK_DIR" \
+        > "$WORK_DIR/ren-other.crt" 2>/dev/null
+else
+    fail "renewal: Phase 1 CA started (loopback HTTP, autosign=true)" \
+        "timed out waiting for health"
+fi
+
+kill "$_REN_PID" 2>/dev/null; wait "$_REN_PID" 2>/dev/null || true
+_REN_PID=""
+
+# --- Phase 2: TLS, exercise the renewal endpoint -----------------------------
+
+puppet-ca --cadir "$_REN_DIR" \
+    --host 127.0.0.1 --port "$_REN_PORT" \
+    --tls-cert "$_REN_DIR/tls-server.crt" \
+    --tls-key  "$_REN_DIR/renewal-test-ca_key.pem" \
+    >/dev/null 2>&1 &
+_REN_PID=$!
+
+if _wait_ren_ca "https://127.0.0.1:${_REN_PORT}"; then
+    pass "renewal: Phase 2 CA started (TLS)"
+
+    # Build a renewal CSR for $_REN_NODE (different key from the original — the
+    # renewal sends a new public key; make_csr reuses $WORK_DIR/test.key).
+    make_csr "$_REN_NODE" "$WORK_DIR/ren-renewal.csr"
+
+    # Happy path: node cert + matching CSR CN → 200 with PEM certificate body
+    _ren_body=$(curl -sk \
+        --cert "$WORK_DIR/ren-node.crt" \
+        --key  "$WORK_DIR/${_REN_NODE}_key.pem" \
+        -X POST -H "Content-Type: text/plain" \
+        --data-binary @"$WORK_DIR/ren-renewal.csr" \
+        "https://127.0.0.1:${_REN_PORT}/puppet-ca/v1/certificate_renewal") || true
+    echo "$_ren_body" | grep -qF "BEGIN CERTIFICATE" \
+        && pass "renewal: POST /certificate_renewal returns PEM certificate" \
+        || fail "renewal: POST /certificate_renewal returns PEM certificate" \
+               "body: $(echo "$_ren_body" | head -3)"
+
+    # CN mismatch: ren-other authenticates but CSR is for ren-node → 403
+    assert_http 403 "renewal: CN mismatch returns 403" \
+        -sk \
+        --cert "$WORK_DIR/ren-other.crt" \
+        --key  "$WORK_DIR/${_REN_OTHER}_key.pem" \
+        -X POST -H "Content-Type: text/plain" \
+        --data-binary @"$WORK_DIR/ren-renewal.csr" \
+        "https://127.0.0.1:${_REN_PORT}/puppet-ca/v1/certificate_renewal"
+
+    # No client cert → 403 (RequestClientCert allows no cert, handler enforces)
+    assert_http 403 "renewal: no client cert returns 403" \
+        -sk \
+        -X POST -H "Content-Type: text/plain" \
+        --data-binary @"$WORK_DIR/ren-renewal.csr" \
+        "https://127.0.0.1:${_REN_PORT}/puppet-ca/v1/certificate_renewal"
+
+    # Invalid CSR body → 400
+    assert_http 400 "renewal: invalid CSR body returns 400" \
+        -sk \
+        --cert "$WORK_DIR/ren-node.crt" \
+        --key  "$WORK_DIR/${_REN_NODE}_key.pem" \
+        -X POST -H "Content-Type: text/plain" \
+        -d "this is not a csr" \
+        "https://127.0.0.1:${_REN_PORT}/puppet-ca/v1/certificate_renewal"
+
+    # Bare-path alias /certificate_renewal (without /puppet-ca/v1) also works
+    make_csr "$_REN_NODE" "$WORK_DIR/ren-renewal2.csr"
+    assert_http 200 "renewal: bare-path /certificate_renewal returns 200" \
+        -sk \
+        --cert "$WORK_DIR/ren-node.crt" \
+        --key  "$WORK_DIR/${_REN_NODE}_key.pem" \
+        -X POST -H "Content-Type: text/plain" \
+        --data-binary @"$WORK_DIR/ren-renewal2.csr" \
+        "https://127.0.0.1:${_REN_PORT}/certificate_renewal"
+else
+    fail "renewal: Phase 2 CA started (TLS)" "timed out waiting for health"
+    for _skip in \
+        "renewal: POST /certificate_renewal returns PEM certificate" \
+        "renewal: CN mismatch returns 403" \
+        "renewal: no client cert returns 403" \
+        "renewal: invalid CSR body returns 400" \
+        "renewal: bare-path /certificate_renewal returns 200"
+    do
+        fail "$_skip" "SKIP: CA did not start"
+    done
+fi
+
+kill "$_REN_PID" 2>/dev/null; wait "$_REN_PID" 2>/dev/null || true
+rm -rf "$_REN_DIR"
+
+# ═════════════════════════════════════════════════════════════════════════════
 # Results
 # ═════════════════════════════════════════════════════════════════════════════
 printf '\n1..%d\n' "$T"


### PR DESCRIPTION
Agents with an existing CA-signed certificate can now renew it over mTLS without waiting for manual approval: the CA verifies the CSR CN matches the authenticated client CN and issues a replacement certificate immediately. This is required for golang-puppet-ca to be a full drop-in replacement for the Puppet Server CA.

New CA method Renew() acquires the per-subject distributed lock, saves the renewal CSR, and calls signWithDuration() directly — bypassing the pending-CSR queue and autosign check. Auth tier is tierAnyClient so any valid node cert grants access; CN-matching in both the handler and Renew() prevents an agent from renewing another's certificate.

Fixes #15