### PR TITLE
feat(crl): auto-refresh CRL so a low-churn CA never serves an expired one

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A drop-in replacement for Puppet Server's built-in CA, written in Go. It impleme
 - **Random serial numbers:** every issued leaf certificate gets a cryptographically random 128-bit serial (CA/Browser Forum guidance)
 - **CRL Distribution Points:** optionally embed a CRL URL in every issued certificate (`--crl-url`) so verifiers can automatically fetch the CRL
 - **Configurable CRL validity:** control how long each published CRL is valid (`crl_validity_days`)
+- **Automatic CRL refresh:** a background job re-signs the CRL before its validity lapses, so a low-churn CA never serves an expired CRL; safe across replicas (serialised on the shared CRL lock) and tunable or disablable. Operators can also force a refresh on demand via `puppet-ca-ctl reissue-crl`
 - **OCSP responder:** built-in RFC 6960 OCSP responder; AIA extension embedded in issued certs when `--ocsp-url` is set; in-memory cache with nonce bypass
 - **Health probes:** `/healthz/live`, `/healthz/ready`, and `/healthz/startup` endpoints for Kubernetes-style liveness/readiness checks
 - **Graceful shutdown:** `SIGTERM`/`SIGINT` drains in-flight requests with a configurable window (25s default) before exiting; deferred storage and signer cleanup always runs
@@ -140,6 +141,11 @@ ca_validity_days: 0   # 0 = built-in default (~5 years); positive integer overri
 leaf_validity_days: 0 # 0 = built-in default (~5 years); positive integer overrides
 crl_validity_days: 0  # 0 = built-in default (30 days); positive integer overrides
 csr_rate_limit: 60    # max CSR submissions per IP per minute; 0 = disable rate limiting
+# Background CRL refresh keeps the CRL's NextUpdate from lapsing on a low-churn CA.
+# Safe to run on every replica (serialised on the shared CRL lock).
+disable_crl_refresh: false     # true = never auto-refresh the CRL
+crl_refresh_interval_sec: 0    # how often to check; 0 = built-in default (1h)
+crl_refresh_before_sec: 0      # re-sign when remaining validity < this; 0 = crl_validity/3
 # CA key encryption at rest.
 encrypt_ca_key: false           # encrypt the CA private key (AES-256-GCM + Argon2id)
 ca_key_passphrase_file: ""      # path to passphrase file; auto-generated if omitted
