### PR TITLE
ci: lint Dockerfiles with hadolint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,30 @@ jobs:
       - name: Check formatting, vet, and module tidy
         run: mage dev:check
 
+  # -- Dockerfile lint (hadolint) ----------------------------------------------
+  # Lints every Dockerfile in the repo. hadolint has no auto-fix mode (it only
+  # reports), so this job fails the build on violations and the developer fixes
+  # them -- the same fail-and-fix contract as `mage dev:check` above. One matrix
+  # leg per Dockerfile so annotations stay attributed to the right file.
+  hadolint:
+    name: Dockerfile lint (${{ matrix.dockerfile }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dockerfile:
+          - Dockerfile
+          - Dockerfile.alpine
+          - Dockerfile.run
+          - docker/puppet/Dockerfile
+          - docker/puppet/Dockerfile.client
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run hadolint
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: ${{ matrix.dockerfile }}
+
   # -- Unit tests --------------------------------------------------------------─
   unit:
     name: Unit tests

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,17 @@
+# hadolint configuration (https://github.com/hadolint/hadolint)
+#
+# Ignored rules:
+#   DL3041 - "Specify version with dnf install -y <package>-<version>"
+#   DL3018 - "Pin versions in apk add"
+#
+# We intentionally do not pin dnf/apk package versions: the images build
+# against rolling distro repositories (CentOS Stream, Alpine), where pinning
+# exact versions breaks builds as soon as upstream rebuilds a package.
+#
+# These are global defaults. Individual rules can still be re-enabled or
+# further suppressed per Dockerfile with inline comments, e.g.:
+#   # hadolint ignore=DL3008,DL3009
+#   RUN ...
+ignored:
+  - DL3041
+  - DL3018


### PR DESCRIPTION
## What

Adds a `hadolint` matrix job to the CI workflow that lints all five Dockerfiles in the repo:

- `Dockerfile`
- `Dockerfile.alpine`
- `Dockerfile.run`
- `docker/puppet/Dockerfile`
- `docker/puppet/Dockerfile.client`

One matrix leg per file keeps annotations attributed to the right Dockerfile.

## Behaviour

hadolint has no auto-fix mode (it only reports), so the job **fails the build** on violations and the developer fixes them — the same fail-and-fix contract as `mage dev:check`.

A repo-level `.hadolint.yaml` ignores the two version-pinning rules:

- **DL3041** — "Specify version with `dnf install -y <package>-<version>`"
- **DL3018** — "Pin versions in `apk add`"

These images build against rolling distro repositories (CentOS Stream, Alpine), where pinning exact package versions breaks builds the moment upstream rebuilds a package. Every other hadolint rule stays enforced.

## Verification

Ran `hadolint` locally against all five Dockerfiles with this config — all pass clean (`rc=0`). The new job will be green on first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)