### PR TITLE
ci: build and publish multi-arch container images

### DIFF
--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -1,0 +1,240 @@
+name: Container images
+
+# Builds the CentOS Stream and Alpine runtime images for linux/amd64 and
+# linux/arm64 and publishes multi-arch manifests to the GitHub Container
+# Registry (GHCR).
+#
+# Triggers:
+#   * Release tags (v*)        -> build + push versioned + latest tags.
+#   * Manual (workflow_dispatch) -> build, push only if the "push" input is set.
+#   * Pull requests, on demand -> apply the "build-images" label to a PR to
+#     build both variants on both architectures as a validation check. Same-repo
+#     PRs additionally push a throwaway pr-<n> tag; fork PRs build only (their
+#     GITHUB_TOKEN is read-only and cannot write packages).
+#
+# See docs/container-images.md for the one-time repository setup the owner must
+# perform (enabling GHCR, the build-images label, and package visibility).
+
+on:
+  push:
+    tags:
+      - "v*"
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+  workflow_dispatch:
+    inputs:
+      push:
+        description: "Push images to GHCR (otherwise build only)"
+        type: boolean
+        default: false
+
+# GITHUB_TOKEN needs packages:write to push to GHCR. On pull requests from
+# forks GitHub automatically downgrades this to read-only; the build job
+# detects that and skips pushing.
+permissions:
+  contents: read
+  packages: write
+
+# Cancel superseded PR runs, but never cancel a release/tag build mid-flight.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  # -- Decide whether this run pushes, and compute the image name -------------─
+  setup:
+    name: Configure
+    # PR runs only proceed when explicitly opted in via the build-images label.
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'build-images')
+    runs-on: ubuntu-latest
+    outputs:
+      push: ${{ steps.cfg.outputs.push }}
+      image: ${{ steps.cfg.outputs.image }}
+    steps:
+      - name: Determine push policy and image name
+        id: cfg
+        env:
+          EVENT: ${{ github.event_name }}
+          DISPATCH_PUSH: ${{ github.event.inputs.push }}
+          # Empty for same-repo PRs is impossible; for forks this differs from
+          # the base repository, which is how we detect a fork PR.
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+        run: |
+          case "$EVENT" in
+            push)             push=true ;;                 # tag build (release)
+            workflow_dispatch) push="$DISPATCH_PUSH" ;;     # honour the input
+            pull_request)
+              # Push only for same-repo PRs; fork PRs lack a write token.
+              if [ "$PR_HEAD_REPO" = "$BASE_REPO" ]; then push=true; else push=false; fi
+              ;;
+            *)                push=false ;;
+          esac
+          # GHCR requires a lowercase image path.
+          image="ghcr.io/$(echo "$BASE_REPO" | tr '[:upper:]' '[:lower:]')"
+          {
+            echo "push=$push"
+            echo "image=$image"
+          } >> "$GITHUB_OUTPUT"
+          echo "push=$push image=$image"
+
+  # -- Build one (variant x architecture) on a native runner ------------------─
+  # Each image is pushed by digest (no tag); the merge job assembles the
+  # per-variant multi-arch manifest from the collected digests.
+  build:
+    name: Build ${{ matrix.variant }} (${{ matrix.arch }})
+    needs: setup
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [centos, alpine]
+        platform: [linux/amd64, linux/arm64]
+        include:
+          - variant: centos
+            dockerfile: Dockerfile
+          - variant: alpine
+            dockerfile: Dockerfile.alpine
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: needs.setup.outputs.push == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ needs.setup.outputs.image }}
+
+      # Push path: build and push by digest for later manifest assembly.
+      - name: Build and push by digest
+        if: needs.setup.outputs.push == 'true'
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Provenance attestations create extra manifests that confuse
+          # push-by-digest + imagetools merge, so disable them here.
+          provenance: false
+          outputs: type=image,name=${{ needs.setup.outputs.image }},push-by-digest=true,name-canonical=true,push=true
+
+      # Validation path (fork PRs / dispatch without push): build for the
+      # runner's native arch, load it, and smoke-test the entrypoint.
+      - name: Build and load for smoke test
+        if: needs.setup.outputs.push != 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          load: true
+          tags: puppet-ca:smoke-${{ matrix.variant }}-${{ matrix.arch }}
+      - name: Smoke test entrypoint
+        if: needs.setup.outputs.push != 'true'
+        run: docker run --rm puppet-ca:smoke-${{ matrix.variant }}-${{ matrix.arch }} --help
+
+      - name: Export digest
+        if: needs.setup.outputs.push == 'true'
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.push.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: needs.setup.outputs.push == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.variant }}-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # -- Merge per-architecture digests into one multi-arch manifest ------------─
+  merge:
+    name: Publish ${{ matrix.variant }} manifest
+    needs: [setup, build]
+    if: needs.setup.outputs.push == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # CentOS Stream is the default image: unsuffixed tags + latest.
+          - variant: centos
+            flavor: |
+              latest=auto
+          # Alpine images carry an -alpine suffix, including latest-alpine.
+          - variant: alpine
+            flavor: |
+              latest=auto
+              suffix=-alpine,onlatest=true
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-${{ matrix.variant }}-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ needs.setup.outputs.image }}
+          flavor: ${{ matrix.flavor }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref_name, 'v0.') }}
+            type=ref,event=branch
+            type=ref,event=pr
+
+      - name: Create multi-arch manifest
+        working-directory: /tmp/digests
+        env:
+          IMAGE: ${{ needs.setup.outputs.image }}
+        run: |
+          # Word splitting is intentional: expand the -t flags and the
+          # per-digest image references into separate arguments.
+          # shellcheck disable=SC2046
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf "${IMAGE}@sha256:%s " *)
+
+      - name: Inspect published image
+        env:
+          IMAGE: ${{ needs.setup.outputs.image }}
+        run: |
+          tag="$(jq -r '.tags[0]' <<< "$DOCKER_METADATA_OUTPUT_JSON")"
+          docker buildx imagetools inspect "$tag"

