### PR TITLE
feat: add storage-backend migration command (puppet-ca-ctl migrate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,9 +626,18 @@ puppet-ca-ctl import \
   --cert-bundle ca_cert.pem \
   --private-key ca_key.pem \
   --crl-chain   ca_crl.pem     # optional; a new CRL is generated if omitted
+
+# Migrate an entire CA between storage backends offline (any pair of backends:
+# filesystem, sqlite, postgres, mysql, etcd, redis/valkey). Each backend is
+# described by a normal puppet-ca config file. Refuses a non-empty destination
+# unless --force.
+puppet-ca-ctl migrate \
+  --source-config /etc/puppet-ca/filesystem.yaml \
+  --dest-config   /etc/puppet-ca/postgres.yaml
 ```
 
-`setup` and `import` operate directly on the filesystem. No running server is needed.
+`setup`, `import` and `migrate` operate directly on storage. No running server is needed.
+See [docs/storage-backends.md](docs/storage-backends.md#migrating-between-backends) for migration details.
 
 ## Container / Compose
 

--- a/cmd/puppet-ca-ctl/main.go
+++ b/cmd/puppet-ca-ctl/main.go
@@ -545,6 +545,7 @@ Global flags must be specified before the subcommand.`,
 		newGenerateCmd(),
 		newSetupCmd(),
 		newImportCmd(),
+		newMigrateCmd(),
 	)
 
 	if err := rootCmd.Execute(); err != nil {

--- a/cmd/puppet-ca-ctl/migrate.go
+++ b/cmd/puppet-ca-ctl/migrate.go
@@ -1,0 +1,146 @@
+// Copyright (C) 2026 Chris Boot
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/tvaughan/puppet-ca/internal/config"
+	"github.com/tvaughan/puppet-ca/internal/storage"
+	"go.yaml.in/yaml/v3"
+)
+
+// migrateFileConfig is the subset of a puppet-ca server config file needed to
+// open a storage backend for migration: the backend selection and its
+// parameters (via the shared config.StorageConfig), plus cadir. cadir is the
+// backend root for the filesystem backend and, for remote backends, the local
+// directory the spec validator requires (migration never touches the
+// per-subject private keys kept there).
+type migrateFileConfig struct {
+	CADir                string `yaml:"cadir"`
+	config.StorageConfig `yaml:",inline"`
+}
+
+// loadMigrateConfig reads and parses one backend config file.
+func loadMigrateConfig(path string) (migrateFileConfig, error) {
+	var c migrateFileConfig
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return c, fmt.Errorf("reading %s: %w", path, err)
+	}
+	if err := yaml.Unmarshal(data, &c); err != nil {
+		return c, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	return c, nil
+}
+
+// backendSpec turns the file config into a storage.BackendSpec, resolving
+// cadir to an absolute path so logs and errors show canonical locations.
+func (c migrateFileConfig) backendSpec() (storage.BackendSpec, error) {
+	localDir := c.CADir
+	if localDir != "" {
+		abs, err := filepath.Abs(localDir)
+		if err != nil {
+			return storage.BackendSpec{}, fmt.Errorf("resolving cadir %q: %w", localDir, err)
+		}
+		localDir = abs
+	}
+	return c.StorageConfig.ToBackendSpec(localDir)
+}
+
+func newMigrateCmd() *cobra.Command {
+	var sourceConfig, destConfig string
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "migrate",
+		Short: "Copy all CA data from one storage backend to another (offline)",
+		Long: `Copy every stored CA asset from a source storage backend to a destination
+backend: the CA certificate and key, public key, CRL, serial, inventory (with
+its integrity HMAC), all pending CSRs and all signed certificates.
+
+Both backends are described by ordinary puppet-ca config files (the same YAML
+format the server reads): --source-config selects the backend to read from and
+--dest-config the backend to write to. Any pair of backends may be combined, so
+this can import a filesystem CA into a database, move data between databases
+(e.g. Valkey to PostgreSQL), or export a database back to a directory of files.
+
+By default migrate refuses to write into a destination that already holds a CA
+certificate; pass --force to overwrite it.
+
+The server must not be running against either backend during migration.
+
+Per-subject generated private keys are NOT migrated: they always live on the
+local filesystem under cadir, never in a storage backend.`,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			srcCfg, err := loadMigrateConfig(sourceConfig)
+			if err != nil {
+				return fmt.Errorf("source config: %w", err)
+			}
+			dstCfg, err := loadMigrateConfig(destConfig)
+			if err != nil {
+				return fmt.Errorf("destination config: %w", err)
+			}
+
+			srcSpec, err := srcCfg.backendSpec()
+			if err != nil {
+				return fmt.Errorf("source backend: %w", err)
+			}
+			dstSpec, err := dstCfg.backendSpec()
+			if err != nil {
+				return fmt.Errorf("destination backend: %w", err)
+			}
+
+			srcSvc, err := storage.NewServiceFromSpec(srcSpec)
+			if err != nil {
+				return fmt.Errorf("opening source backend: %w", err)
+			}
+			defer func() { _ = srcSvc.Backend().Close() }()
+
+			dstSvc, err := storage.NewServiceFromSpec(dstSpec)
+			if err != nil {
+				return fmt.Errorf("opening destination backend: %w", err)
+			}
+			defer func() { _ = dstSvc.Backend().Close() }()
+
+			report, err := storage.MigrateService(cmd.Context(), srcSvc, dstSvc, storage.MigrateOptions{
+				Force: force,
+				Logf: func(format string, a ...any) {
+					if globalVerbose {
+						fmt.Fprintf(os.Stderr, format+"\n", a...)
+					}
+				},
+			})
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("Migration complete: %d CA/state blob(s), %d CSR(s), %d signed cert(s) copied (%d total)\n",
+				report.Singletons, report.CSRs, report.Certs, report.Total())
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&sourceConfig, "source-config", "", "Path to puppet-ca config file describing the SOURCE backend")
+	cmd.Flags().StringVar(&destConfig, "dest-config", "", "Path to puppet-ca config file describing the DESTINATION backend")
+	cmd.Flags().BoolVar(&force, "force", false, "Overwrite an existing CA in the destination backend")
+	_ = cmd.MarkFlagRequired("source-config")
+	_ = cmd.MarkFlagRequired("dest-config")
+	return cmd
+}

