### PR TITLE
feat: decompose the inventory into a structured store (SQL backend)

### DIFF
--- a/docs/inventory-store.md
+++ b/docs/inventory-store.md
@@ -1,0 +1,167 @@
+# Decomposing the inventory: the `InventoryStore` capability
+
+## Background
+
+Historically the certificate inventory is a single append-only text blob, the
+Puppet-style `inventory.txt`, with one line per issued certificate:
+
+```
+SERIAL NOT_BEFORE NOT_AFTER /SUBJECT
+```
+
+It is addressed by the logical key `inventory` and manipulated through a handful
+of `StorageService` methods (`AppendInventory`, `ReadInventory`,
+`TouchInventory`, `HasInventory`). Integrity is provided by an HMAC-SHA256 over
+the **entire blob**, stored under `inventory_hmac` and keyed by `hmac_key`
+(see [storage-backends.md](storage-backends.md)).
+
+Despite being a blob, the inventory is only ever used three ways:
+
+1. **Append one entry** when a certificate is signed.
+2. **Find the latest serial for a subject** during revocation — a full scan.
+3. **Build a serial → subject index** at startup for OCSP — a full scan, then
+   held in memory and updated incrementally on each signing.
+
+The inventory is never served over the API; the `inventory.txt` text format is
+an internal and on-disk-compatibility concern only.
+
+### Costs of the blob model
+
+- Every append re-hashes the whole inventory (O(n) per append) and every read
+  re-verifies it. Fine while inventories are small; wasteful as they grow.
+- Lookups (revocation) scan the whole blob.
+- A SQL backend stores the entire history as one ever-growing row.
+
+## Goal
+
+Let backends that can do better store the inventory as **structured records**
+(e.g. a SQL table) while preserving exact behaviour for backends that keep the
+blob (filesystem, etcd, redis/valkey). This is opt-in per backend.
+
+## Design
+
+### Optional capability interface
+
+Following the existing `Locker` pattern — an optional interface probed by
+`StorageService` via a type assertion, with a clean fallback — we add:
+
+```go
+// InventoryEntry is one issued-certificate record. NotBefore/NotAfter are
+// stored verbatim as the formatted strings the signing path produces, so that
+// rendering rows back to inventory.txt is byte-identical to the legacy blob.
+type InventoryEntry struct {
+    Serial    string
+    NotBefore string
+    NotAfter  string
+    Subject   string
+}
+
+// InventoryStore is an optional Backend capability for structured inventory
+// storage. Backends that implement it let StorageService skip the
+// render → scan → reparse round-trip. Backends that do not implement it keep
+// using the KeyInventory blob via AppendLine/Get.
+type InventoryStore interface {
+    // AppendEntry inserts e and advances the integrity head atomically.
+    // newHead computes the chained head MAC from the previous head (nil when
+    // the inventory is empty); the backend MUST invoke it inside the same
+    // transaction/lock that serialises appends so the chain cannot fork under
+    // concurrent appenders.
+    AppendEntry(ctx context.Context, e InventoryEntry, newHead func(prev []byte) []byte) error
+
+    // Entries returns every entry in issuance order, for the OCSP index build
+    // and for chain verification.
+    Entries(ctx context.Context) ([]InventoryEntry, error)
+
+    // LatestSerialForSubject returns the most recently issued serial for
+    // subject, wrapping fs.ErrNotExist when the subject has no entry.
+    LatestSerialForSubject(ctx context.Context, subject string) (string, error)
+}
+```
+
+`StorageService` probes `backend.(InventoryStore)`:
+
+- **`AppendInventory`** → structured: build the `newHead` closure and call
+  `AppendEntry`; blob: today's `AppendLine` + whole-blob HMAC recompute.
+- **`LatestSerialForSubject`** (new) → structured: backend query; blob: scan the
+  bytes from `ReadInventory` (the logic moved out of `ca.findSerialForSubject`).
+- **`computeInventoryHMAC`** → structured: fold the chain over `Entries`; blob:
+  HMAC over the blob bytes (unchanged).
+- **`ReadInventory` / `TouchInventory` / `HasInventory`** keep using the blob
+  path; for structured backends they are served by the render/parse shim
+  (below), which keeps migration and the OCSP index build working unchanged.
+
+### Integrity: a hash chain
+
+Re-hashing the whole inventory on every append defeats the point of moving to a
+table, so structured backends use a **hash chain** instead of a blob HMAC:
+
+```
+mac_i = HMAC-SHA256(key, mac_{i-1} ‖ canonical(entry_i))      mac_{-1} = ∅
+head  = mac_n
+```
+
+- `canonical(entry)` is the exact `SERIAL NB NA /SUBJECT\n` line the signing
+  path already writes, so the chain is trivially reproducible and independent of
+  any backend's row encoding.
+- The **head** (`mac_n`) is stored under the existing `inventory_hmac` blob row
+  — no new logical key, and `VerifyInventoryHMAC`/`UpdateInventoryHMAC` keep
+  their shape. The key still lives in `StorageService` (`s.hmacKey`); the
+  `newHead` closure captures it, so no key handling leaks into backends.
+- **Append is O(1)**: read the current head, hash one entry onto it, store the
+  new head — all inside the backend's append transaction so the chain cannot
+  fork across replicas.
+- **Verification** is an O(n) fold over all rows at startup (same cost profile
+  as the existing OCSP index build), compared against the stored head; a
+  mismatch returns `ErrInventoryTampered`, exactly as today.
+
+This detects modification, insertion, deletion, and truncation of the entry set
+— the same tamper-evidence guarantee the blob HMAC provides, with the same
+locally-held key threat model.
+
+### Migration
+
+`Migrate` copies blobs opaquely via `Backend.Get`/`Put` keyed by logical key. To
+keep filesystem ⇄ SQL migrations working without teaching the migrator about
+inventory internals, a structured backend serves the `inventory` logical key
+through a **render/parse shim**:
+
+- `Get(KeyInventory)` renders the rows back to byte-identical `inventory.txt`.
+- `Put(KeyInventory, data)` parses the text and replaces the table contents
+  (also covers the empty `Put` from `TouchInventory`).
+- `Exists(KeyInventory)` reports whether the inventory has been seeded.
+
+A chain head is **not** byte-portable across a backend-type change (a filesystem
+blob HMAC ≠ a chain head over the same entries). So after the copy,
+`MigrateService` — which holds both `StorageService`s and the destination key —
+recomputes the destination's integrity head from its entries
+(`RebuildInventoryHMAC`). This resolves the otherwise-spurious
+`ErrInventoryTampered` that copying a foreign `inventory_hmac` would cause.
+
+## Scope
+
+- **SQL backend** (sqlite/postgres/mysql) implements `InventoryStore` with a
+  dedicated `puppet_ca_inventory` table indexed on `subject` and `serial`, plus
+  the render/parse shim. This is where decomposition pays off.
+- **Filesystem, etcd, redis/valkey keep the blob.** They do not implement the
+  interface; the type assertion fails and they behave exactly as before. Adding
+  the capability to etcd/redis later is possible but not currently motivated.
+- **OCSP is untouched**: the in-memory serial index is still built at startup
+  and updated on signing.
+
+## Implementation phases
+
+Each phase is a separate commit.
+
+1. **Interface + routing.** Define `InventoryEntry` / `InventoryStore`; fork the
+   `StorageService` inventory methods; move the subject-scan into
+   `LatestSerialForSubject`; point `ca.findSerialForSubject` at it. No backend
+   implements the interface yet, so behaviour is unchanged everywhere.
+2. **SQL backend.** New bun migration creating `puppet_ca_inventory`; implement
+   `AppendEntry`/`Entries`/`LatestSerialForSubject`; add the render/parse shim
+   for the `inventory` logical key.
+3. **Migration integrity rebuild.** Add `RebuildInventoryHMAC` and call it from
+   `MigrateService` after the copy.
+4. **Tests.** Exercise the inventory contract against both blob and structured
+   backends: latest-wins lookups, chain tamper detection (modify / insert /
+   delete), byte-identical render, and a filesystem ⇄ sqlite migration
+   round-trip that verifies integrity on both sides.

--- a/docs/inventory-store.md
+++ b/docs/inventory-store.md
@@ -140,8 +140,9 @@ recomputes the destination's integrity head from its entries
 ## Scope
 
 - **SQL backend** (sqlite/postgres/mysql) implements `InventoryStore` with a
-  dedicated `puppet_ca_inventory` table indexed on `subject` and `serial`, plus
-  the render/parse shim. This is where decomposition pays off.
+  dedicated `puppet_ca_inventory` table indexed on `subject` (and a unique index
+  on `serial`, since serials never repeat), plus the render/parse shim. This is
+  where decomposition pays off.
 - **Filesystem, etcd, redis/valkey keep the blob.** They do not implement the
   interface; the type assertion fails and they behave exactly as before. Adding
   the capability to etcd/redis later is possible but not currently motivated.