--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -5,6 +5,7 @@ name: Container images
 # Registry (GHCR).
 #
 # Triggers:
+#   * Push to main            -> build + push the rolling "edge" (and "main") tags.
 #   * Release tags (v*)        -> build + push versioned + latest tags.
 #   * Manual (workflow_dispatch) -> build, push only if the "push" input is set.
 #   * Pull requests, on demand -> apply the "build-images" label to a PR to
@@ -17,6 +18,8 @@ name: Container images
 
 on:
   push:
+    branches:
+      - main
     tags:
       - "v*"
   pull_request:
@@ -214,6 +217,7 @@ jobs:
           images: ${{ needs.setup.outputs.image }}
           flavor: ${{ matrix.flavor }}
           tags: |
+            type=edge
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}},enable=${{ !startsWith(github.ref_name, 'v0.') }}

--- a/docs/container-images.md
+++ b/docs/container-images.md
@@ -1,0 +1,69 @@
+# Container images
+
+The [`Container images`](../.github/workflows/container-images.yml) workflow
+builds the two runtime images and publishes multi-arch manifests to the GitHub
+Container Registry (GHCR).
+
+| Variant       | Dockerfile                              | Base image              | Tag suffix |
+| ------------- | --------------------------------------- | ----------------------- | ---------- |
+| CentOS Stream | [`Dockerfile`](../Dockerfile)           | `quay.io/centos/centos` | *(none)*   |
+| Alpine        | [`Dockerfile.alpine`](../Dockerfile.alpine) | `alpine`            | `-alpine`  |
+
+Both variants are built for `linux/amd64` and `linux/arm64` and published as a
+single multi-arch manifest per variant. The image name follows the repository:
+`ghcr.io/<owner>/golang-puppet-ca`.
+
+```console
+$ docker pull ghcr.io/<owner>/golang-puppet-ca:latest          # CentOS Stream
+$ docker pull ghcr.io/<owner>/golang-puppet-ca:latest-alpine   # Alpine
+```
+
+## When images are built
+
+| Trigger | What happens |
+| --- | --- |
+| **Release tag** (`git push` of a `v*` tag) | Builds both variants on both architectures and pushes the semver tags (`1.2.3`, `1.2`, `1`), `latest`, and their `-alpine` counterparts. |
+| **Manual** (Actions → *Container images* → *Run workflow*) | Builds everything. Pushes only if you tick the **push** input; otherwise it builds and smoke-tests without publishing. |
+| **Pull request** | Builds nothing by default. Apply the **`build-images`** label to a PR to build both variants on both architectures as a validation check. Same-repo PRs also push a throwaway `pr-<n>` tag; fork PRs build only (their token cannot write packages). |
+
+Architecture builds run on native GitHub-hosted runners — `ubuntu-latest`
+(amd64) and `ubuntu-24.04-arm` (arm64) — and the per-architecture digests are
+merged into the final manifest. No QEMU emulation is involved, so arm64 builds
+run at native speed.
+
+## One-time repository setup (for the repository owner)
+
+These steps must be performed once by someone with admin access to the upstream
+repository. Until then, release/manual builds will fail at the push step and PR
+validation builds will still work (they don't push).
+
+1. **Allow Actions to publish packages.**
+   Settings → Actions → General → *Workflow permissions*. The workflow already
+   requests `packages: write`, but if an organization policy overrides this,
+   select **Read and write permissions** (or explicitly allow the
+   `GITHUB_TOKEN` to write packages for this repository).
+
+2. **Publish a release to create the package, then set its visibility.**
+   The GHCR package is created on the first successful push and is **private**
+   by default. To make the images publicly pullable: your profile/org →
+   *Packages* → `golang-puppet-ca` → *Package settings* → *Change visibility* →
+   **Public**. The package is automatically linked to this repository via the
+   `org.opencontainers.image.source` label.
+
+3. **Create the `build-images` label.**
+   Issues → *Labels* → *New label*, name it exactly `build-images`. Maintainers
+   apply this label to a PR to opt it into a container build. Because applying a
+   label requires triage/write access, contributors cannot self-trigger builds.
+
+4. **arm64 runners.**
+   The `ubuntu-24.04-arm` runner used for arm64 is free for **public**
+   repositories. For a private repository you must provision arm64 runners
+   (GitHub-hosted larger runners or self-hosted) or the arm64 build jobs will
+   queue indefinitely.
+
+5. **Fork pull-request approval (the build "gate").**
+   GitHub holds workflow runs on PRs from first-time contributors until a
+   maintainer approves them (Settings → Actions → General → *Fork pull request
+   workflows from outside collaborators*). Combined with the `build-images`
+   label, this means fork PRs only build after a maintainer both approves the
+   run and applies the label — and even then they never push.

--- a/docs/container-images.md
+++ b/docs/container-images.md
@@ -22,6 +22,7 @@ $ docker pull ghcr.io/<owner>/golang-puppet-ca:latest-alpine   # Alpine
 
 | Trigger | What happens |
 | --- | --- |
+| **Push to `main`** | Builds both variants on both architectures and pushes the rolling `edge` (and `main`) tags, plus their `-alpine` counterparts. `edge` always points at the latest default-branch build. |
 | **Release tag** (`git push` of a `v*` tag) | Builds both variants on both architectures and pushes the semver tags (`1.2.3`, `1.2`, `1`), `latest`, and their `-alpine` counterparts. |
 | **Manual** (Actions → *Container images* → *Run workflow*) | Builds everything. Pushes only if you tick the **push** input; otherwise it builds and smoke-tests without publishing. |
 | **Pull request** | Builds nothing by default. Apply the **`build-images`** label to a PR to build both variants on both architectures as a validation check. Same-repo PRs also push a throwaway `pr-<n>` tag; fork PRs build only (their token cannot write packages). |


### PR DESCRIPTION
## Summary

Adds a `Container images` workflow that builds both runtime images for **linux/amd64** and **linux/arm64** and publishes multi-arch manifests to the GitHub Container Registry (GHCR):

| Variant | Dockerfile | Tag suffix |
| --- | --- | --- |
| CentOS Stream | `Dockerfile` | *(none)* — the default image |
| Alpine | `Dockerfile.alpine` | `-alpine` |

Image name follows the repo: `ghcr.io/<owner>/golang-puppet-ca`.

### Build strategy
Each architecture builds on a **native** GitHub-hosted runner (`ubuntu-latest` for amd64, `ubuntu-24.04-arm` for arm64), is pushed by digest, and a merge job assembles the per-variant multi-arch manifest. No QEMU emulation, so arm64 builds run at native speed.

### When images are built
- **Push to `main`** → builds all 4 and pushes the rolling `edge` (and `main`) tags, plus their `-alpine` counterparts. `edge` always points at the latest default-branch build; `latest` is reserved for tagged releases.
- **Release tags (`v*`)** → builds all 4 and pushes `1.2.3`, `1.2`, `1`, `latest` and their `-alpine` counterparts.
- **Manual (`workflow_dispatch`)** → builds on demand; pushes only if the `push` input is ticked, otherwise builds + smoke-tests without publishing.
- **Pull requests** → nothing by default. Apply the **`build-images`** label to validate both variants on both arches. Same-repo PRs also push a throwaway `pr-<n>` tag; **fork PRs build and smoke-test (`puppet-ca --help`) without pushing**, since their `GITHUB_TOKEN` is read-only. This — plus GitHub's built-in fork-PR run approval and the fact that applying a label needs write access — is the approval gate before any fork build runs.

## ⚠️ Required one-time setup (repository owner)

These must be done once by an admin of this repository. Full details in [`docs/container-images.md`](docs/container-images.md):

1. **Allow Actions to publish packages** — the workflow requests `packages: write`; if an org policy overrides it, enable *Read and write permissions* (Settings → Actions → General).
2. **Set package visibility to Public** after the first publish (GHCR packages are private by default). Auto-linked to the repo via the `org.opencontainers.image.source` label.
3. **Create the `build-images` label** so maintainers can opt PRs into a build.
4. **arm64 runners** (`ubuntu-24.04-arm`) are free for **public** repos; private repos must provision their own arm64 runners.
5. **Fork PR approval** is GitHub's default — runs from outside contributors wait for maintainer approval.

Note: once merged, every push to `main` will publish `edge` images, so steps 1/2 should be done around merge time. Until then, push builds fail at the push step, but PR validation builds (which don't push) still work.

## Testing
- `actionlint` clean (including shellcheck).
- Confirmed the entrypoint CLI (cobra) exits 0 on `--help` for the validation smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)