### PR TITLE
ci: add etcd storage-backend integration job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,23 @@ jobs:
       - name: Run MySQL-backend integration tests
         run: mage test:backendsMySQL
 
+  # Runs the etcd-backend Go integration suite (build tag etcd_integration).
+  # The suite boots an in-process embedded etcd, so it needs no external service
+  # or compose stack.
+  backends-etcd:
+    name: Storage backend tests (etcd)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Install Mage
+        run: go install github.com/magefile/mage@v1.15.0
+      - name: Run etcd-backend integration tests
+        run: mage test:backendsEtcd
+
   # -- Compose integration tests (docker compose) ------------------------------─
   # podman-compose is not pre-installed on GitHub runners; composeCmd() in
   # magefile.go falls back to `docker compose` (v2 plugin, always available).

--- a/internal/storage/etcd.go
+++ b/internal/storage/etcd.go
@@ -23,6 +23,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io/fs"
+	"math/rand/v2"
 	"strings"
 	"sync"
 	"time"
@@ -304,7 +305,7 @@ func (b *EtcdBackend) AppendLine(ctx context.Context, key string, data []byte, _
 		return err
 	}
 
-	const maxRetries = 8
+	const maxRetries = 16
 	for attempt := range maxRetries {
 		getCtx, cancel := b.callCtx(ctx)
 		resp, err := b.client.Get(getCtx, phys)
@@ -340,12 +341,18 @@ func (b *EtcdBackend) AppendLine(ctx context.Context, key string, data []byte, _
 		if txnResp.Succeeded {
 			return nil
 		}
-		// Another writer won the race; back off briefly and retry —
-		// honour the caller's cancellation rather than spinning past it.
+		// Another writer won the race; back off and retry. The sleep is a
+		// growing window with full jitter: jitter decorrelates two writers
+		// that would otherwise retry in lock-step on the same schedule and
+		// keep colliding (the cause of spurious "too many concurrent writers"
+		// under load). Honour the caller's cancellation rather than spinning
+		// past it.
+		window := time.Duration(attempt+1) * 10 * time.Millisecond
+		backoff := time.Duration(rand.Int64N(int64(window))) //nolint:gosec // jitter, not security-sensitive
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(time.Duration(attempt+1) * 10 * time.Millisecond):
+		case <-time.After(backoff):
 		}
 	}
 	return fmt.Errorf("append to %q failed: too many concurrent writers", key)

--- a/magefile.go
+++ b/magefile.go
@@ -51,7 +51,7 @@ import (
 // -- Namespaces ----------------------------------------------------------------
 
 type Build mg.Namespace // build:all  build:fips  build:dist
-type Test mg.Namespace  // test:unit  test:integcompose  test:integcomposefips  test:loadcompose  test:bench  test:puppet  test:puppetfips  test:migration  test:backendsRedis
+type Test mg.Namespace  // test:unit  test:integcompose  test:integcomposefips  test:loadcompose  test:bench  test:puppet  test:puppetfips  test:migration  test:backendsRedis  test:backendsEtcd
 type Dev mg.Namespace   // dev:check  dev:tidy    dev:clean  dev:container
 
 // -- Helpers ------------------------------------------------------------------─
@@ -498,6 +498,14 @@ func (Test) BackendsMySQL() error {
 		map[string]string{"PUPPET_CA_TEST_MYSQL_DSN": dsn},
 		"go", "test", "-tags", "mysql_integration", "-count=1", "./internal/storage/...",
 	)
+}
+
+// BackendsEtcd runs the etcd-backend Go integration suite (build tag
+// etcd_integration). The suite boots an in-process embedded etcd, so unlike the
+// Redis suite it needs no external service, compose stack, or network pulls.
+func (Test) BackendsEtcd() error {
+	fmt.Println("Running etcd-backend integration tests...")
+	return sh.RunV("go", "test", "-tags", "etcd_integration", "-count=1", "./internal/storage/...")
 }
 
 // PuppetFIPS is like Puppet but compiles with GOEXPERIMENT=boringcrypto so the


### PR DESCRIPTION
## Summary

The CI matrix had a **Storage backend tests (Redis)** job but nothing exercising the **etcd** backend. This adds an equivalent etcd job. Branched off `main` (independent of the SQL-backend PRs #28–#30).

- New `mage test:backendsEtcd` target → runs the `etcd_integration` suite. The suite boots an **in-process embedded etcd**, so the job needs no external service, compose stack, or image pulls (lighter than the Redis job).
- New **Storage backend tests (etcd)** CI job mirroring `backends-redis`.

## Pre-existing flake fixed
Wiring the suite into CI surfaced a pre-existing flake in `TestEtcdBackendAppendLineConcurrent`. The etcd `AppendLine` optimistic-`Txn` retry used a **linear backoff with no jitter**, so two writers contending on the same `ModRevision` could retry in lock-step and keep colliding — exhausting the retry budget under load with `too many concurrent writers`.

Fix: **full jitter** on the backoff window + raise the retry ceiling from 8 to 16. This also makes real two-replica etcd deployments more robust under write contention, not just the test.

## Verification
- `go build ./...`, `go vet ./...`, full `go test ./...` — green.
- `go test -tags etcd_integration ./internal/storage/...` stress-run **10×: 0 failures** (previously ~1-in-5).
- `mage test:backendsEtcd` passes end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)