--- a/docs/storage-backends.md
+++ b/docs/storage-backends.md
@@ -39,7 +39,7 @@ Every backend serves the following logical keys:
 | `crl`               | Current Certificate Revocation List (PEM)                 | bootstrap, revoke, rotate |
 | `serial`            | Next leaf certificate serial counter                      | sign                      |
 | `inventory`         | Append-only log of issued/revoked certificates            | sign / revoke             |
-| `inventory_hmac`    | HMAC-SHA256 of inventory, for tamper detection            | sign / revoke             |
+| `inventory_hmac`    | Inventory integrity head (blob HMAC or hash chain on SQL) | sign / revoke             |
 | `hmac_key`          | Integrity key for `inventory_hmac`                        | first run                 |
 | `csr/<subject>`     | Pending certificate signing request (PEM), per subject    | CSR submission            |
 | `cert/<subject>`    | Issued certificate (PEM), per subject                     | sign                      |
@@ -397,10 +397,13 @@ PUPPET_CA_TEST_REDIS_ADDR=127.0.0.1:6379 \
 ## SQL backends
 
 A single shared backend stores every logical key (except the local
-private-key directory) as one row in a key-value table inside a SQL database.
-The same implementation drives every dialect; only the driver, a few SQL
-clauses, and the cross-node lock mechanism differ. The first dialect to ship
-is **SQLite**; PostgreSQL and MySQL/MariaDB build on the same code.
+private-key directory) as one row in a key-value table inside a SQL database,
+with the certificate inventory broken out into its own structured table (see
+[Structured inventory](#structured-inventory) and
+[inventory-store.md](inventory-store.md)). The same implementation drives every
+dialect; only the driver, a few SQL clauses, and the cross-node lock mechanism
+differ. The first dialect to ship is **SQLite**; PostgreSQL and MySQL/MariaDB
+build on the same code.
 
 All drivers are pure Go, so the default `CGO_ENABLED=0` and
 `GOEXPERIMENT=boringcrypto` (FIPS) builds are unaffected. SQLite uses
@@ -409,7 +412,7 @@ translation of SQLite, no CGO).
 
 ### Schema and migrations
 
-The schema is a single table, `puppet_ca_blobs`:
+Most logical keys live in a key-value table, `puppet_ca_blobs`:
 
 | Column        | Purpose                                                       |
 |---------------|---------------------------------------------------------------|
@@ -424,6 +427,31 @@ its own `bun_migrations` table; a `bun_migration_locks` table serialises
 concurrent runners so multiple replicas can start against the same database
 safely. Migrations are defined as Go functions, so one definition emits
 dialect-correct DDL across SQLite, PostgreSQL, and MySQL/MariaDB.
+
+### Structured inventory
+
+The SQL backends do not store the inventory as one growing `inventory` blob.
+Each issued certificate is a row in a dedicated `puppet_ca_inventory` table,
+indexed by subject:
+
+| Column                    | Purpose                                              |
+|---------------------------|------------------------------------------------------|
+| `id`                      | autoincrement key; also defines issuance order       |
+| `serial`                  | certificate serial                                   |
+| `subject`                 | certificate subject (indexed)                        |
+| `not_before` / `not_after`| validity window, stored as the inventory.txt strings |
+
+This turns appends and revocation lookups (`LatestSerialForSubject`) into
+single-row operations instead of scanning the whole inventory. Integrity uses a
+**hash chain** rather than a whole-blob HMAC: each append folds the new line
+into the previous head, which is kept in the `inventory_hmac` row and verified
+by replaying the chain at startup. The `inventory` row in `puppet_ca_blobs` is
+retained only as an empty marker recording that the inventory has been
+initialised, and the `inventory` logical key is still served (rows rendered to
+`inventory.txt` text, and parsed back) so migrations remain backend-agnostic.
+A migration into or out of a SQL backend recomputes the integrity head for the
+destination's scheme. See [inventory-store.md](inventory-store.md) for the full
+design.
 
 ### SQLite backend
 
@@ -558,7 +586,8 @@ and releases the advisory lock automatically.
 - **CA cert and key.** As with the etcd/redis backends, the CA private key
   lives in the database by default. Enable `encrypt_ca_key`, or pin the key to
   a local file via `ca_key_file` (see below).
-- **Schema.** The backend owns the `puppet_ca_blobs` table plus bun's
+- **Schema.** The backend owns the `puppet_ca_blobs` and `puppet_ca_inventory`
+  tables plus bun's
   `bun_migrations` / `bun_migration_locks` bookkeeping tables. Grant the
   configured role rights to create tables on first run (or pre-create the
   schema and grant DML).
@@ -630,10 +659,11 @@ replica's session ends and its named locks release automatically.
 #### Operational notes
 
 - **Schema.** On first run the migration widens the `data` column to
-  `LONGBLOB` (MySQL's default `BLOB` caps at 64 KiB, too small for the
-  append-only inventory). Concurrent inventory appends use a `FOR UPDATE`
-  transaction; an InnoDB deadlock (the expected outcome when two replicas race
-  to create the same row) is retried transparently.
+  `LONGBLOB` (MySQL's default `BLOB` caps at 64 KiB, too small for large blobs
+  such as the CRL). Concurrent inventory appends serialise on a `FOR UPDATE`
+  transaction (locking the inventory marker row before advancing the integrity
+  chain); an InnoDB deadlock — the expected outcome when two replicas race to
+  create the same not-yet-existing row — is retried transparently.
 - **CA cert and key.** As with the other shared backends, the CA private key
   lives in the database by default. Enable `encrypt_ca_key`, or pin the key to
   a local file via `ca_key_file` (see below).

--- a/docs/storage-backends.md
+++ b/docs/storage-backends.md
@@ -437,7 +437,7 @@ indexed by subject:
 | Column                    | Purpose                                              |
 |---------------------------|------------------------------------------------------|
 | `id`                      | autoincrement key; also defines issuance order       |
-| `serial`                  | certificate serial                                   |
+| `serial`                  | certificate serial (unique)                          |
 | `subject`                 | certificate subject (indexed)                        |
 | `not_before` / `not_after`| validity window, stored as the inventory.txt strings |
 

--- a/internal/ca/revoke.go
+++ b/internal/ca/revoke.go
@@ -18,8 +18,6 @@
 package ca
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/x509"
@@ -149,42 +147,10 @@ func parseInventoryLine(line string) (serial, subject string, ok bool) {
 }
 
 // findSerialForSubject returns the most-recently issued serial for subject.
-// It reads through storage to honour the inventory mutex.
+// It delegates to storage, which uses an indexed lookup on structured backends
+// and a verified blob scan otherwise.
 func (c *CA) findSerialForSubject(ctx context.Context, subject string) (string, error) {
-	data, err := c.Storage.ReadInventory(ctx)
-	if err != nil {
-		return "", err
-	}
-
-	scanner := bufio.NewScanner(bytes.NewReader(data))
-	last := ""
-	lineNum := 0
-	badLines := 0
-	for scanner.Scan() {
-		lineNum++
-		line := scanner.Text()
-		if strings.TrimSpace(line) == "" {
-			continue
-		}
-		serial, subj, ok := parseInventoryLine(line)
-		if !ok {
-			badLines++
-			continue
-		}
-		if subj == subject {
-			last = serial
-		}
-	}
-	if badLines > 0 {
-		slog.Warn("Inventory file contains unparseable lines", "count", badLines)
-	}
-	if err := scanner.Err(); err != nil {
-		return "", err
-	}
-	if last == "" {
-		return "", fmt.Errorf("subject %s not found in inventory", subject)
-	}
-	return last, nil
+	return c.Storage.LatestSerialForSubject(ctx, subject)
 }
 
 // IsRevokedSerial reports whether the given serial number appears in the