--- a/cmd/puppet-ca-ctl/migrate_test.go
+++ b/cmd/puppet-ca-ctl/migrate_test.go
@@ -1,0 +1,222 @@
+// Copyright (C) 2026 Chris Boot
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tvaughan/puppet-ca/internal/storage"
+)
+
+// writeFile is a test helper that writes data to path, failing the test on error.
+func writeFile(t *testing.T, path, data string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(data), 0600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// seedFilesystemCA populates a filesystem backend rooted at dir with a minimal
+// CA: a cert, key, serial and one CSR.
+func seedFilesystemCA(t *testing.T, dir string) {
+	t.Helper()
+	ctx := context.Background()
+	b := storage.NewFilesystemBackend(dir)
+	if err := b.EnsureReady(ctx); err != nil {
+		t.Fatalf("EnsureReady: %v", err)
+	}
+	puts := []struct {
+		key  string
+		data string
+		kind storage.BlobKind
+	}{
+		{storage.KeyCACert, "ca-cert", storage.BlobPublic},
+		{storage.KeyCAKey, "ca-key", storage.BlobPrivate},
+		{storage.KeySerial, "01", storage.BlobPublic},
+		{storage.CSRKey("node1"), "csr-node1", storage.BlobPublic},
+	}
+	for _, p := range puts {
+		if err := b.Put(ctx, p.key, []byte(p.data), p.kind); err != nil {
+			t.Fatalf("seed Put %q: %v", p.key, err)
+		}
+	}
+}
+
+// fsConfig returns a minimal filesystem-backend config file pointing at dir.
+func fsConfig(t *testing.T, configPath, caDir string) {
+	t.Helper()
+	writeFile(t, configPath, "storage_backend: filesystem\ncadir: "+caDir+"\n")
+}
+
+func TestMigrateCommandFilesystemToFilesystem(t *testing.T) {
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
+	cfgDir := t.TempDir()
+	seedFilesystemCA(t, srcDir)
+
+	srcCfg := filepath.Join(cfgDir, "src.yaml")
+	dstCfg := filepath.Join(cfgDir, "dst.yaml")
+	fsConfig(t, srcCfg, srcDir)
+	fsConfig(t, dstCfg, dstDir)
+
+	cmd := newMigrateCmd()
+	cmd.SetArgs([]string{"--source-config", srcCfg, "--dest-config", dstCfg})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	for _, rel := range []string{"ca_crt.pem", filepath.Join("private", "ca_key.pem"), "serial", filepath.Join("requests", "node1.pem")} {
+		if _, err := os.Stat(filepath.Join(dstDir, rel)); err != nil {
+			t.Errorf("expected %s in destination: %v", rel, err)
+		}
+	}
+}
+
+func TestMigrateCommandRefusesNonEmptyDestination(t *testing.T) {
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
+	cfgDir := t.TempDir()
+	seedFilesystemCA(t, srcDir)
+	seedFilesystemCA(t, dstDir) // destination already has a CA
+
+	srcCfg := filepath.Join(cfgDir, "src.yaml")
+	dstCfg := filepath.Join(cfgDir, "dst.yaml")
+	fsConfig(t, srcCfg, srcDir)
+	fsConfig(t, dstCfg, dstDir)
+
+	cmd := newMigrateCmd()
+	cmd.SetArgs([]string{"--source-config", srcCfg, "--dest-config", dstCfg})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error migrating into a non-empty destination")
+	}
+
+	// With --force it succeeds.
+	cmd = newMigrateCmd()
+	cmd.SetArgs([]string{"--source-config", srcCfg, "--dest-config", dstCfg, "--force"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("migrate --force: %v", err)
+	}
+}
+
+// runMigrate executes the migrate command with the given args, failing the
+// test on error.
+func runMigrate(t *testing.T, args ...string) {
+	t.Helper()
+	cmd := newMigrateCmd()
+	cmd.SetArgs(args)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("migrate %v: %v", args, err)
+	}
+}
+
+// TestMigrateCommandRoundTripViaSQLite migrates a filesystem CA into a SQLite
+// database and back out to a second directory, then asserts the exported tree
+// is byte-for-byte identical to the original — the canonical
+// files => sqlite => files round-trip exercised in CI.
+func TestMigrateCommandRoundTripViaSQLite(t *testing.T) {
+	srcDir := t.TempDir()
+	sqliteCADir := t.TempDir()
+	dstDir := t.TempDir()
+	cfgDir := t.TempDir()
+	dbPath := filepath.Join(t.TempDir(), "ca.db")
+	seedFilesystemCA(t, srcDir)
+
+	srcCfg := filepath.Join(cfgDir, "fs-src.yaml")
+	sqlCfg := filepath.Join(cfgDir, "sqlite.yaml")
+	dstCfg := filepath.Join(cfgDir, "fs-dst.yaml")
+	fsConfig(t, srcCfg, srcDir)
+	fsConfig(t, dstCfg, dstDir)
+	writeFile(t, sqlCfg, "storage_backend: sqlite\ncadir: "+sqliteCADir+"\nsql_dsn: file:"+dbPath+"\n")
+
+	// files => sqlite
+	runMigrate(t, "--source-config", srcCfg, "--dest-config", sqlCfg)
+	// sqlite => files
+	runMigrate(t, "--source-config", sqlCfg, "--dest-config", dstCfg)
+
+	assertTreesEqual(t, srcDir, dstDir)
+}
+
+// assertTreesEqual fails the test unless every regular file under want exists
+// under got with identical contents (and vice versa).
+func assertTreesEqual(t *testing.T, want, got string) {
+	t.Helper()
+	wantFiles := collectFiles(t, want)
+	gotFiles := collectFiles(t, got)
+
+	for rel, data := range wantFiles {
+		other, ok := gotFiles[rel]
+		if !ok {
+			t.Errorf("missing in exported tree: %s", rel)
+			continue
+		}
+		if !bytes.Equal(data, other) {
+			t.Errorf("content differs after round-trip: %s", rel)
+		}
+	}
+	for rel := range gotFiles {
+		if _, ok := wantFiles[rel]; !ok {
+			t.Errorf("unexpected extra file in exported tree: %s", rel)
+		}
+	}
+}
+
+// collectFiles returns a map of relative path => contents for every regular
+// file under root.
+func collectFiles(t *testing.T, root string) map[string][]byte {
+	t.Helper()
+	out := map[string][]byte{}
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		out[rel] = data
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	return out
+}
+
+func TestMigrateCommandRejectsUnknownBackend(t *testing.T) {
+	cfgDir := t.TempDir()
+	srcCfg := filepath.Join(cfgDir, "src.yaml")
+	dstCfg := filepath.Join(cfgDir, "dst.yaml")
+	writeFile(t, srcCfg, "storage_backend: nonsense\ncadir: "+t.TempDir()+"\n")
+	fsConfig(t, dstCfg, t.TempDir())
+
+	cmd := newMigrateCmd()
+	cmd.SetArgs([]string{"--source-config", srcCfg, "--dest-config", dstCfg})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error for unknown source backend")
+	}
+}