@@ -195,6 +201,9 @@ The CA key passphrase can also be provided via `PUPPET_CA_KEY_PASSPHRASE` (env v
 | `ca_validity_days` | `PUPPET_CA_CA_VALIDITY_DAYS` |
 | `leaf_validity_days` | `PUPPET_CA_LEAF_VALIDITY_DAYS` |
 | `crl_validity_days` | `PUPPET_CA_CRL_VALIDITY_DAYS` |
+| `disable_crl_refresh` | `PUPPET_CA_DISABLE_CRL_REFRESH` |
+| `crl_refresh_interval_sec` | `PUPPET_CA_CRL_REFRESH_INTERVAL_SEC` |
+| `crl_refresh_before_sec` | `PUPPET_CA_CRL_REFRESH_BEFORE_SEC` |
 | `shutdown_timeout_sec` | `PUPPET_CA_SHUTDOWN_TIMEOUT_SEC` |
 | `etcd_username` | `PUPPET_CA_ETCD_USERNAME` |
 | `etcd_password` | `PUPPET_CA_ETCD_PASSWORD` |
@@ -384,6 +393,7 @@ Response:
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/certificate_revocation_list/ca` | Download the current CRL PEM |
+| `PUT` | `/certificate_revocation_list/ca` | Re-sign the CRL with a fresh validity window (preserves all revocations); admin-only. Returns the new CRL PEM |
 
 ### Expirations
 
@@ -433,7 +443,7 @@ When mTLS is enabled (both `--tls-cert` and `--tls-key` set), each endpoint requ
 | **Public** | None | `GET /healthz/*`, `GET /certificate/{subject}`, `GET /certificate_revocation_list/ca`, `PUT /certificate_request/{subject}`, `GET /expirations`, `POST /ocsp`, `GET /ocsp/{request}` |
 | **Any client** | Any CA-signed cert | `GET /certificate_status/{subject}` (public with `--allow-public-status`), `POST /certificate_renewal` |
 | **Self or admin** | Cert CN matches path subject, OR cert is admin | `GET /certificate_request/{subject}` |
-| **Admin** | Cert is admin (see below) | `PUT /certificate_status/{subject}`, `DELETE /certificate_status/{subject}`, `DELETE /certificate_request/{subject}`, `GET /certificate_statuses/*`, `POST /sign`, `POST /sign/all`, `POST /generate/{subject}`, `PUT /clean` |
+| **Admin** | Cert is admin (see below) | `PUT /certificate_status/{subject}`, `DELETE /certificate_status/{subject}`, `DELETE /certificate_request/{subject}`, `GET /certificate_statuses/*`, `POST /sign`, `POST /sign/all`, `POST /generate/{subject}`, `PUT /clean`, `PUT /certificate_revocation_list/ca` |
 
 In plain HTTP mode (no TLS), all endpoints are accessible without authentication.
 
@@ -618,6 +628,9 @@ puppet-ca-ctl revoke --certname agent.example.com
 
 # Revoke + delete cert and CSR
 puppet-ca-ctl clean --certname agent.example.com
+
+# Re-sign the CRL with a fresh validity window (preserves all revocations)
+puppet-ca-ctl reissue-crl
 
 # Generate a server-side key+cert pair (key saved to ./agent.example.com_key.pem)
 puppet-ca-ctl generate --certname agent.example.com

--- a/cmd/puppet-ca-ctl/main.go
+++ b/cmd/puppet-ca-ctl/main.go
@@ -316,6 +316,32 @@ func newRevokeCmd() *cobra.Command {
 	return cmd
 }
 
+func newReissueCRLCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "reissue-crl",
+		Short:        "Re-sign the CRL with a fresh validity window (preserves all revocations)",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := newClient()
+			if err != nil {
+				return err
+			}
+
+			path := "/puppet-ca/v1/certificate_revocation_list/ca"
+			code, respBody, err := c.put(path, nil)
+			if err != nil {
+				return err
+			}
+			if err := checkHTTP(code, respBody, "PUT", path); err != nil {
+				return err
+			}
+			fmt.Println("Reissued CRL")
+			return nil
+		},
+	}
+	return cmd
+}
+
 func newCleanCmd() *cobra.Command {
 	var certname string
 	cmd := &cobra.Command{
@@ -541,6 +567,7 @@ Global flags must be specified before the subcommand.`,
 		newListCmd(),
 		newSignCmd(),
 		newRevokeCmd(),
+		newReissueCRLCmd(),
 		newCleanCmd(),
 		newGenerateCmd(),
 		newSetupCmd(),

--- a/cmd/puppet-ca/config.go
+++ b/cmd/puppet-ca/config.go
@@ -83,6 +83,13 @@ type serverConfig struct {
 	CRLValidityDays  int `yaml:"crl_validity_days"`  // 0 = built-in default (30 days)
 	CSRRateLimit     int `yaml:"csr_rate_limit"`     // max CSR submissions per IP per minute; 0 = use built-in default (60)
 
+	// Background CRL refresh keeps the CRL's NextUpdate from lapsing when no
+	// certificates are being revoked. Safe to run on every replica: the work is
+	// serialised on the shared CRL lock, so only one replica re-signs per cycle.
+	DisableCRLRefresh     bool `yaml:"disable_crl_refresh"`      // true = never auto-refresh the CRL
+	CRLRefreshIntervalSec int  `yaml:"crl_refresh_interval_sec"` // how often to check; 0 = built-in default (1h)
+	CRLRefreshBeforeSec   int  `yaml:"crl_refresh_before_sec"`   // re-sign when remaining validity < this; 0 = crl_validity/3
+
 	// CA key encryption at rest.
 	EncryptCAKey        bool   `yaml:"encrypt_ca_key"`         // encrypt the CA private key at rest (AES-256-GCM + Argon2id)
 	CAKeyPassphraseFile string `yaml:"ca_key_passphrase_file"` // path to file containing the CA key passphrase
@@ -133,6 +140,23 @@ func (c *serverConfig) shutdownDrain() time.Duration {
 		return time.Duration(c.ShutdownTimeoutSec) * time.Second
 	}
 	return defaultShutdownDrain
+}
+
+// defaultCRLRefreshInterval is how often the background job checks whether the
+// CRL needs re-signing when the operator has not configured an interval. One
+// hour is frequent enough to act well within the default refresh window (a
+// third of the 30-day CRL validity) while imposing negligible load.
+const defaultCRLRefreshInterval = time.Hour
+
+// crlRefreshInterval resolves how often the background job checks the CRL,
+// falling back to defaultCRLRefreshInterval when unset. The refresh window
+// itself (how close to expiry triggers a re-sign) is resolved by the CA from
+// CRLRefreshBeforeSec, defaulting to a third of the CRL validity.
+func (c *serverConfig) crlRefreshInterval() time.Duration {
+	if c.CRLRefreshIntervalSec > 0 {
+		return time.Duration(c.CRLRefreshIntervalSec) * time.Second
+	}
+	return defaultCRLRefreshInterval
 }
 
 // applyServerEnv overlays PUPPET_CA_* environment variables onto cfg.
@@ -249,6 +273,21 @@ func applyServerEnv(cfg *serverConfig) {
 	if v := os.Getenv("PUPPET_CA_CRL_VALIDITY_DAYS"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			cfg.CRLValidityDays = n
+		}
+	}
+	if v := os.Getenv("PUPPET_CA_DISABLE_CRL_REFRESH"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.DisableCRLRefresh = b
+		}
+	}
+	if v := os.Getenv("PUPPET_CA_CRL_REFRESH_INTERVAL_SEC"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.CRLRefreshIntervalSec = n
+		}
+	}
+	if v := os.Getenv("PUPPET_CA_CRL_REFRESH_BEFORE_SEC"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.CRLRefreshBeforeSec = n
 		}
 	}
 	if v := os.Getenv("PUPPET_CA_CSR_RATE_LIMIT"); v != "" {

--- a/cmd/puppet-ca/config_test.go
+++ b/cmd/puppet-ca/config_test.go
@@ -52,6 +52,9 @@ var serverEnvVars = []string{
 	"PUPPET_CA_CA_VALIDITY_DAYS",
 	"PUPPET_CA_LEAF_VALIDITY_DAYS",
 	"PUPPET_CA_SHUTDOWN_TIMEOUT_SEC",
+	"PUPPET_CA_DISABLE_CRL_REFRESH",
+	"PUPPET_CA_CRL_REFRESH_INTERVAL_SEC",
+	"PUPPET_CA_CRL_REFRESH_BEFORE_SEC",
 }
 
 // clearServerEnv unsets all PUPPET_CA_* vars and restores them after the test.
@@ -191,6 +194,45 @@ func TestShutdownDrainRejectsNonPositive(t *testing.T) {
 	}
 	if got := cfg.shutdownDrain(); got != defaultShutdownDrain {
 		t.Errorf("shutdownDrain() with 0 = %v; want default %v", got, defaultShutdownDrain)
+	}
+}
+
+// --- crlRefreshInterval ---
+
+func TestCRLRefreshIntervalDefault(t *testing.T) {
+	clearServerEnv(t)
+	cfg, err := loadServerConfig("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := cfg.crlRefreshInterval(); got != defaultCRLRefreshInterval {
+		t.Errorf("crlRefreshInterval() = %v; want default %v", got, defaultCRLRefreshInterval)
+	}
+}
+
+func TestCRLRefreshIntervalEnvOverride(t *testing.T) {
+	clearServerEnv(t)
+	t.Setenv("PUPPET_CA_CRL_REFRESH_INTERVAL_SEC", "900")
+
+	cfg, err := loadServerConfig("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := cfg.crlRefreshInterval(), 900*time.Second; got != want {
+		t.Errorf("crlRefreshInterval() = %v; want %v", got, want)
+	}
+}
+
+func TestCRLRefreshIntervalRejectsNonPositive(t *testing.T) {
+	clearServerEnv(t)
+	t.Setenv("PUPPET_CA_CRL_REFRESH_INTERVAL_SEC", "0")
+
+	cfg, err := loadServerConfig("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := cfg.crlRefreshInterval(); got != defaultCRLRefreshInterval {
+		t.Errorf("crlRefreshInterval() with 0 = %v; want default %v", got, defaultCRLRefreshInterval)
 	}
 }
 
@@ -489,6 +531,21 @@ func TestApplyServerEnvEachVar(t *testing.T) {
 			name: "LEAF_VALIDITY_DAYS", envKey: "PUPPET_CA_LEAF_VALIDITY_DAYS", envVal: "1825",
 			check: func(c *serverConfig) bool { return c.LeafValidityDays == 1825 },
 			desc:  "LeafValidityDays",
+		},
+		{
+			name: "DISABLE_CRL_REFRESH", envKey: "PUPPET_CA_DISABLE_CRL_REFRESH", envVal: "true",
+			check: func(c *serverConfig) bool { return c.DisableCRLRefresh },
+			desc:  "DisableCRLRefresh",
+		},
+		{
+			name: "CRL_REFRESH_INTERVAL_SEC", envKey: "PUPPET_CA_CRL_REFRESH_INTERVAL_SEC", envVal: "900",
+			check: func(c *serverConfig) bool { return c.CRLRefreshIntervalSec == 900 },
+			desc:  "CRLRefreshIntervalSec",
+		},
+		{
+			name: "CRL_REFRESH_BEFORE_SEC", envKey: "PUPPET_CA_CRL_REFRESH_BEFORE_SEC", envVal: "86400",
+			check: func(c *serverConfig) bool { return c.CRLRefreshBeforeSec == 86400 },
+			desc:  "CRLRefreshBeforeSec",
 		},
 	}
 

--- a/cmd/puppet-ca/crl_refresh.go
+++ b/cmd/puppet-ca/crl_refresh.go
@@ -1,0 +1,72 @@
+// Copyright (C) 2026 Chris Boot
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package main
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/tvaughan/puppet-ca/internal/ca"
+)
+
+// runCRLRefresher periodically re-signs the CRL before its validity lapses, so
+// a low-churn CA (one that simply hasn't revoked anything in a while) never
+// ends up serving an expired CRL. It runs in the frontend process, which signs
+// via the isolated signer over IPC.
+//
+// Replica safety: CA.RefreshCRLIfDue performs its expiry check and re-sign
+// together under the shared cluster CRL lock, so when this runs on multiple
+// replicas only the first to acquire the lock re-signs (pushing NextUpdate far
+// out); the others observe a fresh CRL and do nothing. No leader election is
+// required.
+//
+// It returns when ctx is cancelled (i.e. on shutdown).
+func runCRLRefresher(ctx context.Context, c *ca.CA, interval, refreshBefore time.Duration) {
+	slog.Info("Starting CRL refresh job", "interval", interval, "refresh_before", refreshBefore)
+
+	// Check immediately at startup so a CRL that already lapsed while every
+	// replica was down is refreshed without waiting a full interval.
+	refreshCRLOnce(ctx, c, refreshBefore)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Debug("CRL refresh job stopping")
+			return
+		case <-ticker.C:
+			refreshCRLOnce(ctx, c, refreshBefore)
+		}
+	}
+}
+
+// refreshCRLOnce runs a single refresh check, logging the outcome. Errors are
+// logged and swallowed so a transient storage/lock failure does not stop the
+// job; the next tick will retry.
+func refreshCRLOnce(ctx context.Context, c *ca.CA, refreshBefore time.Duration) {
+	reissued, err := c.RefreshCRLIfDue(ctx, refreshBefore)
+	switch {
+	case err != nil:
+		slog.Warn("CRL refresh check failed", "error", err)
+	case reissued:
+		slog.Info("CRL refreshed (validity window renewed)")
+	default:
+		slog.Debug("CRL refresh check: still current, no action")
+	}
+}

--- a/cmd/puppet-ca/crl_refresh_test.go
+++ b/cmd/puppet-ca/crl_refresh_test.go
@@ -1,0 +1,137 @@
+// Copyright (C) 2026 Chris Boot
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package main
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+	"time"
+
+	"github.com/tvaughan/puppet-ca/internal/ca"
+	"github.com/tvaughan/puppet-ca/internal/storage"
+	"github.com/tvaughan/puppet-ca/internal/testutil"
+)
+
+// newRefresherTestCA builds an initialised CA backed by a temp filesystem store,
+// seeded with a freshly generated test CA and CRL.
+func newRefresherTestCA(t *testing.T) (*ca.CA, *storage.StorageService) {
+	t.Helper()
+	keyPEM, crtPEM, crlPEM, err := testutil.GenerateTestCA()
+	if err != nil {
+		t.Fatalf("GenerateTestCA: %v", err)
+	}
+
+	store := storage.New(t.TempDir())
+	c := ca.New(store, ca.AutosignConfig{Mode: "off"}, "puppet.test")
+	ctx := context.Background()
+	if err := store.EnsureDirs(ctx); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+	if err := store.SaveCAKey(ctx, keyPEM); err != nil {
+		t.Fatalf("SaveCAKey: %v", err)
+	}
+	if err := store.SaveCACert(ctx, crtPEM); err != nil {
+		t.Fatalf("SaveCACert: %v", err)
+	}
+	if err := store.UpdateCRL(ctx, crlPEM); err != nil {
+		t.Fatalf("UpdateCRL: %v", err)
+	}
+	if err := store.WriteSerial(ctx, "0001"); err != nil {
+		t.Fatalf("WriteSerial: %v", err)
+	}
+	if err := store.TouchInventory(ctx); err != nil {
+		t.Fatalf("TouchInventory: %v", err)
+	}
+	if err := c.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	return c, store
+}
+
+func storedCRLNumber(t *testing.T, store *storage.StorageService) int64 {
+	t.Helper()
+	crlPEM, err := store.GetCRL(context.Background())
+	if err != nil {
+		t.Fatalf("GetCRL: %v", err)
+	}
+	block, _ := pem.Decode(crlPEM)
+	if block == nil {
+		t.Fatalf("CRL is not PEM")
+	}
+	crl, err := x509.ParseRevocationList(block.Bytes)
+	if err != nil {
+		t.Fatalf("ParseRevocationList: %v", err)
+	}
+	return crl.Number.Int64()
+}
+
+// refreshCRLOnce should re-sign when the refresh window exceeds the CRL's
+// remaining validity, and leave it alone otherwise.
+func TestRefreshCRLOnce(t *testing.T) {
+	c, store := newRefresherTestCA(t)
+	ctx := context.Background()
+
+	start := storedCRLNumber(t, store)
+
+	// Window far larger than remaining validity: must re-sign.
+	refreshCRLOnce(ctx, c, 3650*24*time.Hour)
+	afterDue := storedCRLNumber(t, store)
+	if afterDue != start+1 {
+		t.Fatalf("expected CRL number to increment from %d, got %d", start, afterDue)
+	}
+
+	// Tiny window against a freshly reissued CRL: must not re-sign.
+	refreshCRLOnce(ctx, c, time.Hour)
+	afterFresh := storedCRLNumber(t, store)
+	if afterFresh != afterDue {
+		t.Fatalf("expected CRL number to stay at %d, got %d", afterDue, afterFresh)
+	}
+}
+
+// runCRLRefresher must perform an immediate check at startup and then return
+// promptly once its context is cancelled.
+func TestRunCRLRefresherStartupAndShutdown(t *testing.T) {
+	c, store := newRefresherTestCA(t)
+	start := storedCRLNumber(t, store)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		// A large refresh window guarantees the startup check re-signs.
+		runCRLRefresher(ctx, c, time.Hour, 3650*24*time.Hour)
+		close(done)
+	}()
+
+	// The startup check should re-sign before we cancel; poll briefly.
+	deadline := time.After(2 * time.Second)
+	for storedCRLNumber(t, store) == start {
+		select {
+		case <-deadline:
+			t.Fatal("startup refresh did not run within 2s")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runCRLRefresher did not return after context cancellation")
+	}
+}

--- a/cmd/puppet-ca/main.go
+++ b/cmd/puppet-ca/main.go
@@ -590,6 +590,19 @@ func newRootCmd() *cobra.Command {
 				slog.Info("TLS enabled", "cert", cfg.TLSCert)
 			}
 
+			// Background CRL refresh: keeps the CRL's NextUpdate from lapsing on a
+			// low-churn CA. Safe on every replica (serialised on the shared CRL
+			// lock). Bound to ctx so it stops on shutdown.
+			if !cfg.DisableCRLRefresh {
+				refreshBefore := myCA.DefaultCRLRefreshBefore()
+				if cfg.CRLRefreshBeforeSec > 0 {
+					refreshBefore = time.Duration(cfg.CRLRefreshBeforeSec) * time.Second
+				}
+				go runCRLRefresher(ctx, myCA, cfg.crlRefreshInterval(), refreshBefore)
+			} else {
+				slog.Info("CRL auto-refresh disabled by configuration")
+			}
+
 			shutdownDone := make(chan struct{})
 			go func() {
 				<-ctx.Done()

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -90,6 +90,33 @@ var _ = Describe("API Workflow", func() {
 		os.RemoveAll(tmpDir)
 	})
 
+	Context("CRL reissue endpoint", func() {
+		parseCRL := func(pemBytes []byte) *x509.RevocationList {
+			block, _ := pem.Decode(pemBytes)
+			Expect(block).NotTo(BeNil())
+			crl, err := x509.ParseRevocationList(block.Bytes)
+			Expect(err).NotTo(HaveOccurred())
+			return crl
+		}
+
+		It("re-signs the CRL on PUT and returns the fresh CRL", func() {
+			getReq := httptest.NewRequest("GET", "/certificate_revocation_list/ca", nil)
+			getRR := httptest.NewRecorder()
+			mux.ServeHTTP(getRR, getReq)
+			Expect(getRR.Code).To(Equal(http.StatusOK))
+			before := parseCRL(getRR.Body.Bytes())
+
+			putReq := httptest.NewRequest("PUT", "/certificate_revocation_list/ca", nil)
+			putRR := httptest.NewRecorder()
+			mux.ServeHTTP(putRR, putReq)
+			Expect(putRR.Code).To(Equal(http.StatusOK))
+
+			after := parseCRL(putRR.Body.Bytes())
+			Expect(after.Number.Cmp(before.Number)).To(Equal(1))
+			Expect(after.NextUpdate).To(BeTemporally(">", time.Now()))
+		})
+	})
+
 	Context("Certificate Request", func() {
 		var (
 			subject string

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -613,6 +613,23 @@ var _ = Describe("Auth Middleware", func() {
 			mux.ServeHTTP(rr, req)
 			Expect(rr.Code).To(Equal(http.StatusForbidden))
 		})
+
+		It("returns 403 for PUT /certificate_revocation_list/ca (reissue) with no cert", func() {
+			req := httptest.NewRequest("PUT", "/certificate_revocation_list/ca", nil)
+			req.TLS = &tls.ConnectionState{}
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+			Expect(rr.Code).To(Equal(http.StatusForbidden))
+		})
+
+		It("returns 403 for PUT /certificate_revocation_list/ca (reissue) with a valid non-admin cert", func() {
+			clientCert := issueClientCert("regular-node", caCert, caKey)
+			req := httptest.NewRequest("PUT", "/certificate_revocation_list/ca", nil)
+			req = withClientCert(req, clientCert)
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+			Expect(rr.Code).To(Equal(http.StatusForbidden))
+		})
 	})
 
 	// --- Prefixed paths honour the same tier rules ---
@@ -1027,6 +1044,7 @@ var _ = Describe("lookupTier classification", func() {
 		Entry("public certificate fetch (prefixed)", "GET", "/puppet-ca/v1/certificate/node1", "node1", "public"),
 		Entry("public CSR submission", "PUT", "/certificate_request/node1", "node1", "public"),
 		Entry("public CRL fetch", "GET", "/certificate_revocation_list/ca", "", "public"),
+		Entry("CRL reissue is admin-only", "PUT", "/certificate_revocation_list/ca", "", "adminOnly"),
 		// certificate_status defaults to any-CA-signed-client when not public.
 		Entry("status read requires any client", "GET", "/certificate_status/node1", "node1", "anyClient"),
 		// Self-or-admin read of a pending CSR.

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -104,6 +104,7 @@ func (s *Server) Routes() http.Handler {
 		{"DELETE", "/certificate_request/{subject}", s.handleDeleteRequest},
 		{"GET", "/certificate/{subject}", s.handleGetCert},
 		{"GET", "/certificate_revocation_list/ca", s.handleGetCRL},
+		{"PUT", "/certificate_revocation_list/ca", s.handleReissueCRL},
 		{"POST", "/ocsp", s.handleOCSP},
 		{"GET", "/ocsp/{request}", s.handleOCSP},
 		{"GET", "/expirations", s.handleGetExpirations},
@@ -292,6 +293,29 @@ func (s *Server) handleGetCRL(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		}
+	}
+
+	crlPEM, err := s.CA.Storage.GetCRL(r.Context())
+	if err != nil {
+		http.Error(w, "CRL not found", http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", "text/plain")
+	w.Write(crlPEM)
+}
+
+// handleReissueCRL re-signs the CRL with a fresh validity window, preserving
+// all existing revocation entries. Admin-only (enforced by the auth middleware,
+// which defaults non-GET methods on this path to tierAdminOnly). This lets an
+// operator refresh a CRL whose NextUpdate has lapsed (or is about to) without
+// having to revoke a certificate.
+func (s *Server) handleReissueCRL(w http.ResponseWriter, r *http.Request) {
+	slog.Debug("PUT certificate_revocation_list/ca", "client", clientCN(r))
+
+	if err := s.CA.ReissueCRL(r.Context()); err != nil {
+		slog.Warn("CRL reissue failed", "error", err)
+		http.Error(w, "failed to reissue CRL", http.StatusInternalServerError)
+		return
 	}
 
 	crlPEM, err := s.CA.Storage.GetCRL(r.Context())

--- a/internal/ca/crl.go
+++ b/internal/ca/crl.go
@@ -1,0 +1,149 @@
+// Copyright (C) 2026 Chris Boot
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package ca
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
+)
+
+// signCRLLocked re-signs the CRL with the given revoked entries, bumping the
+// CRL number past prevNumber and stamping fresh ThisUpdate/NextUpdate. It
+// writes the result to storage and refreshes the in-memory cache. The cluster
+// CRL lock (lockNameCRL) and c.mu must both be held by the caller.
+func (c *CA) signCRLLocked(ctx context.Context, prevNumber *big.Int, revoked []x509.RevocationListEntry) error {
+	nextNum := big.NewInt(1)
+	if prevNumber != nil {
+		nextNum.Add(prevNumber, big.NewInt(1))
+	}
+
+	now := time.Now()
+	template := &x509.RevocationList{
+		Number:                    nextNum,
+		RevokedCertificateEntries: revoked,
+		ThisUpdate:                now,
+		NextUpdate:                now.Add(c.crlValidity()),
+	}
+
+	crlBytes, err := x509.CreateRevocationList(rand.Reader, template, c.CACert, c.CAKey)
+	if err != nil {
+		return fmt.Errorf("failed to sign CRL: %w", err)
+	}
+
+	newCRLPEM := pem.EncodeToMemory(&pem.Block{Type: "X509 CRL", Bytes: crlBytes})
+	if err := c.Storage.UpdateCRL(ctx, newCRLPEM); err != nil {
+		return fmt.Errorf("failed to write CRL: %w", err)
+	}
+
+	// Update the in-memory CRL cache so auth checks use the new CRL
+	// immediately without reading from storage.
+	parsedCRL, err := x509.ParseRevocationList(crlBytes)
+	if err != nil {
+		return fmt.Errorf("failed to parse new CRL for cache: %w", err)
+	}
+	c.cachedCRL = parsedCRL
+	return nil
+}
+
+// ReissueCRL re-signs the current CRL with a fresh validity window, preserving
+// every existing revocation entry. It exists so the CRL can be kept current
+// even when no certificates are being revoked: without periodic reissuance the
+// CRL's NextUpdate eventually lapses and clients reject it as expired.
+//
+// It serialises on the cluster-wide CRL lock so it is safe to call from any
+// replica (and concurrently with Revoke) against shared storage; the last
+// writer under the lock wins and bumps the CRL number monotonically.
+func (c *CA) ReissueCRL(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, lockTimeout)
+	defer cancel()
+	return c.Storage.WithLock(ctx, lockNameCRL, func() error {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return c.reissueCRLLocked(ctx)
+	})
+}
+
+// reissueCRLLocked reads the stored CRL and re-signs it unchanged but for a
+// bumped number and a fresh validity window. The cluster CRL lock and c.mu
+// must both be held by the caller.
+func (c *CA) reissueCRLLocked(ctx context.Context) error {
+	crl, err := c.readStoredCRL(ctx)
+	if err != nil {
+		return err
+	}
+	return c.signCRLLocked(ctx, crl.Number, crl.RevokedCertificateEntries)
+}
+
+// readStoredCRL loads and parses the CRL currently in storage.
+func (c *CA) readStoredCRL(ctx context.Context) (*x509.RevocationList, error) {
+	crlPEM, err := c.Storage.GetCRL(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load CRL: %w", err)
+	}
+	block, _ := pem.Decode(crlPEM)
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode CRL PEM")
+	}
+	crl, err := x509.ParseRevocationList(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse CRL: %w", err)
+	}
+	return crl, nil
+}
+
+// RefreshCRLIfDue re-signs the CRL only when its remaining validity has dropped
+// below refreshBefore, and reports whether it re-signed. The check and the
+// re-sign happen together under the cluster CRL lock, so when several replicas
+// run this concurrently only the first re-signs (pushing NextUpdate far out)
+// and the rest observe a fresh CRL and return (false, nil). This makes the
+// background refresh job safe to run on any number of replicas sharing storage.
+func (c *CA) RefreshCRLIfDue(ctx context.Context, refreshBefore time.Duration) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, lockTimeout)
+	defer cancel()
+	var reissued bool
+	err := c.Storage.WithLock(ctx, lockNameCRL, func() error {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+
+		crl, err := c.readStoredCRL(ctx)
+		if err != nil {
+			return err
+		}
+		if time.Until(crl.NextUpdate) > refreshBefore {
+			return nil
+		}
+		if err := c.signCRLLocked(ctx, crl.Number, crl.RevokedCertificateEntries); err != nil {
+			return err
+		}
+		reissued = true
+		return nil
+	})
+	return reissued, err
+}
+
+// DefaultCRLRefreshBefore returns the default refresh window: the CRL is
+// re-signed once less than a third of its validity remains (i.e. at ~2/3 of
+// its lifetime), leaving ample margin to ride out replica outages before the
+// CRL would lapse.
+func (c *CA) DefaultCRLRefreshBefore() time.Duration {
+	return c.crlValidity() / 3
+}

--- a/internal/ca/crl_test.go
+++ b/internal/ca/crl_test.go
@@ -1,0 +1,212 @@
+// Copyright (C) 2026 Chris Boot
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package ca_test
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/tvaughan/puppet-ca/internal/ca"
+	"github.com/tvaughan/puppet-ca/internal/storage"
+	"github.com/tvaughan/puppet-ca/internal/testutil"
+)
+
+// parseStoredCRL is a test helper that loads and parses the CRL currently in
+// storage so assertions can inspect its number, validity, and entries.
+func parseStoredCRL(store *storage.StorageService) *x509.RevocationList {
+	crlPEM, err := store.GetCRL(context.Background())
+	Expect(err).NotTo(HaveOccurred())
+	block, _ := pem.Decode(crlPEM)
+	Expect(block).NotTo(BeNil())
+	crl, err := x509.ParseRevocationList(block.Bytes)
+	Expect(err).NotTo(HaveOccurred())
+	return crl
+}
+
+var _ = Describe("CA CRL reissuance", func() {
+	var (
+		tmpDir string
+		myCA   *ca.CA
+		store  *storage.StorageService
+	)
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "puppet-ca-crl-test")
+		Expect(err).NotTo(HaveOccurred())
+
+		store = storage.New(tmpDir)
+		myCA = ca.New(store, ca.AutosignConfig{Mode: "off"}, "puppet.test")
+
+		Expect(store.EnsureDirs(context.Background())).To(Succeed())
+		Expect(store.SaveCAKey(context.Background(), cachedKeyPEM)).To(Succeed())
+		Expect(store.SaveCACert(context.Background(), cachedCrtPEM)).To(Succeed())
+		Expect(store.UpdateCRL(context.Background(), cachedCrlPEM)).To(Succeed())
+		Expect(store.WriteSerial(context.Background(), "0001")).To(Succeed())
+		Expect(store.TouchInventory(context.Background())).To(Succeed())
+		Expect(myCA.Init(context.Background())).To(Succeed())
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(tmpDir)
+	})
+
+	Describe("ReissueCRL", func() {
+		It("bumps the CRL number and refreshes the validity window", func() {
+			before := parseStoredCRL(store)
+
+			Expect(myCA.ReissueCRL(context.Background())).To(Succeed())
+
+			after := parseStoredCRL(store)
+			Expect(after.Number.Cmp(before.Number)).To(Equal(1), "CRL number must increase")
+			// A freshly reissued CRL should carry the full default validity
+			// window (30 days) from now, allowing slack for execution time and
+			// the whole-second truncation x509 applies to CRL timestamps.
+			Expect(after.NextUpdate).To(BeTemporally("~", time.Now().Add(30*24*time.Hour), time.Minute))
+		})
+
+		It("preserves existing revocation entries", func() {
+			// Sign and revoke a node so the CRL has an entry to preserve.
+			csrPEM, err := testutil.GenerateCSR("crl-preserve-node")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = myCA.SaveRequest(context.Background(), "crl-preserve-node", csrPEM)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = myCA.Sign(context.Background(), "crl-preserve-node")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(myCA.Revoke(context.Background(), "crl-preserve-node")).To(Succeed())
+
+			before := parseStoredCRL(store)
+			Expect(before.RevokedCertificateEntries).To(HaveLen(1))
+			revokedSerial := before.RevokedCertificateEntries[0].SerialNumber
+
+			Expect(myCA.ReissueCRL(context.Background())).To(Succeed())
+
+			after := parseStoredCRL(store)
+			Expect(after.RevokedCertificateEntries).To(HaveLen(1))
+			Expect(after.RevokedCertificateEntries[0].SerialNumber.Cmp(revokedSerial)).To(Equal(0))
+			Expect(after.Number.Cmp(before.Number)).To(Equal(1))
+		})
+
+		It("keeps the revoked serial recognised after reissuance", func() {
+			csrPEM, err := testutil.GenerateCSR("crl-recheck-node")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = myCA.SaveRequest(context.Background(), "crl-recheck-node", csrPEM)
+			Expect(err).NotTo(HaveOccurred())
+			certPEM, err := myCA.Sign(context.Background(), "crl-recheck-node")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(myCA.Revoke(context.Background(), "crl-recheck-node")).To(Succeed())
+
+			block, _ := pem.Decode(certPEM)
+			cert, err := x509.ParseCertificate(block.Bytes)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(myCA.ReissueCRL(context.Background())).To(Succeed())
+
+			revoked, err := myCA.IsRevokedSerial(context.Background(), cert.SerialNumber)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(revoked).To(BeTrue())
+		})
+	})
+
+	Describe("RefreshCRLIfDue", func() {
+		It("does nothing when the CRL is still well within its validity", func() {
+			// Establish a known-fresh CRL (NextUpdate ~ now + crlValidity).
+			Expect(myCA.ReissueCRL(context.Background())).To(Succeed())
+			before := parseStoredCRL(store)
+
+			// A one-hour refresh window against a multi-day-valid CRL: not due.
+			reissued, err := myCA.RefreshCRLIfDue(context.Background(), time.Hour)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(reissued).To(BeFalse())
+
+			after := parseStoredCRL(store)
+			Expect(after.Number.Cmp(before.Number)).To(Equal(0), "CRL must be untouched")
+		})
+
+		It("re-signs when remaining validity is within the refresh window", func() {
+			Expect(myCA.ReissueCRL(context.Background())).To(Succeed())
+			before := parseStoredCRL(store)
+
+			// A refresh window far larger than the CRL's remaining validity
+			// forces the refresh to fire.
+			reissued, err := myCA.RefreshCRLIfDue(context.Background(), 3650*24*time.Hour)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(reissued).To(BeTrue())
+
+			after := parseStoredCRL(store)
+			Expect(after.Number.Cmp(before.Number)).To(Equal(1))
+			Expect(after.NextUpdate).To(BeTemporally("~", time.Now().Add(30*24*time.Hour), time.Minute))
+		})
+
+		It("is idempotent across replicas: a second due-check finds it fresh", func() {
+			// First replica refreshes...
+			reissued, err := myCA.RefreshCRLIfDue(context.Background(), 3650*24*time.Hour)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(reissued).To(BeTrue())
+			afterFirst := parseStoredCRL(store)
+
+			// ...a second replica running the same check with a normal window
+			// sees a fresh CRL and does not re-sign again.
+			reissued, err = myCA.RefreshCRLIfDue(context.Background(), time.Hour)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(reissued).To(BeFalse())
+
+			afterSecond := parseStoredCRL(store)
+			Expect(afterSecond.Number.Cmp(afterFirst.Number)).To(Equal(0))
+		})
+	})
+
+	Describe("DefaultCRLRefreshBefore", func() {
+		It("defaults to a third of the CRL validity window", func() {
+			// Default validity is 30 days; a third is 10 days.
+			Expect(myCA.DefaultCRLRefreshBefore()).To(Equal(30 * 24 * time.Hour / 3))
+		})
+
+		It("tracks a custom CRL validity", func() {
+			myCA.CRLValidityDays = 9
+			Expect(myCA.DefaultCRLRefreshBefore()).To(Equal(3 * 24 * time.Hour))
+		})
+	})
+})
+
+// Guard against an empty-storage edge case so a missing CRL surfaces an error
+// rather than a panic.
+var _ = Describe("CA CRL reissuance without stored CRL", func() {
+	It("returns an error when no CRL is present", func() {
+		tmpDir, err := os.MkdirTemp("", "puppet-ca-crl-missing-test")
+		Expect(err).NotTo(HaveOccurred())
+		defer os.RemoveAll(tmpDir)
+
+		store := storage.New(tmpDir)
+		myCA := ca.New(store, ca.AutosignConfig{Mode: "off"}, "puppet.test")
+		Expect(store.EnsureDirs(context.Background())).To(Succeed())
+		Expect(store.SaveCAKey(context.Background(), cachedKeyPEM)).To(Succeed())
+		Expect(store.SaveCACert(context.Background(), cachedCrtPEM)).To(Succeed())
+
+		// Load the CA key/cert without going through Init (which would seed a CRL).
+		_, err = myCA.LoadKey(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = myCA.RefreshCRLIfDue(context.Background(), time.Hour)
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/internal/ca/revoke.go
+++ b/internal/ca/revoke.go
@@ -19,7 +19,6 @@ package ca
 
 import (
 	"context"
-	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -94,36 +93,9 @@ func (c *CA) revokeLocked(ctx context.Context, subject string) error {
 	revokedCerts := crl.RevokedCertificateEntries
 	revokedCerts = append(revokedCerts, newRevoked)
 
-	// Increment CRL Number
-	nextNum := big.NewInt(1)
-	if crl.Number != nil {
-		nextNum.Add(crl.Number, big.NewInt(1))
+	if err := c.signCRLLocked(ctx, crl.Number, revokedCerts); err != nil {
+		return err
 	}
-
-	template := &x509.RevocationList{
-		Number:                    nextNum,
-		RevokedCertificateEntries: revokedCerts,
-		ThisUpdate:                time.Now(),
-		NextUpdate:                time.Now().Add(c.crlValidity()),
-	}
-
-	crlBytes, err := x509.CreateRevocationList(rand.Reader, template, c.CACert, c.CAKey)
-	if err != nil {
-		return fmt.Errorf("failed to sign CRL: %w", err)
-	}
-
-	newCRLPEM := pem.EncodeToMemory(&pem.Block{Type: "X509 CRL", Bytes: crlBytes})
-	if err := c.Storage.UpdateCRL(ctx, newCRLPEM); err != nil {
-		return fmt.Errorf("failed to write CRL: %w", err)
-	}
-
-	// Update the in-memory CRL cache so auth checks use the new CRL
-	// immediately without reading from disk.
-	parsedCRL, err := x509.ParseRevocationList(crlBytes)
-	if err != nil {
-		return fmt.Errorf("failed to parse new CRL for cache: %w", err)
-	}
-	c.cachedCRL = parsedCRL
 
 	// Invalidate the cached OCSP response for this serial so the next query
 	// returns the correct Revoked status instead of a stale Good response.


### PR DESCRIPTION
## Guess whose CRL just expired 🙃

(Mine. It was mine.) A perfectly healthy, low-churn CA — one that simply hadn't revoked anything in a month — was quietly handing out a stale CRL, and restarting didn't help.

## The bug

The CRL's `NextUpdate` was only ever stamped at **bootstrap** or on a **revocation**, and `GET /certificate_revocation_list/ca` served the stored bytes verbatim. So if no certificate was revoked for longer than `crl_validity_days` (default **30**), the stored CRL's `NextUpdate` silently lapsed and the server kept serving it forever. Restarting didn't fix it either — startup only seeds a CRL when none exists. The storage backend (Redis/Valkey, etcd, filesystem) is irrelevant: the staleness lives in the signed bytes.

## The fix

One shared re-sign primitive, three layers on top:

- **Core** (`internal/ca/crl.go`): `ReissueCRL` / `RefreshCRLIfDue` re-sign the stored CRL preserving all entries, bumping the number and stamping a fresh validity window — all under the cluster-wide `crl` lock. `RefreshCRLIfDue` does the expiry check **and** the re-sign together inside the lock, so it's safe on any number of replicas sharing storage: the first to win re-signs, the rest observe a fresh CRL and no-op. `revokeLocked` now reuses the shared `signCRLLocked` helper.
- **On-demand**: admin `PUT /certificate_revocation_list/ca` + `puppet-ca-ctl reissue-crl`, for refreshing a running cluster without having to revoke anything. (The auth middleware already defaults non-GET on that path to admin-only.)
- **Background job** (`cmd/puppet-ca/crl_refresh.go`): runs in the frontend process (which signs via the isolated signer over IPC). Re-signs at ~2/3 of lifetime (when less than a third of the validity remains), checks hourly by default, runs an immediate check at startup, and stops cleanly on shutdown.

## Configuration

CRL **lifetime** was already configurable (`crl_validity_days` / `PUPPET_CA_CRL_VALIDITY_DAYS`). New knobs control the refresh **cadence** (YAML + `PUPPET_CA_*` env, sensible defaults):

| Setting | Default | Meaning |
|---|---|---|
| `disable_crl_refresh` | `false` | Turn the background job off entirely |
| `crl_refresh_interval_sec` | `0` → 1h | How often to check |
| `crl_refresh_before_sec` | `0` → `crl_validity/3` | Re-sign when remaining validity drops below this |

## Tests

Added across all layers: `ReissueCRL` (number bump, entry preservation, revoked serial still recognised), `RefreshCRLIfDue` (not-due / due / idempotent-across-replicas / missing-CRL error), the default refresh window, the HTTP endpoint, admin-only gating, the new config knobs, and the refresher loop's startup-check + clean-shutdown behaviour.

Full suite green; `go vet` and `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