--- a/internal/storage/20260201000000_inventory.go
+++ b/internal/storage/20260201000000_inventory.go
@@ -1,0 +1,57 @@
+// Copyright (C) 2026 Chris Boot
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package storage
+
+import (
+	"context"
+
+	"github.com/uptrace/bun"
+)
+
+// Migration 20260201000000 (inventory): create the structured inventory table
+// that backs the InventoryStore capability. Each issued certificate is one row,
+// ordered by the autoincrement id (issuance order); the subject index serves
+// LatestSerialForSubject. The legacy KeyInventory row in puppet_ca_blobs is
+// retained as an empty presence marker (see sql_inventory.go), so this
+// migration does not move existing blob data — operators with an inventory blob
+// migrate it via the storage migrate command, which parses it into rows.
+func init() {
+	sqlMigrations.MustRegister(func(ctx context.Context, db *bun.DB) error {
+		if _, err := db.NewCreateTable().
+			Model((*sqlInventoryRow)(nil)).
+			IfNotExists().
+			Exec(ctx); err != nil {
+			return err
+		}
+		// Index subject for LatestSerialForSubject. No IF NOT EXISTS: MySQL does
+		// not support it on CREATE INDEX, and bun applies each migration once.
+		if _, err := db.NewCreateIndex().
+			Model((*sqlInventoryRow)(nil)).
+			Index("idx_puppet_ca_inventory_subject").
+			Column("subject").
+			Exec(ctx); err != nil {
+			return err
+		}
+		return nil
+	}, func(ctx context.Context, db *bun.DB) error {
+		_, err := db.NewDropTable().
+			Model((*sqlInventoryRow)(nil)).
+			IfExists().
+			Exec(ctx)
+		return err
+	})
+}

--- a/internal/storage/20260201000000_inventory.go
+++ b/internal/storage/20260201000000_inventory.go
@@ -46,6 +46,18 @@ func init() {
 			Exec(ctx); err != nil {
 			return err
 		}
+		// Serials are unique per issuance (random 128-bit, fresh on every
+		// (re-)issuance), so enforce it: a duplicate signals a serial collision
+		// or a double insert, which AppendEntry should fail on rather than
+		// silently record two certs under one serial.
+		if _, err := db.NewCreateIndex().
+			Model((*sqlInventoryRow)(nil)).
+			Unique().
+			Index("idx_puppet_ca_inventory_serial").
+			Column("serial").
+			Exec(ctx); err != nil {
+			return err
+		}
 		return nil
 	}, func(ctx context.Context, db *bun.DB) error {
 		_, err := db.NewDropTable().

--- a/internal/storage/backend.go
+++ b/internal/storage/backend.go
@@ -138,6 +138,50 @@ type PathProvider interface {
 	BaseDir() string
 }
 
+// InventoryEntry is one issued-certificate record in the inventory. NotBefore
+// and NotAfter are stored verbatim as the formatted strings the signing path
+// produces, so that rendering entries back to the inventory.txt line is
+// byte-identical to the legacy append-only blob.
+type InventoryEntry struct {
+	Serial    string
+	NotBefore string
+	NotAfter  string
+	Subject   string
+}
+
+// InventoryStore is an optional Backend capability for storing the certificate
+// inventory as structured records (e.g. a SQL table) rather than the single
+// append-only KeyInventory blob. Backends that implement it let StorageService
+// skip the render → scan → reparse round-trip for appends and subject lookups,
+// and verify integrity with a hash chain instead of re-hashing the whole blob.
+//
+// Backends that do not implement it keep using the KeyInventory blob via
+// AppendLine/Get; StorageService selects the path with a type assertion, the
+// same way it probes Locker.
+//
+// A backend that implements InventoryStore must still serve the KeyInventory
+// logical key through Get/Put/Exists (rendering rows to inventory.txt text and
+// parsing text back to rows) so that Migrate and the OCSP index build remain
+// backend-agnostic.
+type InventoryStore interface {
+	// AppendEntry inserts e and advances the integrity head atomically. newHead
+	// computes the chained head MAC from the previous head (nil when the
+	// inventory is empty); the backend MUST invoke it inside the same
+	// transaction or lock that serialises appends so the chain cannot fork
+	// under concurrent appenders. A nil newHead means integrity is disabled
+	// (no HMAC key configured): the backend appends the entry and leaves the
+	// stored head untouched.
+	AppendEntry(ctx context.Context, e InventoryEntry, newHead func(prev []byte) []byte) error
+
+	// Entries returns every entry in issuance order, for the OCSP index build
+	// and for chain verification.
+	Entries(ctx context.Context) ([]InventoryEntry, error)
+
+	// LatestSerialForSubject returns the most recently issued serial for
+	// subject. Wraps os.ErrNotExist when the subject has no entry.
+	LatestSerialForSubject(ctx context.Context, subject string) (string, error)
+}
+
 // Locker is an optional Backend capability that provides a cross-node
 // distributed mutex. Backends implement it when they have a natural way
 // to coordinate a lock across replicas (etcd's concurrency.Mutex, Redis

--- a/internal/storage/migrate.go
+++ b/internal/storage/migrate.go
@@ -101,7 +101,14 @@ func MigrateService(ctx context.Context, src, dst *StorageService, opts MigrateO
 		return dst.WithLock(ctx, migrateLockName, func() error {
 			r, e := Migrate(ctx, src.Backend(), dst.Backend(), opts)
 			report = r
-			return e
+			if e != nil {
+				return e
+			}
+			// The destination's integrity scheme may differ from the source's
+			// (a structured backend uses a hash chain, a blob backend hashes the
+			// whole inventory), so the copied inventory_hmac is not meaningful
+			// for the destination. Recompute it from the copied inventory.
+			return dst.RebuildInventoryHMAC(ctx)
 		})
 	})
 	return report, err

--- a/internal/storage/sql.go
+++ b/internal/storage/sql.go
@@ -292,10 +292,15 @@ func (b *SQLBackend) EnsureReady(ctx context.Context) error {
 	return nil
 }
 
