### PR TITLE
Add opt-in Puppet CA date/time format for JSON responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ csr_rate_limit: 60    # max CSR submissions per IP per minute; 0 = disable rate 
 # CA key encryption at rest.
 encrypt_ca_key: false           # encrypt the CA private key (AES-256-GCM + Argon2id)
 ca_key_passphrase_file: ""      # path to passphrase file; auto-generated if omitted
+# Date/time format in JSON responses.
+puppet_datetime_format: false   # use Puppet CA style "2006-01-02T15:04:05MST" instead of RFC 3339
 ```
 
 **Environment variables (mirrors CLI flags):**
@@ -199,6 +201,7 @@ The CA key passphrase can also be provided via `PUPPET_CA_KEY_PASSPHRASE` (env v
 | `etcd_tls_ca_file` | `PUPPET_CA_ETCD_TLS_CA_FILE` |
 | `etcd_tls_cert_file` | `PUPPET_CA_ETCD_TLS_CERT_FILE` |
 | `etcd_tls_key_file` | `PUPPET_CA_ETCD_TLS_KEY_FILE` |
+| `puppet_datetime_format` | `PUPPET_CA_PUPPET_DATETIME_FORMAT` |
 
 > **Note:** `--daemon` is intentionally excluded from config file and environment
 > variable support because `PUPPET_CA_DAEMON` is used internally as the daemon fork

--- a/cmd/puppet-ca/config.go
+++ b/cmd/puppet-ca/config.go
@@ -77,6 +77,9 @@ type serverConfig struct {
 
 	// PromoteCNToSAN adds the CN as a DNS SAN when the CSR has no SANs (default: true).
 	PromoteCNToSAN bool `yaml:"promote_cn_to_san"`
+	// PuppetDateTimeFormat formats JSON date/time fields using the original Puppet CA
+	// style ("2006-01-02T15:04:05MST") instead of RFC 3339 (default: false).
+	PuppetDateTimeFormat bool `yaml:"puppet_datetime_format"`
 
 	// Storage backend selection. "filesystem" (default) stores all CA data
 	// under CADir; "etcd" keeps CA cert, key, CRL, inventory, serial, CSRs
@@ -271,6 +274,11 @@ func applyServerEnv(cfg *serverConfig) {
 	if v := os.Getenv("PUPPET_CA_PROMOTE_CN_TO_SAN"); v != "" {
 		if b, err := strconv.ParseBool(v); err == nil {
 			cfg.PromoteCNToSAN = b
+		}
+	}
+	if v := os.Getenv("PUPPET_CA_PUPPET_DATETIME_FORMAT"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.PuppetDateTimeFormat = b
 		}
 	}
 	if v := os.Getenv("PUPPET_CA_KEY_PASSPHRASE_FILE"); v != "" {

--- a/cmd/puppet-ca/main.go
+++ b/cmd/puppet-ca/main.go
@@ -553,6 +553,7 @@ func main() {
 			srv.CSRRateLimit = csrRL
 			srv.SignBatchLimit = 50 // Default max batch size for sign operations
 			srv.PlainHTTP = !tlsConfigured && !isLoopback(cfg.Host) && !cfg.NoTLSRequired
+			srv.PuppetDateTimeFormat = cfg.PuppetDateTimeFormat
 
 			// Wire mTLS auth middleware when TLS is configured.
 			if cfg.TLSCert != "" && cfg.TLSKey != "" {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1229,4 +1229,68 @@ var _ = Describe("API Workflow", func() {
 		})
 	})
 
+	Context("PuppetDateTimeFormat", func() {
+		const puppetFmt = "2006-01-02T15:04:05MST"
+
+		signSubject := func(subject string) {
+			csrPEM, err := testutil.GenerateCSR(subject)
+			Expect(err).NotTo(HaveOccurred())
+			mux.ServeHTTP(httptest.NewRecorder(),
+				httptest.NewRequest("PUT", "/certificate_request/"+subject, bytes.NewReader(csrPEM)))
+			body, _ := json.Marshal(api.PutStatusBody{DesiredState: "signed"})
+			mux.ServeHTTP(httptest.NewRecorder(),
+				httptest.NewRequest("PUT", "/certificate_status/"+subject, bytes.NewReader(body)))
+		}
+
+		It("defaults to RFC 3339 format for not_before / not_after", func() {
+			signSubject("fmt-default-node")
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, httptest.NewRequest("GET", "/certificate_status/fmt-default-node", nil))
+			Expect(rr.Code).To(Equal(http.StatusOK))
+
+			var resp api.CertStatusResponse
+			Expect(json.Unmarshal(rr.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp.NotBefore).NotTo(BeNil())
+			// RFC 3339 uses a numeric offset or Z, not a timezone abbreviation.
+			_, err := time.Parse(time.RFC3339, *resp.NotBefore)
+			Expect(err).NotTo(HaveOccurred(), "not_before should parse as RFC 3339")
+		})
+
+		It("uses Puppet CA format for not_before / not_after when enabled", func() {
+			server.PuppetDateTimeFormat = true
+			mux = server.Routes()
+
+			signSubject("fmt-puppet-node")
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, httptest.NewRequest("GET", "/certificate_status/fmt-puppet-node", nil))
+			Expect(rr.Code).To(Equal(http.StatusOK))
+
+			var resp api.CertStatusResponse
+			Expect(json.Unmarshal(rr.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp.NotBefore).NotTo(BeNil())
+			_, err := time.Parse(puppetFmt, *resp.NotBefore)
+			Expect(err).NotTo(HaveOccurred(), "not_before should parse as Puppet CA format")
+			_, err = time.Parse(time.RFC3339, *resp.NotBefore)
+			Expect(err).To(HaveOccurred(), "not_before should not be valid RFC 3339 in Puppet mode")
+		})
+
+		It("uses Puppet CA format for expirations when enabled", func() {
+			server.PuppetDateTimeFormat = true
+			mux = server.Routes()
+
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, httptest.NewRequest("GET", "/expirations", nil))
+			Expect(rr.Code).To(Equal(http.StatusOK))
+
+			var resp struct {
+				CACertificate struct {
+					Expiration string `json:"expiration"`
+				} `json:"ca_certificate"`
+			}
+			Expect(json.Unmarshal(rr.Body.Bytes(), &resp)).To(Succeed())
+			_, err := time.Parse(puppetFmt, resp.CACertificate.Expiration)
+			Expect(err).NotTo(HaveOccurred(), "expiration should parse as Puppet CA format")
+		})
+	})
+
 })

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -59,6 +59,10 @@ type Server struct {
 	// SignBatchLimit is the maximum number of certificates that can be signed
 	// in a single POST /sign or POST /sign/all request. Zero disables the limit.
 	SignBatchLimit int
+	// PuppetDateTimeFormat when true formats date/time fields using the original
+	// Puppet CA style ("2006-01-02T15:04:05MST") instead of RFC 3339. Useful
+	// when integrating with tooling that expects exact Puppet Server output.
+	PuppetDateTimeFormat bool
 
 	csrLimiter     *ipRateLimiter
 	destructiveOps *destructiveOpTracker
@@ -157,7 +161,7 @@ func (s *Server) handleGetStatus(w http.ResponseWriter, r *http.Request) {
 			state = "revoked"
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(certStatusFromCert(subject, certPEM, state))
+		json.NewEncoder(w).Encode(certStatusFromCert(subject, certPEM, state, s.timeFormat()))
 		return
 	}
 
@@ -515,8 +519,16 @@ func noNilSlice(s []string) []string {
 	return s
 }
 
+// timeFormat returns the time layout string to use for JSON date/time fields.
+func (s *Server) timeFormat() string {
+	if s.PuppetDateTimeFormat {
+		return "2006-01-02T15:04:05MST"
+	}
+	return time.RFC3339
+}
+
 // certStatusFromCert builds a CertStatusResponse from a signed or revoked certificate.
-func certStatusFromCert(subject string, certPEM []byte, state string) CertStatusResponse {
+func certStatusFromCert(subject string, certPEM []byte, state string, timeFmt string) CertStatusResponse {
 	cert, err := parseCert(certPEM)
 	if err != nil {
 		slog.Warn("Failed to parse cert for status response", "subject", subject, "error", err)
@@ -533,8 +545,8 @@ func certStatusFromCert(subject string, certPEM []byte, state string) CertStatus
 	}
 	fp := fingerprint(certPEM)
 	serial := cert.SerialNumber.Text(10) // decimal string; preserves full 128-bit value
-	nb := cert.NotBefore.UTC().Format(time.RFC3339)
-	na := cert.NotAfter.UTC().Format(time.RFC3339)
+	nb := cert.NotBefore.UTC().Format(timeFmt)
+	na := cert.NotAfter.UTC().Format(timeFmt)
 	dnsNames := noNilSlice(cert.DNSNames)
 	return CertStatusResponse{
 		Name:                    subject,
@@ -638,7 +650,7 @@ func (s *Server) handleGetStatuses(w http.ResponseWriter, r *http.Request) {
 		if stateFilter != "" && state != stateFilter {
 			continue
 		}
-		statuses = append(statuses, certStatusFromCert(subject, certPEM, state))
+		statuses = append(statuses, certStatusFromCert(subject, certPEM, state, s.timeFormat()))
 	}
 	for _, subject := range csrs {
 		if seen[subject] {
@@ -682,13 +694,13 @@ func (s *Server) handleGetExpirations(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "CA not ready", http.StatusServiceUnavailable)
 		return
 	}
-	certExp := s.CA.CACert.NotAfter.UTC().Format(time.RFC3339)
+	certExp := s.CA.CACert.NotAfter.UTC().Format(s.timeFormat())
 
 	crlNextUpdate := ""
 	if crlPEM, err := s.CA.Storage.GetCRL(r.Context(), ); err == nil {
 		if block, _ := pem.Decode(crlPEM); block != nil {
 			if crl, err := x509.ParseRevocationList(block.Bytes); err == nil {
-				crlNextUpdate = crl.NextUpdate.UTC().Format(time.RFC3339)
+				crlNextUpdate = crl.NextUpdate.UTC().Format(s.timeFormat())
 			}
 		}
 	}


### PR DESCRIPTION
Adds a PuppetDateTimeFormat option (default off) that formats date/time fields in JSON responses using the original Puppet CA style "2006-01-02T15:04:05MST" instead of RFC 3339. Configurable via puppet_datetime_format in YAML config or PUPPET_CA_PUPPET_DATETIME_FORMAT env var.