--- a/cmd/puppet-ca/config.go
+++ b/cmd/puppet-ca/config.go
@@ -82,60 +82,11 @@ type serverConfig struct {
 	// style ("2006-01-02T15:04:05MST") instead of RFC 3339 (default: false).
 	PuppetDateTimeFormat bool `yaml:"puppet_datetime_format"`
 
-	// Storage backend selection. "filesystem" (default) stores all CA data
-	// under CADir; "etcd" keeps CA cert, key, CRL, inventory, serial, CSRs
-	// and signed certs in an etcd cluster; "redis" (alias "valkey") keeps
-	// the same state in a Redis/Valkey instance or Sentinel-managed primary
-	// (per-subject generated private keys always remain on local disk under
-	// CADir, regardless of backend).
-	StorageBackend        string   `yaml:"storage_backend"`
-	EtcdEndpoints         []string `yaml:"etcd_endpoints"`
-	EtcdKeyPrefix         string   `yaml:"etcd_key_prefix"`
-	EtcdUsername          string   `yaml:"etcd_username"`
-	EtcdPassword          string   `yaml:"etcd_password"`
-	EtcdDialTimeoutSec    int      `yaml:"etcd_dial_timeout_sec"`
-	EtcdRequestTimeoutSec int      `yaml:"etcd_request_timeout_sec"`
-	EtcdTLSCAFile         string   `yaml:"etcd_tls_ca_file"`
-	EtcdTLSCertFile       string   `yaml:"etcd_tls_cert_file"`
-	EtcdTLSKeyFile        string   `yaml:"etcd_tls_key_file"`
-
-	// Redis/Valkey backend. RedisAddrs is used in direct mode; when
-	// RedisSentinelMasterName is set, the client resolves the primary via
-	// RedisSentinelAddrs and follows failovers automatically.
-	RedisAddrs              []string `yaml:"redis_addrs"`
-	RedisSentinelMasterName string   `yaml:"redis_sentinel_master_name"`
-	RedisSentinelAddrs      []string `yaml:"redis_sentinel_addrs"`
-	RedisSentinelUsername   string   `yaml:"redis_sentinel_username"`
-	RedisSentinelPassword   string   `yaml:"redis_sentinel_password"`
-	RedisDB                 int      `yaml:"redis_db"`
-	RedisUsername           string   `yaml:"redis_username"`
-	RedisPassword           string   `yaml:"redis_password"`
-	RedisKeyPrefix          string   `yaml:"redis_key_prefix"`
-	RedisDialTimeoutSec     int      `yaml:"redis_dial_timeout_sec"`
-	RedisRequestTimeoutSec  int      `yaml:"redis_request_timeout_sec"`
-	RedisLockTTLSec         int      `yaml:"redis_lock_ttl_sec"`
-	RedisTLSCAFile          string   `yaml:"redis_tls_ca_file"`
-	RedisTLSCertFile        string   `yaml:"redis_tls_cert_file"`
-	RedisTLSKeyFile         string   `yaml:"redis_tls_key_file"`
-
-	// SQL backend (sqlite; postgres and mysql/mariadb added in later releases).
-	// SQLDSN is the driver-specific data source name: a file path/URI for
-	// SQLite ("file:/var/lib/puppet-ca/ca.db"), or a connection string for the
-	// networked engines. SQLTLS* apply only to the networked dialects.
-	SQLDSN               string `yaml:"sql_dsn"`
-	SQLRequestTimeoutSec int    `yaml:"sql_request_timeout_sec"`
-	SQLMaxOpenConns      int    `yaml:"sql_max_open_conns"`
-	SQLMaxIdleConns      int    `yaml:"sql_max_idle_conns"`
-	SQLTLSCAFile         string `yaml:"sql_tls_ca_file"`
-	SQLTLSCertFile       string `yaml:"sql_tls_cert_file"`
-	SQLTLSKeyFile        string `yaml:"sql_tls_key_file"`
-
-	// Local-file overrides. When set, the named asset is read/written via
-	// this filesystem path regardless of the selected backend. Typical use:
-	// keep the CA cert and/or key on local disk (or a mounted secret volume)
-	// while storing CSRs, signed certs, CRL and inventory in etcd.
-	CACertFile string `yaml:"ca_cert_file"`
-	CAKeyFile  string `yaml:"ca_key_file"`
+	// Storage backend selection and parameters. Embedded inline so the YAML
+	// keys (storage_backend, etcd_*, redis_*, sql_*, ca_cert_file, ca_key_file)
+	// remain at the top level. Shared with the operator CLI's migrate command
+	// via config.StorageConfig.
+	config.StorageConfig `yaml:",inline"`
 }
 
 // loadServerConfig applies built-in defaults, optionally loads a YAML config