-// Get returns the blob at key, wrapping fs.ErrNotExist when absent.
+// Get returns the blob at key, wrapping fs.ErrNotExist when absent. The
+// KeyInventory key is served from the structured inventory table (rendered to
+// inventory.txt text) rather than the blob table.
 func (b *SQLBackend) Get(ctx context.Context, key string) ([]byte, error) {
 	if err := validateKey(key); err != nil {
 		return nil, err
+	}
+	if key == KeyInventory {
+		return b.getInventory(ctx)
 	}
 	ctx, cancel := b.callCtx(ctx)
 	defer cancel()
@@ -322,6 +327,9 @@ func (b *SQLBackend) Get(ctx context.Context, key string) ([]byte, error) {
 func (b *SQLBackend) Put(ctx context.Context, key string, data []byte, kind BlobKind) error {
 	if err := validateKey(key); err != nil {
 		return err
+	}
+	if key == KeyInventory {
+		return b.putInventory(ctx, data)
 	}
 	ctx, cancel := b.callCtx(ctx)
 	defer cancel()
@@ -359,6 +367,9 @@ func (b *SQLBackend) Delete(ctx context.Context, key string) error {
 	if err := validateKey(key); err != nil {
 		return err
 	}
+	if key == KeyInventory {
+		return b.deleteInventory(ctx)
+	}
 	ctx, cancel := b.callCtx(ctx)
 	defer cancel()
 	res, err := b.db.NewDelete().Model((*sqlBlob)(nil)).Where("blob_key = ?", key).Exec(ctx)
@@ -382,6 +393,9 @@ func (b *SQLBackend) Exists(ctx context.Context, key string) (bool, error) {
 	}
 	ctx, cancel := b.callCtx(ctx)
 	defer cancel()
+	// KeyInventory existence is the presence marker in puppet_ca_blobs, set by
+	// TouchInventory/putInventory; this reports true for a touched-but-empty
+	// inventory (no rows yet), matching the filesystem backend.
 	return b.db.NewSelect().Model((*sqlBlob)(nil)).Where("blob_key = ?", key).Exists(ctx)
 }
 
@@ -421,6 +435,12 @@ func (b *SQLBackend) List(ctx context.Context, prefix string) ([]string, error) 
 func (b *SQLBackend) AppendLine(ctx context.Context, key string, data []byte, kind BlobKind) error {
 	if err := validateKey(key); err != nil {
 		return err
+	}
+	if key == KeyInventory {
+		// Inventory is structured: append parsed rows. StorageService routes
+		// inventory appends through AppendEntry, so this only runs if a caller
+		// uses Backend.AppendLine(KeyInventory, ...) directly.
+		return b.appendInventoryLines(ctx, data)
 	}
 	b.appendMu.Lock()
 	defer b.appendMu.Unlock()

--- a/internal/storage/sql_inventory.go
+++ b/internal/storage/sql_inventory.go
@@ -1,0 +1,333 @@
+// Copyright (C) 2026 Chris Boot
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package storage
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io/fs"
+	"strings"
+	"time"
+
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect"
+)
+
+// sqlInventoryRow is one issued-certificate record in the structured inventory
+// table. id is an autoincrement surrogate key that also defines issuance order,
+// which drives both the rendered inventory.txt ordering and the integrity hash
+// chain. NotBefore/NotAfter are stored verbatim as the formatted strings the
+// signing path produces so that rendering is byte-identical to the legacy blob.
+type sqlInventoryRow struct {
+	bun.BaseModel `bun:"table:puppet_ca_inventory,alias:inv"`
+
+	ID        int64  `bun:"id,pk,autoincrement"`
+	Serial    string `bun:"serial,notnull,type:varchar(128)"`
+	Subject   string `bun:"subject,notnull,type:varchar(512)"`
+	NotBefore string `bun:"not_before,notnull,type:varchar(64)"`
+	NotAfter  string `bun:"not_after,notnull,type:varchar(64)"`
+}
+
+func inventoryRowFromEntry(e InventoryEntry) *sqlInventoryRow {
+	return &sqlInventoryRow{
+		Serial:    e.Serial,
+		Subject:   e.Subject,
+		NotBefore: e.NotBefore,
+		NotAfter:  e.NotAfter,
+	}
+}
+
+func (r sqlInventoryRow) entry() InventoryEntry {
+	return InventoryEntry{
+		Serial:    r.Serial,
+		NotBefore: r.NotBefore,
+		NotAfter:  r.NotAfter,
+		Subject:   r.Subject,
+	}
+}
+
+// SQLBackend implements InventoryStore: the certificate inventory lives in the
+// puppet_ca_inventory table rather than a single KeyInventory blob. The
+// KeyInventory row in puppet_ca_blobs is kept only as an empty presence marker
+// recording that the inventory has been initialised (TouchInventory), so that
+// Exists/HasInventory report true for a touched-but-empty inventory. The
+// integrity head stays in the KeyInventoryHMAC blob row, advanced by a hash
+// chain (see StorageService.AppendInventory).
+var _ InventoryStore = (*SQLBackend)(nil)
+
+// AppendEntry inserts e and advances the integrity head atomically. The whole
+// operation runs in one transaction that locks the presence-marker row, so
+// concurrent appenders — including separate replicas — serialise and the hash
+// chain cannot fork. newHead is invoked inside that transaction with the
+// current head (nil when none); a nil newHead means integrity is disabled and
+// the stored head is left untouched.
+func (b *SQLBackend) AppendEntry(ctx context.Context, e InventoryEntry, newHead func(prev []byte) []byte) error {
+	b.appendMu.Lock()
+	defer b.appendMu.Unlock()
+
+	ctx, cancel := b.callCtx(ctx)
+	defer cancel()
+
+	const maxAttempts = 10
+	for attempt := 0; ; attempt++ {
+		err := b.appendEntryOnce(ctx, e, newHead)
+		if err == nil {
+			return nil
+		}
+		if attempt+1 >= maxAttempts || !isRetryableSQLError(err) {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Duration(attempt+1) * 5 * time.Millisecond):
+		}
+	}
+}
+
+func (b *SQLBackend) appendEntryOnce(ctx context.Context, e InventoryEntry, newHead func(prev []byte) []byte) error {
+	return b.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+		// Lock the presence marker (created by TouchInventory during bootstrap)
+		// to serialise appends across replicas before reading the head. On the
+		// rare first append with no prior touch the marker is absent and no row
+		// is locked; appendMu still serialises within this process, and CA
+		// bootstrap is guarded by the distributed "bootstrap" lock.
+		if _, err := b.blobDataTx(ctx, tx, KeyInventory, true); err != nil {
+			return err
+		}
+
+		if _, err := tx.NewInsert().Model(inventoryRowFromEntry(e)).Exec(ctx); err != nil {
+			return err
+		}
+
+		if newHead != nil {
+			prev, err := b.blobDataTx(ctx, tx, KeyInventoryHMAC, false)
+			if err != nil {
+				return err
+			}
+			if err := b.upsert(ctx, tx, &sqlBlob{
+				Key:        KeyInventoryHMAC,
+				Data:       newHead(prev),
+				Kind:       int(BlobPrivate),
+				ModifiedAt: time.Now(),
+			}); err != nil {
+				return err
+			}
+		}
+
+		// Ensure the presence marker exists and bump its mtime.
+		return b.upsert(ctx, tx, &sqlBlob{
+			Key:        KeyInventory,
+			Data:       []byte{},
+			Kind:       int(BlobPrivate),
+			ModifiedAt: time.Now(),
+		})
+	})
+}
+
+// Entries returns every inventory entry in issuance order.
+func (b *SQLBackend) Entries(ctx context.Context) ([]InventoryEntry, error) {
+	ctx, cancel := b.callCtx(ctx)
+	defer cancel()
+
+	var rows []sqlInventoryRow
+	if err := b.db.NewSelect().Model(&rows).Order("id ASC").Scan(ctx); err != nil {
+		return nil, err
+	}
+	entries := make([]InventoryEntry, len(rows))
+	for i, r := range rows {
+		entries[i] = r.entry()
+	}
+	return entries, nil
+}
+
+// LatestSerialForSubject returns the most recently issued serial for subject,
+// wrapping fs.ErrNotExist when the subject has no entry.
+func (b *SQLBackend) LatestSerialForSubject(ctx context.Context, subject string) (string, error) {
+	ctx, cancel := b.callCtx(ctx)
+	defer cancel()
+
+	row := new(sqlInventoryRow)
+	err := b.db.NewSelect().
+		Model(row).
+		Column("serial").
+		Where("subject = ?", subject).
+		Order("id DESC").
+		Limit(1).
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", &fs.PathError{Op: "latest-serial", Path: subject, Err: fs.ErrNotExist}
+		}
+		return "", err
+	}
+	return row.Serial, nil
+}
+
+// --- KeyInventory blob shim ---
+//
+// A structured backend must still serve the KeyInventory logical key through
+// Get/Put/Exists/AppendLine so that Migrate and the OCSP index build remain
+// backend-agnostic. These helpers render rows to inventory.txt text and parse
+// text back to rows; Get/Put/Exists/Delete/AppendLine in sql.go dispatch to
+// them when key == KeyInventory.
+
+// getInventory renders the inventory table to byte-identical inventory.txt
+// text. It returns fs.ErrNotExist when the inventory has never been
+// initialised (no presence marker), matching the filesystem backend.
+func (b *SQLBackend) getInventory(ctx context.Context) ([]byte, error) {
+	ctx, cancel := b.callCtx(ctx)
+	defer cancel()
+
+	exists, err := b.db.NewSelect().Model((*sqlBlob)(nil)).Where("blob_key = ?", KeyInventory).Exists(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, &fs.PathError{Op: "get", Path: KeyInventory, Err: fs.ErrNotExist}
+	}
+
+	var rows []sqlInventoryRow
+	if err := b.db.NewSelect().Model(&rows).Order("id ASC").Scan(ctx); err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	for _, r := range rows {
+		buf.WriteString(canonicalInventoryLine(r.entry()))
+		buf.WriteByte('\n')
+	}
+	// Normalise to a non-nil empty slice so a touched-but-empty inventory reads
+	// as present-but-empty, not absent (matching the blob backends' Get).
+	if buf.Len() == 0 {
+		return []byte{}, nil
+	}
+	return buf.Bytes(), nil
+}
+
+// putInventory replaces the entire inventory with the entries parsed from data
+// (an inventory.txt blob) and sets the presence marker. Used by TouchInventory
+// (empty data) and by Migrate when importing into a structured backend. The
+// integrity head is not touched here: Migrate recomputes it afterwards, and
+// TouchInventory writes an empty inventory whose baseline head is established on
+// first verification.
+func (b *SQLBackend) putInventory(ctx context.Context, data []byte) error {
+	ctx, cancel := b.callCtx(ctx)
+	defer cancel()
+
+	return b.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+		if _, err := tx.NewDelete().Model((*sqlInventoryRow)(nil)).Where("1 = 1").Exec(ctx); err != nil {
+			return err
+		}
+		if err := insertInventoryLines(ctx, tx, data); err != nil {
+			return err
+		}
+		return b.upsert(ctx, tx, &sqlBlob{
+			Key:        KeyInventory,
+			Data:       []byte{},
+			Kind:       int(BlobPrivate),
+			ModifiedAt: time.Now(),
+		})
+	})
+}
+
+// appendInventoryLines appends the entries parsed from data as new rows and
+// ensures the presence marker exists, without touching the integrity head.
+// StorageService routes inventory appends through AppendEntry, so this only
+// runs if a caller invokes Backend.AppendLine(KeyInventory, ...) directly.
+func (b *SQLBackend) appendInventoryLines(ctx context.Context, data []byte) error {
+	b.appendMu.Lock()
+	defer b.appendMu.Unlock()
+
+	ctx, cancel := b.callCtx(ctx)
+	defer cancel()
+
+	return b.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+		if err := insertInventoryLines(ctx, tx, data); err != nil {
+			return err
+		}
+		return b.upsert(ctx, tx, &sqlBlob{
+			Key:        KeyInventory,
+			Data:       []byte{},
+			Kind:       int(BlobPrivate),
+			ModifiedAt: time.Now(),
+		})
+	})
+}
+
+// deleteInventory removes all entries and the presence marker, wrapping
+// fs.ErrNotExist when the inventory was never initialised.
+func (b *SQLBackend) deleteInventory(ctx context.Context) error {
+	ctx, cancel := b.callCtx(ctx)
+	defer cancel()
+
+	return b.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+		res, err := tx.NewDelete().Model((*sqlBlob)(nil)).Where("blob_key = ?", KeyInventory).Exec(ctx)
+		if err != nil {
+			return err
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return &fs.PathError{Op: "delete", Path: KeyInventory, Err: fs.ErrNotExist}
+		}
+		_, err = tx.NewDelete().Model((*sqlInventoryRow)(nil)).Where("1 = 1").Exec(ctx)
+		return err
+	})
+}
+
+// insertInventoryLines parses an inventory.txt blob and inserts one row per
+// non-blank line, in order. Malformed lines are rejected so a corrupt import
+// fails loudly rather than silently dropping records.
+func insertInventoryLines(ctx context.Context, tx bun.Tx, data []byte) error {
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		e, ok := parseInventoryEntry(line)
+		if !ok {
+			return fmt.Errorf("malformed inventory line %q", line)
+		}
+		if _, err := tx.NewInsert().Model(inventoryRowFromEntry(e)).Exec(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// blobDataTx reads a blob's data within tx, returning nil when the row is
+// absent. When forUpdate is set (and the dialect supports row locks) it takes a
+// FOR UPDATE lock so concurrent transactions serialise on the row.
+func (b *SQLBackend) blobDataTx(ctx context.Context, tx bun.Tx, key string, forUpdate bool) ([]byte, error) {
+	row := new(sqlBlob)
+	q := tx.NewSelect().Model(row).Column("data").Where("blob_key = ?", key)
+	if forUpdate && b.db.Dialect().Name() != dialect.SQLite {
+		q = q.For("UPDATE")
+	}
+	switch err := q.Scan(ctx); {
+	case err == nil:
+		return row.Data, nil
+	case errors.Is(err, sql.ErrNoRows):
+		return nil, nil
+	default:
+		return nil, err
+	}
+}

--- a/internal/storage/sql_inventory_test.go
+++ b/internal/storage/sql_inventory_test.go
@@ -73,6 +73,18 @@ func TestSQLiteInventoryLatestSerialForSubject(t *testing.T) {
 	}
 }
 
+func TestSQLiteInventorySerialUnique(t *testing.T) {
+	ctx := context.Background()
+	svc, _ := newInventoryService(t)
+
+	// sampleInventoryLines already issued serial 0001 to node1. Re-using it for
+	// a different subject must be rejected by the unique index on serial.
+	dup := "0001 2024-02-01T00:00:00UTC 2029-02-01T00:00:00UTC /someother"
+	if err := svc.AppendInventory(ctx, dup); err == nil {
+		t.Fatal("AppendInventory with duplicate serial succeeded; want a unique-constraint error")
+	}
+}
+
 func TestSQLiteInventoryRenderByteIdentical(t *testing.T) {
 	ctx := context.Background()
 	svc, _ := newInventoryService(t)

--- a/internal/storage/sql_inventory_test.go
+++ b/internal/storage/sql_inventory_test.go
@@ -1,0 +1,205 @@
+// Copyright (C) 2026 Chris Boot
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package storage
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io/fs"
+	"testing"
+)
+
+// sampleInventoryLines is a small inventory with a repeated subject (node1
+// appears twice; its later serial 0003 is the current one).
+var sampleInventoryLines = []string{
+	"0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1",
+	"0002 2024-01-02T00:00:00UTC 2029-01-02T00:00:00UTC /node2",
+	"0003 2024-01-03T00:00:00UTC 2029-01-03T00:00:00UTC /node1",
+}
+
+// newInventoryService returns a StorageService over a fresh SQLite backend with
+// the inventory touched, integrity initialised, and sampleInventoryLines
+// appended. The backend is returned so tests can tamper with rows directly.
+func newInventoryService(t *testing.T) (*StorageService, *SQLBackend) {
+	t.Helper()
+	ctx := context.Background()
+	b := newSQLiteBackend(t)
+	svc := NewWithBackend(b, "")
+	if err := svc.TouchInventory(ctx); err != nil {
+		t.Fatalf("TouchInventory: %v", err)
+	}
+	if err := svc.InitHMAC(ctx); err != nil {
+		t.Fatalf("InitHMAC: %v", err)
+	}
+	for _, line := range sampleInventoryLines {
+		if err := svc.AppendInventory(ctx, line); err != nil {
+			t.Fatalf("AppendInventory(%q): %v", line, err)
+		}
+	}
+	return svc, b
+}
+
+func TestSQLiteInventoryLatestSerialForSubject(t *testing.T) {
+	ctx := context.Background()
+	svc, _ := newInventoryService(t)
+
+	// node1 was issued twice; the most recent serial wins.
+	if got, err := svc.LatestSerialForSubject(ctx, "node1"); err != nil || got != "0003" {
+		t.Errorf("LatestSerialForSubject(node1) = %q, %v; want 0003, nil", got, err)
+	}
+	if got, err := svc.LatestSerialForSubject(ctx, "node2"); err != nil || got != "0002" {
+		t.Errorf("LatestSerialForSubject(node2) = %q, %v; want 0002, nil", got, err)
+	}
+
+	// An unknown subject wraps fs.ErrNotExist.
+	_, err := svc.LatestSerialForSubject(ctx, "ghost")
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("LatestSerialForSubject(ghost) err = %v; want fs.ErrNotExist", err)
+	}
+}
+
+func TestSQLiteInventoryRenderByteIdentical(t *testing.T) {
+	ctx := context.Background()
+	svc, _ := newInventoryService(t)
+
+	var want bytes.Buffer
+	for _, line := range sampleInventoryLines {
+		want.WriteString(line)
+		want.WriteByte('\n')
+	}
+
+	got, err := svc.ReadInventory(ctx)
+	if err != nil {
+		t.Fatalf("ReadInventory: %v", err)
+	}
+	if !bytes.Equal(got, want.Bytes()) {
+		t.Errorf("rendered inventory = %q, want %q", got, want.Bytes())
+	}
+}
+
+// TestSQLiteInventoryChainTamperDetection asserts the hash chain detects every
+// kind of out-of-band edit to the inventory table: modification, insertion, and
+// deletion of a row. Each mutates rows directly via the backend's db handle,
+// bypassing AppendEntry so the stored head is not advanced.
+func TestSQLiteInventoryChainTamperDetection(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("modified row", func(t *testing.T) {
+		svc, b := newInventoryService(t)
+		if _, err := b.db.NewUpdate().
+			Model((*sqlInventoryRow)(nil)).
+			Set("serial = ?", "DEAD").
+			Where("subject = ?", "node2").
+			Exec(ctx); err != nil {
+			t.Fatalf("tamper update: %v", err)
+		}
+		if _, err := svc.ReadInventory(ctx); !errors.Is(err, ErrInventoryTampered) {
+			t.Errorf("ReadInventory err = %v; want ErrInventoryTampered", err)
+		}
+	})
+
+	t.Run("inserted row", func(t *testing.T) {
+		svc, b := newInventoryService(t)
+		if _, err := b.db.NewInsert().
+			Model(&sqlInventoryRow{
+				Serial:    "9999",
+				Subject:   "rogue",
+				NotBefore: "2024-06-01T00:00:00UTC",
+				NotAfter:  "2029-06-01T00:00:00UTC",
+			}).
+			Exec(ctx); err != nil {
+			t.Fatalf("tamper insert: %v", err)
+		}
+		if _, err := svc.ReadInventory(ctx); !errors.Is(err, ErrInventoryTampered) {
+			t.Errorf("ReadInventory err = %v; want ErrInventoryTampered", err)
+		}
+	})
+
+	t.Run("deleted row", func(t *testing.T) {
+		svc, b := newInventoryService(t)
+		if _, err := b.db.NewDelete().
+			Model((*sqlInventoryRow)(nil)).
+			Where("subject = ?", "node2").
+			Exec(ctx); err != nil {
+			t.Fatalf("tamper delete: %v", err)
+		}
+		if _, err := svc.ReadInventory(ctx); !errors.Is(err, ErrInventoryTampered) {
+			t.Errorf("ReadInventory err = %v; want ErrInventoryTampered", err)
+		}
+	})
+}
+
+// TestInventoryMigrationRoundTrip migrates an inventory filesystem → sqlite →
+// filesystem and asserts entries survive byte-for-byte and integrity verifies
+// at each hop, even though the filesystem backend hashes the whole blob while
+// the SQL backend uses a hash chain.
+func TestInventoryMigrationRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	// Source filesystem CA with inventory + integrity.
+	src := New(t.TempDir())
+	if err := src.EnsureDirs(ctx); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+	if err := src.SaveCACert(ctx, []byte("ca-cert-pem")); err != nil {
+		t.Fatalf("SaveCACert: %v", err)
+	}
+	if err := src.TouchInventory(ctx); err != nil {
+		t.Fatalf("TouchInventory: %v", err)
+	}
+	if err := src.InitHMAC(ctx); err != nil {
+		t.Fatalf("InitHMAC: %v", err)
+	}
+	for _, line := range sampleInventoryLines {
+		if err := src.AppendInventory(ctx, line); err != nil {
+			t.Fatalf("AppendInventory: %v", err)
+		}
+	}
+	srcText, err := src.ReadInventory(ctx)
+	if err != nil {
+		t.Fatalf("ReadInventory(src): %v", err)
+	}
+
+	// Migrate filesystem → sqlite.
+	sqlite := NewWithBackend(newSQLiteBackend(t), "")
+	if _, err := MigrateService(ctx, src, sqlite, MigrateOptions{}); err != nil {
+		t.Fatalf("MigrateService fs→sqlite: %v", err)
+	}
+	// Integrity must verify on the structured destination.
+	if err := sqlite.InitHMAC(ctx); err != nil {
+		t.Fatalf("sqlite integrity after migrate: %v", err)
+	}
+	if got, _ := sqlite.ReadInventory(ctx); !bytes.Equal(got, srcText) {
+		t.Errorf("sqlite inventory = %q, want %q", got, srcText)
+	}
+	if s, err := sqlite.LatestSerialForSubject(ctx, "node1"); err != nil || s != "0003" {
+		t.Errorf("sqlite LatestSerialForSubject(node1) = %q, %v; want 0003, nil", s, err)
+	}
+
+	// Migrate sqlite → a second filesystem CA.
+	dst := New(t.TempDir())
+	if _, err := MigrateService(ctx, sqlite, dst, MigrateOptions{}); err != nil {
+		t.Fatalf("MigrateService sqlite→fs: %v", err)
+	}
+	if err := dst.InitHMAC(ctx); err != nil {
+		t.Fatalf("fs integrity after round-trip: %v", err)
+	}
+	if got, _ := dst.ReadInventory(ctx); !bytes.Equal(got, srcText) {
+		t.Errorf("round-tripped inventory = %q, want %q", got, srcText)
+	}
+}