--- a/cmd/puppet-ca/main.go
+++ b/cmd/puppet-ca/main.go
@@ -76,74 +76,10 @@ func setupLogger(cfg *serverConfig) (*os.File, error) {
 // buildBackendSpec derives a storage.BackendSpec from the server config. The
 // spec is used to construct the StorageService in every mode (frontend,
 // signer, single-process), ensuring backend selection happens in one place.
+// The backend-selection logic is shared with the operator CLI's migrate
+// command via config.StorageConfig.ToBackendSpec.
 func buildBackendSpec(cfg *serverConfig, absCADir string) (storage.BackendSpec, error) {
-	kind, err := storage.ParseBackendKind(cfg.StorageBackend)
-	if err != nil {
-		return storage.BackendSpec{}, err
-	}
-	spec := storage.BackendSpec{
-		Kind:       kind,
-		LocalDir:   absCADir,
-		CACertFile: absIfSet(cfg.CACertFile),
-		CAKeyFile:  absIfSet(cfg.CAKeyFile),
-	}
-	if kind == storage.BackendEtcd {
-		spec.Etcd = storage.EtcdSpec{
-			Endpoints:         cfg.EtcdEndpoints,
-			KeyPrefix:         cfg.EtcdKeyPrefix,
-			Username:          cfg.EtcdUsername,
-			Password:          cfg.EtcdPassword,
-			DialTimeoutSec:    cfg.EtcdDialTimeoutSec,
-			RequestTimeoutSec: cfg.EtcdRequestTimeoutSec,
-			TLSCAFile:         cfg.EtcdTLSCAFile,
-			TLSCertFile:       cfg.EtcdTLSCertFile,
-			TLSKeyFile:        cfg.EtcdTLSKeyFile,
-		}
-	}
-	if kind == storage.BackendRedis {
-		spec.Redis = storage.RedisSpec{
-			Addrs:              cfg.RedisAddrs,
-			SentinelMasterName: cfg.RedisSentinelMasterName,
-			SentinelAddrs:      cfg.RedisSentinelAddrs,
-			SentinelUsername:   cfg.RedisSentinelUsername,
-			SentinelPassword:   cfg.RedisSentinelPassword,
-			DB:                 cfg.RedisDB,
-			Username:           cfg.RedisUsername,
-			Password:           cfg.RedisPassword,
-			KeyPrefix:          cfg.RedisKeyPrefix,
-			DialTimeoutSec:     cfg.RedisDialTimeoutSec,
-			RequestTimeoutSec:  cfg.RedisRequestTimeoutSec,
-			LockTTLSec:         cfg.RedisLockTTLSec,
-			TLSCAFile:          cfg.RedisTLSCAFile,
-			TLSCertFile:        cfg.RedisTLSCertFile,
-			TLSKeyFile:         cfg.RedisTLSKeyFile,
-		}
-	}
-	if kind == storage.BackendSQLite || kind == storage.BackendPostgres || kind == storage.BackendMySQL {
-		spec.SQL = storage.SQLSpec{
-			DSN:               cfg.SQLDSN,
-			RequestTimeoutSec: cfg.SQLRequestTimeoutSec,
-			MaxOpenConns:      cfg.SQLMaxOpenConns,
-			MaxIdleConns:      cfg.SQLMaxIdleConns,
-			TLSCAFile:         cfg.SQLTLSCAFile,
-			TLSCertFile:       cfg.SQLTLSCertFile,
-			TLSKeyFile:        cfg.SQLTLSKeyFile,
-		}
-	}
-	return spec, nil
-}
-
-// absIfSet returns filepath.Abs(p) when p is non-empty, otherwise "".
-// Resolving at config time lets error messages and logs show canonical paths.
-func absIfSet(p string) string {
-	if p == "" {
-		return ""
-	}
-	abs, err := filepath.Abs(p)
-	if err != nil {
-		return p
-	}
-	return abs
+	return cfg.StorageConfig.ToBackendSpec(absCADir)
 }
 
 // applyCAConfig applies the common CA configuration fields from serverConfig

--- a/cmd/puppet-ca/sql_config_test.go
+++ b/cmd/puppet-ca/sql_config_test.go
@@ -19,6 +19,7 @@ package main
 import (
 	"testing"
 
+	"github.com/tvaughan/puppet-ca/internal/config"
 	"github.com/tvaughan/puppet-ca/internal/storage"
 )
 
@@ -50,9 +51,11 @@ func TestBuildBackendSpecSQLite(t *testing.T) {
 	for _, alias := range []string{"sqlite", "sqlite3"} {
 		t.Run(alias, func(t *testing.T) {
 			cfg := &serverConfig{
-				StorageBackend:       alias,
-				SQLDSN:               "file:/tmp/ca.db",
-				SQLRequestTimeoutSec: 12,
+				StorageConfig: config.StorageConfig{
+					StorageBackend:       alias,
+					SQLDSN:               "file:/tmp/ca.db",
+					SQLRequestTimeoutSec: 12,
+				},
 			}
 			spec, err := buildBackendSpec(cfg, "/abs/cadir")
 			if err != nil {
@@ -78,9 +81,11 @@ func TestBuildBackendSpecPostgres(t *testing.T) {
 	for _, alias := range []string{"postgres", "postgresql", "pg"} {
 		t.Run(alias, func(t *testing.T) {
 			cfg := &serverConfig{
-				StorageBackend: alias,
-				SQLDSN:         "postgres://u:p@host:5432/db?sslmode=require",
-				SQLTLSCAFile:   "/etc/pg-ca.pem",
+				StorageConfig: config.StorageConfig{
+					StorageBackend: alias,
+					SQLDSN:         "postgres://u:p@host:5432/db?sslmode=require",
+					SQLTLSCAFile:   "/etc/pg-ca.pem",
+				},
 			}
 			spec, err := buildBackendSpec(cfg, "/abs/cadir")
 			if err != nil {
@@ -103,8 +108,10 @@ func TestBuildBackendSpecMySQL(t *testing.T) {
 	for _, alias := range []string{"mysql", "mariadb"} {
 		t.Run(alias, func(t *testing.T) {
 			cfg := &serverConfig{
-				StorageBackend: alias,
-				SQLDSN:         "puppetca:secret@tcp(db:3306)/puppetca",
+				StorageConfig: config.StorageConfig{
+					StorageBackend: alias,
+					SQLDSN:         "puppetca:secret@tcp(db:3306)/puppetca",
+				},
 			}
 			spec, err := buildBackendSpec(cfg, "/abs/cadir")
 			if err != nil {

--- a/docs/storage-backends.md
+++ b/docs/storage-backends.md
@@ -718,6 +718,69 @@ key out of the cadir tree and onto a separately-mounted volume.
 
 ---
 
+## Migrating between backends
+
+`puppet-ca-ctl migrate` copies an entire CA from one backend to another. Because
+every backend implements the same `Backend` contract, any pair can be combined:
+
+- import an existing filesystem CA into a database (`filesystem` → `postgres`),
+- move between databases or stores (`redis`/`valkey` → `postgres`, `etcd` →
+  `sqlite`, …),
+- export a database back to a plain directory of files (`postgres` →
+  `filesystem`), e.g. for an offline backup or to revert to a single-node setup.
+
+Both ends are described by ordinary `puppet-ca` config files — the same YAML the
+server reads — so each backend's parameters are expressed exactly as they are in
+production. `--source-config` is read from; `--dest-config` is written to.
+
+```bash
+# Import a filesystem CA into PostgreSQL.
+puppet-ca-ctl migrate \
+  --source-config /etc/puppet-ca/filesystem.yaml \
+  --dest-config   /etc/puppet-ca/postgres.yaml
+
+# Export it back out to a directory of files.
+puppet-ca-ctl migrate \
+  --source-config /etc/puppet-ca/postgres.yaml \
+  --dest-config   /etc/puppet-ca/filesystem.yaml
+```
+
+Each config file needs only the storage fields (plus `cadir`); for example a
+minimal SQLite target:
+
+```yaml
+# sqlite.yaml
+storage_backend: sqlite
+cadir: /var/lib/puppet-ca
+sql_dsn: file:/var/lib/puppet-ca/ca.db
+```
+
+What is copied: the CA certificate, public key and private key, the CRL, the
+serial, the inventory **and its integrity HMAC** (so tamper-detection keeps
+working after the move), every pending CSR and every signed certificate. Each
+blob is written with its normal visibility, so a `filesystem` destination ends
+up with the usual `0600`/`0644` permissions. Blobs absent in the source (for
+example the `serial` file of a CA that has not signed anything yet) are simply
+skipped.
+
+What is **not** copied: per-subject generated private keys. These always live on
+the local filesystem under `cadir`, never in a backend (see
+[Backend contract](#backend-contract)); when running a remote backend they stay
+put across a migration. The local-file overrides `ca_cert_file` / `ca_key_file`
+are honoured on both ends, so they participate transparently.
+
+Notes:
+
+- **Stop the server first.** Run `migrate` while no `puppet-ca` is serving
+  either backend, so the copy sees a consistent snapshot.
+- **Overwrite protection.** `migrate` refuses to write into a destination that
+  already holds a CA certificate. Pass `--force` to overwrite it.
+- **Re-runnable.** The copy is idempotent per key; an interrupted run can be
+  repeated (with `--force` if a partial CA already landed).
+- Use `--verbose` to log each blob as it is copied.
+
+---
+
 ## Choosing a backend
 
 |                              | `filesystem`       | `sqlite`                          | `postgres` / `mysql`              | `etcd`                            | `redis` / `valkey`                |
@@ -748,5 +811,9 @@ The `Backend` interface is defined in
 backend, implement the interface, register it in
 [internal/storage/spec.go](../internal/storage/spec.go)'s
 `NewServiceFromSpec`, and add any backend-specific config fields to
-[cmd/puppet-ca/config.go](../cmd/puppet-ca/config.go). The `OverlayBackend`
-wrapper (overlay.go) shows how to compose a backend with local-file overrides.
+[internal/config/storage.go](../internal/config/storage.go)'s `StorageConfig`
+(shared by the server and `puppet-ca-ctl migrate`, and mapped to a
+`BackendSpec` by `ToBackendSpec`). The `OverlayBackend` wrapper (overlay.go)
+shows how to compose a backend with local-file overrides. A new backend is
+automatically migratable — `puppet-ca-ctl migrate` works against any
+`Backend` implementation with no extra code.

--- a/internal/config/storage.go
+++ b/internal/config/storage.go
@@ -1,0 +1,160 @@
+// Copyright (C) 2026 Chris Boot
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package config
+
+import (
+	"path/filepath"
+
+	"github.com/tvaughan/puppet-ca/internal/storage"
+)
+
+// StorageConfig is the storage-backend portion of a puppet-ca configuration,
+// shared by the server (cmd/puppet-ca) and the operator CLI (cmd/puppet-ca-ctl)
+// so that both interpret the same YAML keys identically. The server embeds it
+// inline into its larger config; the migrate command parses two of them, one
+// per backend.
+type StorageConfig struct {
+	// Storage backend selection. "filesystem" (default) stores all CA data
+	// under cadir; "etcd" keeps CA cert, key, CRL, inventory, serial, CSRs
+	// and signed certs in an etcd cluster; "redis" (alias "valkey") keeps
+	// the same state in a Redis/Valkey instance or Sentinel-managed primary;
+	// "sqlite", "postgres" and "mysql"/"mariadb" use a SQL database
+	// (per-subject generated private keys always remain on local disk under
+	// cadir, regardless of backend).
+	StorageBackend        string   `yaml:"storage_backend"`
+	EtcdEndpoints         []string `yaml:"etcd_endpoints"`
+	EtcdKeyPrefix         string   `yaml:"etcd_key_prefix"`
+	EtcdUsername          string   `yaml:"etcd_username"`
+	EtcdPassword          string   `yaml:"etcd_password"`
+	EtcdDialTimeoutSec    int      `yaml:"etcd_dial_timeout_sec"`
+	EtcdRequestTimeoutSec int      `yaml:"etcd_request_timeout_sec"`
+	EtcdTLSCAFile         string   `yaml:"etcd_tls_ca_file"`
+	EtcdTLSCertFile       string   `yaml:"etcd_tls_cert_file"`
+	EtcdTLSKeyFile        string   `yaml:"etcd_tls_key_file"`
+
+	// Redis/Valkey backend. RedisAddrs is used in direct mode; when
+	// RedisSentinelMasterName is set, the client resolves the primary via
+	// RedisSentinelAddrs and follows failovers automatically.
+	RedisAddrs              []string `yaml:"redis_addrs"`
+	RedisSentinelMasterName string   `yaml:"redis_sentinel_master_name"`
+	RedisSentinelAddrs      []string `yaml:"redis_sentinel_addrs"`
+	RedisSentinelUsername   string   `yaml:"redis_sentinel_username"`
+	RedisSentinelPassword   string   `yaml:"redis_sentinel_password"`
+	RedisDB                 int      `yaml:"redis_db"`
+	RedisUsername           string   `yaml:"redis_username"`
+	RedisPassword           string   `yaml:"redis_password"`
+	RedisKeyPrefix          string   `yaml:"redis_key_prefix"`
+	RedisDialTimeoutSec     int      `yaml:"redis_dial_timeout_sec"`
+	RedisRequestTimeoutSec  int      `yaml:"redis_request_timeout_sec"`
+	RedisLockTTLSec         int      `yaml:"redis_lock_ttl_sec"`
+	RedisTLSCAFile          string   `yaml:"redis_tls_ca_file"`
+	RedisTLSCertFile        string   `yaml:"redis_tls_cert_file"`
+	RedisTLSKeyFile         string   `yaml:"redis_tls_key_file"`
+
+	// SQL backend (sqlite, postgres, mysql/mariadb). SQLDSN is the
+	// driver-specific data source name: a file path/URI for SQLite
+	// ("file:/var/lib/puppet-ca/ca.db"), or a connection string for the
+	// networked engines. SQLTLS* apply only to the networked dialects.
+	SQLDSN               string `yaml:"sql_dsn"`
+	SQLRequestTimeoutSec int    `yaml:"sql_request_timeout_sec"`
+	SQLMaxOpenConns      int    `yaml:"sql_max_open_conns"`
+	SQLMaxIdleConns      int    `yaml:"sql_max_idle_conns"`
+	SQLTLSCAFile         string `yaml:"sql_tls_ca_file"`
+	SQLTLSCertFile       string `yaml:"sql_tls_cert_file"`
+	SQLTLSKeyFile        string `yaml:"sql_tls_key_file"`
+
+	// Local-file overrides. When set, the named asset is read/written via
+	// this filesystem path regardless of the selected backend. Typical use:
+	// keep the CA cert and/or key on local disk (or a mounted secret volume)
+	// while storing CSRs, signed certs, CRL and inventory in a remote backend.
+	CACertFile string `yaml:"ca_cert_file"`
+	CAKeyFile  string `yaml:"ca_key_file"`
+}
+
+// ToBackendSpec derives a storage.BackendSpec from the configured backend
+// fields. localDir is the operational directory on local disk: the backend
+// root for the filesystem backend, and the location of per-subject generated
+// private keys for every backend. It returns an error for an unknown backend
+// name.
+func (c StorageConfig) ToBackendSpec(localDir string) (storage.BackendSpec, error) {
+	kind, err := storage.ParseBackendKind(c.StorageBackend)
+	if err != nil {
+		return storage.BackendSpec{}, err
+	}
+	spec := storage.BackendSpec{
+		Kind:       kind,
+		LocalDir:   localDir,
+		CACertFile: absIfSet(c.CACertFile),
+		CAKeyFile:  absIfSet(c.CAKeyFile),
+	}
+	switch kind {
+	case storage.BackendEtcd:
+		spec.Etcd = storage.EtcdSpec{
+			Endpoints:         c.EtcdEndpoints,
+			KeyPrefix:         c.EtcdKeyPrefix,
+			Username:          c.EtcdUsername,
+			Password:          c.EtcdPassword,
+			DialTimeoutSec:    c.EtcdDialTimeoutSec,
+			RequestTimeoutSec: c.EtcdRequestTimeoutSec,
+			TLSCAFile:         c.EtcdTLSCAFile,
+			TLSCertFile:       c.EtcdTLSCertFile,
+			TLSKeyFile:        c.EtcdTLSKeyFile,
+		}
+	case storage.BackendRedis:
+		spec.Redis = storage.RedisSpec{
+			Addrs:              c.RedisAddrs,
+			SentinelMasterName: c.RedisSentinelMasterName,
+			SentinelAddrs:      c.RedisSentinelAddrs,
+			SentinelUsername:   c.RedisSentinelUsername,
+			SentinelPassword:   c.RedisSentinelPassword,
+			DB:                 c.RedisDB,
+			Username:           c.RedisUsername,
+			Password:           c.RedisPassword,
+			KeyPrefix:          c.RedisKeyPrefix,
+			DialTimeoutSec:     c.RedisDialTimeoutSec,
+			RequestTimeoutSec:  c.RedisRequestTimeoutSec,
+			LockTTLSec:         c.RedisLockTTLSec,
+			TLSCAFile:          c.RedisTLSCAFile,
+			TLSCertFile:        c.RedisTLSCertFile,
+			TLSKeyFile:         c.RedisTLSKeyFile,
+		}
+	case storage.BackendSQLite, storage.BackendPostgres, storage.BackendMySQL:
+		spec.SQL = storage.SQLSpec{
+			DSN:               c.SQLDSN,
+			RequestTimeoutSec: c.SQLRequestTimeoutSec,
+			MaxOpenConns:      c.SQLMaxOpenConns,
+			MaxIdleConns:      c.SQLMaxIdleConns,
+			TLSCAFile:         c.SQLTLSCAFile,
+			TLSCertFile:       c.SQLTLSCertFile,
+			TLSKeyFile:        c.SQLTLSKeyFile,
+		}
+	}
+	return spec, nil
+}
+
+// absIfSet returns filepath.Abs(p) when p is non-empty, otherwise "".
+// Resolving at config time lets error messages and logs show canonical paths.
+func absIfSet(p string) string {
+	if p == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return p
+	}
+	return abs
+}

--- a/internal/storage/migrate.go
+++ b/internal/storage/migrate.go
@@ -1,0 +1,198 @@
+// Copyright (C) 2026 Chris Boot
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+)
+
+// migratableSingleton pairs a fixed (non-enumerable) blob key with the
+// visibility it is normally written with, so the destination backend can
+// reproduce the correct permissions (e.g. 0600 vs 0644 on the filesystem).
+type migratableSingleton struct {
+	Key  string
+	Kind BlobKind
+}
+
+// migratableSingletons lists every fixed blob a CA may hold, in a stable copy
+// order (CA material first, then operational state). The kinds mirror how
+// StorageService writes each blob. Per-subject CSRs and signed certs are
+// enumerated separately via List; per-subject generated private keys are
+// intentionally excluded — they always live on local disk
+// (StorageService.localPrivateKeyDir) and are never stored in a backend.
+var migratableSingletons = []migratableSingleton{
+	{KeyCACert, BlobPublic},
+	{KeyCAPubKey, BlobPublic},
+	{KeyCAKey, BlobPrivate},
+	{KeyCRL, BlobPrivate},
+	{KeySerial, BlobPublic},
+	{KeyInventory, BlobPrivate},
+	{KeyInventoryHMAC, BlobPrivate},
+	{KeyHMACKey, BlobPrivate},
+}
+
+// MigrateOptions tunes a Migrate run.
+type MigrateOptions struct {
+	// Force permits writing into a destination that already holds CA material.
+	// When false, Migrate aborts with ErrDestinationNotEmpty if the destination
+	// already has a CA certificate, to avoid clobbering a live CA.
+	Force bool
+
+	// Logf, when non-nil, receives one human-readable line per copied blob.
+	Logf func(format string, args ...any)
+}
+
+// MigrateReport summarises what a Migrate run copied.
+type MigrateReport struct {
+	Singletons int // fixed CA/operational blobs copied
+	CSRs       int // pending certificate requests copied
+	Certs      int // signed certificates copied
+}
+
+// Total returns the total number of blobs copied.
+func (r MigrateReport) Total() int { return r.Singletons + r.CSRs + r.Certs }
+
+// ErrDestinationNotEmpty is returned by Migrate when the destination backend
+// already holds a CA certificate and MigrateOptions.Force is false.
+var ErrDestinationNotEmpty = errors.New("destination backend already contains a CA certificate (use --force to overwrite)")
+
+// migrateLockName is the distributed-lock name MigrateService holds on both
+// backends for the duration of a copy. It deliberately matches the CA
+// bootstrap lock (internal/ca uses "bootstrap") so a migration and a server
+// bootstrapping or re-initialising the same backend are mutually exclusive,
+// and so two migrations cannot run against the same backend at once.
+//
+// Per-subject signing uses different lock names and is therefore not held off;
+// operators should still stop the server during a migration. Backends without
+// distributed locking fall back to a process-local mutex (no cross-process
+// effect), which is why MigrateService is best-effort for those.
+const migrateLockName = "bootstrap"
+
+// MigrateService copies src to dst exactly like Migrate, but holds each
+// backend's distributed lock (when the backend supports one) for the whole
+// copy, guarding against a concurrent migration or a CA bootstrap racing on
+// either backend. Locks are acquired source-first, then destination, and
+// released in reverse on return. Backends that cannot provide a distributed
+// lock fall back to a process-local mutex via StorageService.WithLock.
+//
+// Note: pointing both src and dst at the same distributed backend would have
+// the two lock acquisitions (from separate sessions) deadlock; migrating a
+// store onto itself is not a supported operation.
+func MigrateService(ctx context.Context, src, dst *StorageService, opts MigrateOptions) (MigrateReport, error) {
+	var report MigrateReport
+	err := src.WithLock(ctx, migrateLockName, func() error {
+		return dst.WithLock(ctx, migrateLockName, func() error {
+			r, e := Migrate(ctx, src.Backend(), dst.Backend(), opts)
+			report = r
+			return e
+		})
+	})
+	return report, err
+}
+
+// Migrate copies every blob held by src into dst, preserving each blob's
+// visibility (public/private). It is backend-agnostic: any pair of Backend
+// implementations may be combined, enabling filesystem→database,
+// database→database and database→filesystem migrations.
+//
+// Per-subject generated private keys are not copied: they always live on the
+// local filesystem outside any backend.
+//
+// Migrate is not transactional. On error it returns the blobs copied so far in
+// the report. Re-running is safe: copies overwrite matching keys idempotently.
+func Migrate(ctx context.Context, src, dst Backend, opts MigrateOptions) (MigrateReport, error) {
+	var report MigrateReport
+
+	if err := dst.EnsureReady(ctx); err != nil {
+		return report, fmt.Errorf("preparing destination: %w", err)
+	}
+
+	if !opts.Force {
+		exists, err := dst.Exists(ctx, KeyCACert)
+		if err != nil {
+			return report, fmt.Errorf("checking destination for existing CA: %w", err)
+		}
+		if exists {
+			return report, ErrDestinationNotEmpty
+		}
+	}
+
+	logf := opts.Logf
+	if logf == nil {
+		logf = func(string, ...any) {}
+	}
+
+	// copyKey copies one blob; a key absent in the source is skipped (not an
+	// error) so partially-populated CAs migrate cleanly.
+	copyKey := func(key string, kind BlobKind) (bool, error) {
+		data, err := src.Get(ctx, key)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return false, nil
+			}
+			return false, fmt.Errorf("reading %q from source: %w", key, err)
+		}
+		if err := dst.Put(ctx, key, data, kind); err != nil {
+			return false, fmt.Errorf("writing %q to destination: %w", key, err)
+		}
+		logf("copied %s (%d bytes)", key, len(data))
+		return true, nil
+	}
+
+	for _, s := range migratableSingletons {
+		copied, err := copyKey(s.Key, s.Kind)
+		if err != nil {
+			return report, err
+		}
+		if copied {
+			report.Singletons++
+		}
+	}
+
+	csrKeys, err := src.List(ctx, csrPrefix)
+	if err != nil {
+		return report, fmt.Errorf("listing CSRs in source: %w", err)
+	}
+	for _, key := range csrKeys {
+		copied, err := copyKey(key, BlobPublic)
+		if err != nil {
+			return report, err
+		}
+		if copied {
+			report.CSRs++
+		}
+	}
+
+	certKeys, err := src.List(ctx, certPrefix)
+	if err != nil {
+		return report, fmt.Errorf("listing signed certificates in source: %w", err)
+	}
+	for _, key := range certKeys {
+		copied, err := copyKey(key, BlobPublic)
+		if err != nil {
+			return report, err
+		}
+		if copied {
+			report.Certs++
+		}
+	}
+
+	return report, nil
+}

--- a/internal/storage/migrate_test.go
+++ b/internal/storage/migrate_test.go
@@ -1,0 +1,296 @@
+// Copyright (C) 2026 Chris Boot
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package storage
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// seedCA populates a backend with a representative set of CA blobs: every
+// singleton plus a couple of per-subject CSRs and signed certs.
+func seedCA(t *testing.T, b Backend) map[string][]byte {
+	t.Helper()
+	ctx := context.Background()
+	if err := b.EnsureReady(ctx); err != nil {
+		t.Fatalf("EnsureReady: %v", err)
+	}
+	want := map[string][]byte{
+		KeyCACert:        []byte("ca-cert-pem"),
+		KeyCAPubKey:      []byte("ca-pub-pem"),
+		KeyCAKey:         []byte("ca-key-pem"),
+		KeyCRL:           []byte("crl-pem"),
+		KeySerial:        []byte("0A"),
+		KeyInventory:     []byte("0xABC /CN=a\n"),
+		KeyInventoryHMAC: []byte("hmac-bytes"),
+		KeyHMACKey:       []byte("hmac-key-bytes"),
+		CSRKey("web01"):  []byte("csr-web01"),
+		CSRKey("web02"):  []byte("csr-web02"),
+		CertKey("web01"): []byte("cert-web01"),
+	}
+	for k, v := range want {
+		if err := b.Put(ctx, k, v, BlobPublic); err != nil {
+			t.Fatalf("seed Put %q: %v", k, err)
+		}
+	}
+	return want
+}
+
+func TestMigrateCopiesEverything(t *testing.T) {
+	ctx := context.Background()
+	src := NewFilesystemBackend(t.TempDir())
+	want := seedCA(t, src)
+
+	dst := NewFilesystemBackend(t.TempDir())
+
+	report, err := Migrate(ctx, src, dst, MigrateOptions{})
+	if err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	if report.Singletons != 8 || report.CSRs != 2 || report.Certs != 1 {
+		t.Errorf("report = %+v, want 8 singletons, 2 CSRs, 1 cert", report)
+	}
+	if report.Total() != len(want) {
+		t.Errorf("Total = %d, want %d", report.Total(), len(want))
+	}
+
+	for k, v := range want {
+		got, err := dst.Get(ctx, k)
+		if err != nil {
+			t.Errorf("dst.Get %q: %v", k, err)
+			continue
+		}
+		if !bytes.Equal(got, v) {
+			t.Errorf("dst[%q] = %q, want %q", k, got, v)
+		}
+	}
+}
+
+// TestMigratePreservesVisibility verifies that private singletons land with
+// 0600 and public ones with 0644 on a filesystem destination.
+func TestMigratePreservesVisibility(t *testing.T) {
+	ctx := context.Background()
+	src := NewFilesystemBackend(t.TempDir())
+	seedCA(t, src)
+
+	dstDir := t.TempDir()
+	dst := NewFilesystemBackend(dstDir)
+	if _, err := Migrate(ctx, src, dst, MigrateOptions{}); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	cases := []struct {
+		key  string
+		perm os.FileMode
+	}{
+		{KeyCACert, FilePermPublic},
+		{KeySerial, FilePermPublic},
+		{KeyCAKey, FilePermPrivate},
+		{KeyInventory, FilePermPrivate},
+		{KeyHMACKey, FilePermPrivate},
+	}
+	for _, c := range cases {
+		p := dst.Path(c.key)
+		info, err := os.Stat(p)
+		if err != nil {
+			t.Fatalf("stat %q: %v", p, err)
+		}
+		if got := info.Mode().Perm(); got != c.perm {
+			t.Errorf("%s perm = %o, want %o", c.key, got, c.perm)
+		}
+	}
+}
+
+func TestMigrateRefusesNonEmptyDestination(t *testing.T) {
+	ctx := context.Background()
+	src := NewFilesystemBackend(t.TempDir())
+	seedCA(t, src)
+
+	dst := NewFilesystemBackend(t.TempDir())
+	if err := dst.EnsureReady(ctx); err != nil {
+		t.Fatalf("EnsureReady: %v", err)
+	}
+	// Pre-populate the destination with a CA cert.
+	if err := dst.Put(ctx, KeyCACert, []byte("existing"), BlobPublic); err != nil {
+		t.Fatalf("seed dst: %v", err)
+	}
+
+	_, err := Migrate(ctx, src, dst, MigrateOptions{})
+	if !errors.Is(err, ErrDestinationNotEmpty) {
+		t.Fatalf("err = %v, want ErrDestinationNotEmpty", err)
+	}
+
+	// The existing cert must be untouched (no partial copy occurred).
+	got, err := dst.Get(ctx, KeyCACert)
+	if err != nil || !bytes.Equal(got, []byte("existing")) {
+		t.Fatalf("dst CA cert = %q (err %v), want untouched", got, err)
+	}
+
+	// --force overwrites it.
+	if _, err := Migrate(ctx, src, dst, MigrateOptions{Force: true}); err != nil {
+		t.Fatalf("Migrate --force: %v", err)
+	}
+	got, _ = dst.Get(ctx, KeyCACert)
+	if !bytes.Equal(got, []byte("ca-cert-pem")) {
+		t.Errorf("after force, dst CA cert = %q, want ca-cert-pem", got)
+	}
+}
+
+func TestMigrateSkipsAbsentSingletons(t *testing.T) {
+	ctx := context.Background()
+	src := NewFilesystemBackend(t.TempDir())
+	if err := src.EnsureReady(ctx); err != nil {
+		t.Fatalf("EnsureReady: %v", err)
+	}
+	// Only a CA cert and one CSR exist; everything else is absent.
+	if err := src.Put(ctx, KeyCACert, []byte("c"), BlobPublic); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := src.Put(ctx, CSRKey("only"), []byte("r"), BlobPublic); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	dst := NewFilesystemBackend(t.TempDir())
+	report, err := Migrate(ctx, src, dst, MigrateOptions{})
+	if err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	if report.Singletons != 1 || report.CSRs != 1 || report.Certs != 0 {
+		t.Errorf("report = %+v, want 1 singleton, 1 CSR, 0 certs", report)
+	}
+	// An absent singleton must not be created at the destination.
+	if _, err := os.Stat(dst.Path(KeySerial)); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("serial unexpectedly present at destination: %v", err)
+	}
+}
+
+func TestMigrateLogfReceivesEachCopiedBlob(t *testing.T) {
+	ctx := context.Background()
+	src := NewFilesystemBackend(t.TempDir())
+	want := seedCA(t, src)
+	dst := NewFilesystemBackend(t.TempDir())
+
+	var lines int
+	_, err := Migrate(ctx, src, dst, MigrateOptions{
+		Logf: func(string, ...any) { lines++ },
+	})
+	if err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	if lines != len(want) {
+		t.Errorf("Logf called %d times, want %d", lines, len(want))
+	}
+}
+
+// unlockFunc adapts a func to the Unlocker interface.
+type unlockFunc func() error
+
+func (f unlockFunc) Unlock() error { return f() }
+
+// lockingBackend wraps a filesystem backend and additionally implements Locker,
+// recording every lock acquired and released so tests can assert that
+// MigrateService coordinates the copy under a distributed lock.
+type lockingBackend struct {
+	*FilesystemBackend
+	acquired []string
+	released int
+}
+
+func (b *lockingBackend) AcquireLock(_ context.Context, name string) (Unlocker, error) {
+	b.acquired = append(b.acquired, name)
+	return unlockFunc(func() error { b.released++; return nil }), nil
+}
+
+func TestMigrateServiceLocksBothBackends(t *testing.T) {
+	ctx := context.Background()
+	srcB := &lockingBackend{FilesystemBackend: NewFilesystemBackend(t.TempDir())}
+	want := seedCA(t, srcB)
+	dstB := &lockingBackend{FilesystemBackend: NewFilesystemBackend(t.TempDir())}
+
+	src := NewWithBackend(srcB, t.TempDir())
+	dst := NewWithBackend(dstB, t.TempDir())
+
+	report, err := MigrateService(ctx, src, dst, MigrateOptions{})
+	if err != nil {
+		t.Fatalf("MigrateService: %v", err)
+	}
+	if report.Total() != len(want) {
+		t.Errorf("Total = %d, want %d", report.Total(), len(want))
+	}
+
+	for label, b := range map[string]*lockingBackend{"source": srcB, "destination": dstB} {
+		if len(b.acquired) != 1 || b.acquired[0] != migrateLockName {
+			t.Errorf("%s locks acquired = %v, want [%q]", label, b.acquired, migrateLockName)
+		}
+		if b.released != 1 {
+			t.Errorf("%s locks released = %d, want 1", label, b.released)
+		}
+	}
+
+	// The data was actually copied under the lock.
+	got, err := dstB.Get(ctx, KeyCACert)
+	if err != nil || !bytes.Equal(got, want[KeyCACert]) {
+		t.Fatalf("dst CA cert = %q (err %v), want copied", got, err)
+	}
+}
+
+// TestMigrateServiceWithoutLocker confirms MigrateService still works against
+// backends that do not implement Locker (it falls back to a process-local
+// mutex via WithLock).
+func TestMigrateServiceWithoutLocker(t *testing.T) {
+	ctx := context.Background()
+	srcB := NewFilesystemBackend(t.TempDir())
+	want := seedCA(t, srcB)
+	dstB := NewFilesystemBackend(t.TempDir())
+
+	src := NewWithBackend(srcB, t.TempDir())
+	dst := NewWithBackend(dstB, t.TempDir())
+
+	report, err := MigrateService(ctx, src, dst, MigrateOptions{})
+	if err != nil {
+		t.Fatalf("MigrateService: %v", err)
+	}
+	if report.Total() != len(want) {
+		t.Errorf("Total = %d, want %d", report.Total(), len(want))
+	}
+}
+
+// TestMigrateRoundTripsLocalFileLayout sanity-checks that a migrated
+// filesystem destination is readable as a normal on-disk CA (paths exist where
+// the filesystem backend expects them).
+func TestMigrateRoundTripsLocalFileLayout(t *testing.T) {
+	ctx := context.Background()
+	src := NewFilesystemBackend(t.TempDir())
+	seedCA(t, src)
+
+	dstDir := t.TempDir()
+	dst := NewFilesystemBackend(dstDir)
+	if _, err := Migrate(ctx, src, dst, MigrateOptions{}); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	// Spot-check a couple of well-known on-disk paths.
+	for _, rel := range []string{"ca_crt.pem", filepath.Join("private", "ca_key.pem"), filepath.Join("requests", "web01.pem")} {
+		if _, err := os.Stat(filepath.Join(dstDir, rel)); err != nil {
+			t.Errorf("expected %s on disk: %v", rel, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds `puppet-ca-ctl migrate`, an offline command that copies an entire CA between **any pair** of storage backends — `filesystem`, `sqlite`, `postgres`, `mysql`, `etcd`, `redis`/`valkey`. This covers:

- importing a file-based CA into a database (`filesystem` → `postgres`),
- moving between stores (`redis`/`valkey` → `postgres`, `etcd` → `sqlite`, …),
- exporting a database back to a plain directory of files (`postgres` → `filesystem`).

```bash
puppet-ca-ctl migrate \
  --source-config /etc/puppet-ca/filesystem.yaml \
  --dest-config   /etc/puppet-ca/postgres.yaml
```

Both ends are described by ordinary `puppet-ca` config files (the same YAML the server reads), so each backend's parameters are expressed exactly as in production.

## What it copies

CA certificate, public key and private key, CRL, serial, inventory **and its integrity HMAC** (so tamper-detection keeps working after the move), every pending CSR and every signed certificate. Each blob is written with its normal public/private visibility, so a `filesystem` destination ends up with the usual `0600`/`0644` permissions. Blobs absent in the source are skipped.

Per-subject generated private keys are **not** migrated: by design they always live on the local filesystem under `cadir`, never in a backend.

## Safety

- **Distributed locking.** The copy holds each backend's distributed lock when supported (`StorageService.WithLock`, sharing the CA `bootstrap` lock name), so a migration and a server bootstrap — or two migrations — cannot race on the same backend. Backends without distributed locking fall back to a process-local mutex. The server should still be stopped during a migration (per-subject signing locks are not held); this is documented.
- **Overwrite protection.** A destination that already holds a CA certificate is refused unless `--force`.
- **Re-runnable.** The per-key copy is idempotent.

## Implementation

- `internal/storage/migrate.go` — backend-agnostic `Migrate` (works against the `Backend` interface) and `MigrateService` (adds locking over two `StorageService`s).
- `cmd/puppet-ca-ctl/migrate.go` — the cobra command.
- `internal/config/storage.go` — backend-selection plumbing extracted into a shared `StorageConfig.ToBackendSpec`, embedded inline by the server config so the server and the migrate command interpret the same YAML identically (no duplication; net reduction in `cmd/puppet-ca`).

## Tests

Unit tests cover the backend-agnostic copy, visibility/permission preservation, overwrite protection, lock acquisition/release on both backends, and a real **filesystem ⇒ sqlite ⇒ filesystem** round-trip through the actual command, asserting the exported tree is byte-identical to the original. SQLite is pure-Go, so this runs in the existing `unit` CI job with no extra service.

Docs updated: a new "Migrating between backends" section in `docs/storage-backends.md` plus the `puppet-ca-ctl` subcommand list in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)