--- a/internal/storage/sql_mysql_integration_test.go
+++ b/internal/storage/sql_mysql_integration_test.go
@@ -45,9 +45,9 @@ func mysqlDSNFromEnv(t *testing.T) string {
 }
 
 // newMySQLBackend connects to a real MySQL/MariaDB, migrates the schema, and
-// truncates the blobs table so each test starts clean. Tests in a package run
-// sequentially, so a shared table with a per-test truncate is sufficient
-// isolation.
+// truncates the blobs and inventory tables so each test starts clean. Tests in
+// a package run sequentially, so shared tables with a per-test truncate are
+// sufficient isolation.
 func newMySQLBackend(t *testing.T) *SQLBackend {
 	t.Helper()
 	b, err := NewSQLBackend(SQLConfig{Dialect: SQLMySQL, DSN: mysqlDSNFromEnv(t)})
@@ -57,8 +57,10 @@ func newMySQLBackend(t *testing.T) *SQLBackend {
 	if err := b.EnsureReady(context.Background()); err != nil {
 		t.Fatalf("EnsureReady: %v", err)
 	}
-	if _, err := b.db.ExecContext(context.Background(), "DELETE FROM puppet_ca_blobs"); err != nil {
-		t.Fatalf("truncate: %v", err)
+	for _, table := range []string{"puppet_ca_blobs", "puppet_ca_inventory"} {
+		if _, err := b.db.ExecContext(context.Background(), "DELETE FROM "+table); err != nil {
+			t.Fatalf("truncate %s: %v", table, err)
+		}
 	}
 	t.Cleanup(func() { _ = b.Close() })
 	return b
@@ -97,15 +99,17 @@ func TestMySQLPutGetDelete(t *testing.T) {
 }
 
 func TestMySQLLargeBlob(t *testing.T) {
-	// Exceed MySQL's 64 KiB BLOB cap to prove the data column was widened to
-	// LONGBLOB by the migration.
+	// Exceed MySQL's 64 KiB BLOB cap to prove the puppet_ca_blobs.data column was
+	// widened to LONGBLOB by the migration. Use KeyCRL: it is a realistic large
+	// blob, whereas KeyInventory is now backed by the structured inventory table
+	// (which parses writes as inventory.txt lines, not opaque bytes).
 	b := newMySQLBackend(t)
 	ctx := context.Background()
 	big := bytes.Repeat([]byte("x"), 200*1024)
-	if err := b.Put(ctx, KeyInventory, big, BlobPrivate); err != nil {
+	if err := b.Put(ctx, KeyCRL, big, BlobPrivate); err != nil {
 		t.Fatalf("Put large blob: %v", err)
 	}
-	got, err := b.Get(ctx, KeyInventory)
+	got, err := b.Get(ctx, KeyCRL)
 	if err != nil {
 		t.Fatalf("Get large blob: %v", err)
 	}
@@ -156,6 +160,9 @@ func TestMySQLModTime(t *testing.T) {
 }
 
 func TestMySQLAppendLineConcurrent(t *testing.T) {
+	// Two backends over the same database simulate two replicas appending
+	// inventory entries; each AppendLine inserts a row and none may be dropped.
+	// Inventory is structured, so lines must be valid entries.
 	dsn := mysqlDSNFromEnv(t)
 	a := newMySQLBackend(t)
 	b, err := NewSQLBackend(SQLConfig{Dialect: SQLMySQL, DSN: dsn})
@@ -177,7 +184,7 @@ func TestMySQLAppendLineConcurrent(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for i := 0; i < perWriter; i++ {
-				line := fmt.Sprintf("w%d-i%d\n", w, i)
+				line := fmt.Sprintf("%04d 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /w%d-i%d\n", w*perWriter+i, w, i)
 				if err := backend.AppendLine(context.Background(), KeyInventory, []byte(line), BlobPrivate); err != nil {
 					t.Errorf("AppendLine: %v", err)
 					return

--- a/internal/storage/sql_mysql_integration_test.go
+++ b/internal/storage/sql_mysql_integration_test.go
@@ -296,14 +296,19 @@ func TestMySQLEndToEndViaStorageService(t *testing.T) {
 	if err := svc.InitHMAC(ctx); err != nil {
 		t.Fatalf("InitHMAC: %v", err)
 	}
-	if err := svc.AppendInventory(ctx, "line 1"); err != nil {
+	line1 := "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1"
+	line2 := "0002 2024-01-02T00:00:00UTC 2029-01-02T00:00:00UTC /node2"
+	if err := svc.AppendInventory(ctx, line1); err != nil {
 		t.Fatalf("AppendInventory: %v", err)
 	}
-	if err := svc.AppendInventory(ctx, "line 2"); err != nil {
+	if err := svc.AppendInventory(ctx, line2); err != nil {
 		t.Fatalf("AppendInventory: %v", err)
 	}
-	if inv, _ := svc.ReadInventory(ctx); string(inv) != "line 1\nline 2\n" {
-		t.Errorf("ReadInventory = %q, want 'line 1\\nline 2\\n'", inv)
+	if inv, _ := svc.ReadInventory(ctx); string(inv) != line1+"\n"+line2+"\n" {
+		t.Errorf("ReadInventory = %q, want %q", inv, line1+"\n"+line2+"\n")
+	}
+	if serial, err := svc.LatestSerialForSubject(ctx, "node2"); err != nil || serial != "0002" {
+		t.Errorf("LatestSerialForSubject(node2) = %q, %v; want 0002, nil", serial, err)
 	}
 	if err := svc.SaveCSR(ctx, "node1", []byte("csr-pem")); err != nil {
 		t.Fatalf("SaveCSR: %v", err)

--- a/internal/storage/sql_postgres_integration_test.go
+++ b/internal/storage/sql_postgres_integration_test.go
@@ -279,14 +279,19 @@ func TestPostgresEndToEndViaStorageService(t *testing.T) {
 	if err := svc.InitHMAC(ctx); err != nil {
 		t.Fatalf("InitHMAC: %v", err)
 	}
-	if err := svc.AppendInventory(ctx, "line 1"); err != nil {
+	line1 := "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1"
+	line2 := "0002 2024-01-02T00:00:00UTC 2029-01-02T00:00:00UTC /node2"
+	if err := svc.AppendInventory(ctx, line1); err != nil {
 		t.Fatalf("AppendInventory: %v", err)
 	}
-	if err := svc.AppendInventory(ctx, "line 2"); err != nil {
+	if err := svc.AppendInventory(ctx, line2); err != nil {
 		t.Fatalf("AppendInventory: %v", err)
 	}
-	if inv, _ := svc.ReadInventory(ctx); string(inv) != "line 1\nline 2\n" {
-		t.Errorf("ReadInventory = %q, want 'line 1\\nline 2\\n'", inv)
+	if inv, _ := svc.ReadInventory(ctx); string(inv) != line1+"\n"+line2+"\n" {
+		t.Errorf("ReadInventory = %q, want %q", inv, line1+"\n"+line2+"\n")
+	}
+	if serial, err := svc.LatestSerialForSubject(ctx, "node2"); err != nil || serial != "0002" {
+		t.Errorf("LatestSerialForSubject(node2) = %q, %v; want 0002, nil", serial, err)
 	}
 	if err := svc.SaveCSR(ctx, "node1", []byte("csr-pem")); err != nil {
 		t.Fatalf("SaveCSR: %v", err)

--- a/internal/storage/sql_postgres_integration_test.go
+++ b/internal/storage/sql_postgres_integration_test.go
@@ -44,9 +44,9 @@ func postgresDSNFromEnv(t *testing.T) string {
 }
 
 // newPostgresBackend connects to a real PostgreSQL, migrates the schema, and
-// truncates the blobs table so each test starts clean. Tests in a package run
-// sequentially, so a shared table with a per-test truncate is sufficient
-// isolation. Registers a cleanup that closes the backend.
+// truncates the blobs and inventory tables so each test starts clean. Tests in
+// a package run sequentially, so shared tables with a per-test truncate are
+// sufficient isolation. Registers a cleanup that closes the backend.
 func newPostgresBackend(t *testing.T) *SQLBackend {
 	t.Helper()
 	b, err := NewSQLBackend(SQLConfig{Dialect: SQLPostgres, DSN: postgresDSNFromEnv(t)})
@@ -56,8 +56,10 @@ func newPostgresBackend(t *testing.T) *SQLBackend {
 	if err := b.EnsureReady(context.Background()); err != nil {
 		t.Fatalf("EnsureReady: %v", err)
 	}
-	if _, err := b.db.ExecContext(context.Background(), "DELETE FROM puppet_ca_blobs"); err != nil {
-		t.Fatalf("truncate: %v", err)
+	for _, table := range []string{"puppet_ca_blobs", "puppet_ca_inventory"} {
+		if _, err := b.db.ExecContext(context.Background(), "DELETE FROM "+table); err != nil {
+			t.Fatalf("truncate %s: %v", table, err)
+		}
 	}
 	t.Cleanup(func() { _ = b.Close() })
 	return b
@@ -137,8 +139,9 @@ func TestPostgresModTime(t *testing.T) {
 }
 
 func TestPostgresAppendLineConcurrent(t *testing.T) {
-	// Two backends over the same database simulate two replicas; the row-locking
-	// (SELECT ... FOR UPDATE) transaction must not drop any line.
+	// Two backends over the same database simulate two replicas appending
+	// inventory entries; each AppendLine inserts a row and none may be dropped.
+	// Inventory is structured, so lines must be valid entries.
 	dsn := postgresDSNFromEnv(t)
 	a := newPostgresBackend(t)
 	b, err := NewSQLBackend(SQLConfig{Dialect: SQLPostgres, DSN: dsn})
@@ -160,7 +163,7 @@ func TestPostgresAppendLineConcurrent(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for i := 0; i < perWriter; i++ {
-				line := fmt.Sprintf("w%d-i%d\n", w, i)
+				line := fmt.Sprintf("%04d 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /w%d-i%d\n", w*perWriter+i, w, i)
 				if err := backend.AppendLine(context.Background(), KeyInventory, []byte(line), BlobPrivate); err != nil {
 					t.Errorf("AppendLine: %v", err)
 					return

--- a/internal/storage/sql_test.go
+++ b/internal/storage/sql_test.go
@@ -159,7 +159,8 @@ func TestSQLiteModTime(t *testing.T) {
 
 func TestSQLiteAppendLineConcurrent(t *testing.T) {
 	// Two backends over the same database file simulate two replicas appending
-	// concurrently; the row-locking transaction must not drop any line.
+	// inventory entries concurrently; each AppendLine inserts a row and no entry
+	// may be dropped. Inventory is structured, so lines must be valid entries.
 	dsn := "file:" + filepath.Join(t.TempDir(), "ca.db")
 	a, err := NewSQLBackend(SQLConfig{Dialect: SQLitePure, DSN: dsn})
 	if err != nil {
@@ -188,7 +189,7 @@ func TestSQLiteAppendLineConcurrent(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for i := 0; i < perWriter; i++ {
-				line := fmt.Sprintf("w%d-i%d\n", w, i)
+				line := fmt.Sprintf("%04d 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /w%d-i%d\n", w*perWriter+i, w, i)
 				if err := backend.AppendLine(context.Background(), KeyInventory, []byte(line), BlobPrivate); err != nil {
 					t.Errorf("AppendLine: %v", err)
 					return
@@ -278,18 +279,23 @@ func TestSQLiteEndToEndViaStorageService(t *testing.T) {
 	if err := svc.InitHMAC(ctx); err != nil {
 		t.Fatalf("InitHMAC: %v", err)
 	}
-	if err := svc.AppendInventory(ctx, "line 1"); err != nil {
+	line1 := "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1"
+	line2 := "0002 2024-01-02T00:00:00UTC 2029-01-02T00:00:00UTC /node2"
+	if err := svc.AppendInventory(ctx, line1); err != nil {
 		t.Fatalf("AppendInventory: %v", err)
 	}
-	if err := svc.AppendInventory(ctx, "line 2"); err != nil {
+	if err := svc.AppendInventory(ctx, line2); err != nil {
 		t.Fatalf("AppendInventory: %v", err)
 	}
 	inv, err := svc.ReadInventory(ctx)
 	if err != nil {
 		t.Fatalf("ReadInventory: %v", err)
 	}
-	if string(inv) != "line 1\nline 2\n" {
-		t.Errorf("ReadInventory = %q, want 'line 1\\nline 2\\n'", inv)
+	if string(inv) != line1+"\n"+line2+"\n" {
+		t.Errorf("ReadInventory = %q, want %q", inv, line1+"\n"+line2+"\n")
+	}
+	if serial, err := svc.LatestSerialForSubject(ctx, "node2"); err != nil || serial != "0002" {
+		t.Errorf("LatestSerialForSubject(node2) = %q, %v; want 0002, nil", serial, err)
 	}
 
 	if err := svc.SaveCSR(ctx, "node1", []byte("csr-pem")); err != nil {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -169,9 +169,27 @@ func (s *StorageService) InitHMAC(ctx context.Context) error {
 	return s.VerifyInventoryHMAC(ctx, key)
 }
 
+// AppendInventory adds entry (a single inventory.txt line, without a trailing
+// newline) to the inventory. On backends that implement InventoryStore the
+// entry is stored as a structured record and the integrity head is advanced by
+// a hash chain in O(1); otherwise the line is appended to the KeyInventory blob
+// and the whole-blob HMAC is recomputed.
 func (s *StorageService) AppendInventory(ctx context.Context, entry string) error {
 	s.inventoryMu.Lock()
 	defer s.inventoryMu.Unlock()
+
+	if store, ok := s.backend.(InventoryStore); ok {
+		parsed, ok := parseInventoryEntry(entry)
+		if !ok {
+			return fmt.Errorf("malformed inventory entry %q", entry)
+		}
+		var newHead func(prev []byte) []byte
+		if s.hmacKey != nil {
+			key := s.hmacKey
+			newHead = func(prev []byte) []byte { return chainInventoryMAC(key, prev, entry) }
+		}
+		return store.AppendEntry(ctx, parsed, newHead)
+	}
 
 	if err := s.backend.AppendLine(ctx, KeyInventory, []byte(entry+"\n"), BlobPrivate); err != nil {
 		return err
@@ -183,6 +201,24 @@ func (s *StorageService) AppendInventory(ctx context.Context, entry string) erro
 		}
 	}
 	return nil
+}
+
+// LatestSerialForSubject returns the most recently issued serial for subject.
+// On InventoryStore backends this is an indexed lookup; otherwise it scans the
+// inventory blob (verifying its HMAC first, via ReadInventory). Wraps
+// os.ErrNotExist when the subject has no entry.
+func (s *StorageService) LatestSerialForSubject(ctx context.Context, subject string) (string, error) {
+	if store, ok := s.backend.(InventoryStore); ok {
+		s.inventoryMu.RLock()
+		defer s.inventoryMu.RUnlock()
+		return store.LatestSerialForSubject(ctx, subject)
+	}
+
+	data, err := s.ReadInventory(ctx)
+	if err != nil {
+		return "", err
+	}
+	return latestSerialFromBlob(data, subject)
 }
 
 func (s *StorageService) ReadInventory(ctx context.Context) ([]byte, error) {
@@ -513,9 +549,25 @@ func (s *StorageService) EnsureHMACKey(ctx context.Context) ([]byte, error) {
 	return key, nil
 }
 
-// computeInventoryHMAC computes HMAC-SHA256 of the inventory contents.
+// computeInventoryHMAC computes the integrity value for the current inventory.
+// On InventoryStore backends it folds a hash chain over the entries in issuance
+// order (the head MAC); otherwise it is HMAC-SHA256 of the whole blob. An empty
+// inventory yields an empty head in the structured case, mirroring how a
+// missing blob hashes the same as an empty one.
 // Caller must hold inventoryMu.
 func (s *StorageService) computeInventoryHMAC(ctx context.Context, hmacKey []byte) ([]byte, error) {
+	if store, ok := s.backend.(InventoryStore); ok {
+		entries, err := store.Entries(ctx)
+		if err != nil {
+			return nil, err
+		}
+		var head []byte
+		for _, e := range entries {
+			head = chainInventoryMAC(hmacKey, head, canonicalInventoryLine(e))
+		}
+		return head, nil
+	}
+
 	data, err := s.readInventoryForHMAC(ctx)
 	if err != nil {
 		return nil, err
@@ -523,6 +575,69 @@ func (s *StorageService) computeInventoryHMAC(ctx context.Context, hmacKey []byt
 	mac := hmac.New(sha256.New, hmacKey)
 	mac.Write(data)
 	return mac.Sum(nil), nil
+}
+
+// chainInventoryMAC advances the inventory hash chain by one entry:
+//
+//	mac_i = HMAC-SHA256(key, mac_{i-1} ‖ line_i)
+//
+// where line_i is the canonical inventory.txt line (no trailing newline) and
+// prev is the previous head (nil/empty for the first entry).
+func chainInventoryMAC(key, prev []byte, line string) []byte {
+	mac := hmac.New(sha256.New, key)
+	mac.Write(prev)
+	mac.Write([]byte(line))
+	return mac.Sum(nil)
+}
+
+// canonicalInventoryLine renders e to its inventory.txt line (without the
+// trailing newline). It is the single source of truth for the on-disk blob
+// format and the input to the integrity hash chain, so the two cannot drift.
+func canonicalInventoryLine(e InventoryEntry) string {
+	return fmt.Sprintf("%s %s %s /%s", e.Serial, e.NotBefore, e.NotAfter, e.Subject)
+}
+
+// parseInventoryEntry parses a single inventory.txt line into an InventoryEntry.
+// The format is "SERIAL NOT_BEFORE NOT_AFTER /SUBJECT"; the leading "/" on the
+// subject is stripped. Returns ok=false for blank or malformed lines.
+func parseInventoryEntry(line string) (InventoryEntry, bool) {
+	fields := strings.Fields(line)
+	if len(fields) < 4 {
+		return InventoryEntry{}, false
+	}
+	return InventoryEntry{
+		Serial:    fields[0],
+		NotBefore: fields[1],
+		NotAfter:  fields[2],
+		Subject:   strings.TrimPrefix(fields[3], "/"),
+	}, true
+}
+
+// latestSerialFromBlob scans a rendered inventory blob and returns the serial
+// of the last entry matching subject. Wraps os.ErrNotExist when none match.
+func latestSerialFromBlob(data []byte, subject string) (string, error) {
+	last := ""
+	badLines := 0
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		e, ok := parseInventoryEntry(line)
+		if !ok {
+			badLines++
+			continue
+		}
+		if e.Subject == subject {
+			last = e.Serial
+		}
+	}
+	if badLines > 0 {
+		slog.Warn("Inventory contains unparseable lines", "count", badLines)
+	}
+	if last == "" {
+		return "", fmt.Errorf("subject %s not found in inventory: %w", subject, fs.ErrNotExist)
+	}
+	return last, nil
 }
 
 // UpdateInventoryHMAC recomputes and writes the HMAC for the current inventory.

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -648,6 +648,28 @@ func (s *StorageService) UpdateInventoryHMAC(ctx context.Context, hmacKey []byte
 	return s.updateInventoryHMACLocked(ctx, hmacKey)
 }
 
+// RebuildInventoryHMAC recomputes the inventory integrity head from the current
+// inventory contents using the stored HMAC key, and writes it. It is meant to
+// run after a migration: the destination's integrity scheme (whole-blob HMAC
+// vs. the structured backends' hash chain) may differ from the source's, so the
+// copied inventory_hmac value is not meaningful for the destination and must be
+// recomputed. It is a no-op when no HMAC key is present (a CA that never
+// initialised integrity), leaving the destination untouched.
+func (s *StorageService) RebuildInventoryHMAC(ctx context.Context) error {
+	hasKey, err := s.backend.Exists(ctx, KeyHMACKey)
+	if err != nil {
+		return fmt.Errorf("checking inventory HMAC key: %w", err)
+	}
+	if !hasKey {
+		return nil
+	}
+	key, err := s.EnsureHMACKey(ctx)
+	if err != nil {
+		return err
+	}
+	return s.UpdateInventoryHMAC(ctx, key)
+}
+
 func (s *StorageService) updateInventoryHMACLocked(ctx context.Context, hmacKey []byte) error {
 	sum, err := s.computeInventoryHMAC(ctx, hmacKey)
 	if err != nil {


### PR DESCRIPTION
## What

Adds an optional `InventoryStore` backend capability so backends that can do better store the certificate inventory as **structured records** instead of one append-only blob, and implements it for the SQL backends (sqlite/postgres/mysql). Filesystem, etcd and redis are unchanged.

Design doc: [docs/inventory-store.md](docs/inventory-store.md).

## Why

The inventory was a single growing blob whose integrity HMAC was recomputed over the whole thing on every append (O(n) per append) and whose subject lookups were full scans; on SQL backends it lived as one ever-growing row. This moves it to an indexed table with O(1) appends.

## How

- **`InventoryStore` interface + `InventoryEntry`** ([backend.go](internal/storage/backend.go)), probed by `StorageService` via a type assertion with a blob fallback — the same pattern as `Locker`. Backends that don't implement it are unchanged.
- **Integrity = hash chain** reusing the existing `inventory_hmac` row: `mac_i = HMAC(key, mac_{i-1} ‖ line_i)`, advanced O(1) inside the append transaction (which locks the presence-marker row so replicas can't fork the chain) and replayed at startup to verify. Crypto stays in `StorageService` via a `newHead` closure — no key handling leaks into backends.
- **SQL backend** gains a `puppet_ca_inventory` table (indexed on subject, with a unique index on serial since serials never repeat) plus a render/parse shim on the `inventory` logical key, so `Migrate` and the OCSP index build stay backend-agnostic. The `inventory` blob row is kept as an empty presence marker.
- **Migration** recomputes the destination's integrity head (`RebuildInventoryHMAC`), since a whole-blob HMAC and a hash-chain head aren't interchangeable across backend types.

Commits are split per phase (interface/routing → SQL backend → migration rebuild → tests → docs), followed by SQL integration-test fixes and the serial unique index.

## Testing

- Unit/contract tests: latest-serial lookup, byte-identical render, chain tamper detection (modify/insert/delete), serial-uniqueness rejection, and a filesystem→sqlite→filesystem migration round-trip verifying integrity at each hop.
- `go test ./...` green. The PostgreSQL and MySQL integration suites were run against live PostgreSQL 16 and MySQL 8 (Docker) — both pass, including the cross-replica concurrent-append test.
- **Manual end-to-end on sqlite** via the running server: bootstrap → autosign a CSR (→ one inventory row + advanced chain head) → revoke (indexed `LatestSerialForSubject`) → restart (chain verifies clean) → tamper a row + restart (CA refuses to start with an integrity error).

## Follow-up (out of scope)

The offline `puppet-ca-ctl` commands `setup`/`generate`/`revoke` hardcode the filesystem backend (`storage.New`) and ignore `storage_backend`; only `migrate` is wired to `NewServiceFromSpec`. Offline sqlite administration isn't supported through them today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)