### PR TITLE
ci: add CodeQL code scanning and bump all actions to latest majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
     name: Format / vet / tidy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -51,9 +51,9 @@ jobs:
           - docker/puppet/Dockerfile
           - docker/puppet/Dockerfile.client
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run hadolint
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: ${{ matrix.dockerfile }}
 
@@ -62,8 +62,8 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -99,8 +99,8 @@ jobs:
           - build: fips
             mage_target: test:puppetFIPS
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -121,8 +121,8 @@ jobs:
     name: Migration tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -140,8 +140,8 @@ jobs:
     name: Storage backend tests (Redis)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -159,8 +159,8 @@ jobs:
     name: Storage backend tests (PostgreSQL)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -178,8 +178,8 @@ jobs:
     name: Storage backend tests (MySQL)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -195,8 +195,8 @@ jobs:
     name: Storage backend tests (etcd)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -221,8 +221,8 @@ jobs:
           - build: fips
             mage_target: test:integComposeFIPS
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,58 @@
+name: CodeQL
+
+# Static analysis (code scanning) for the Go sources. Results are uploaded to
+# the repository's Security -> Code scanning tab and satisfy the "Main" ruleset's
+# code_scanning rule, which otherwise blocks every PR from merging.
+#
+# Triggers:
+#   * Push to main      -> establish the baseline analysis on the default branch.
+#   * Pull requests      -> analyse the proposed changes so the merge gate has
+#     fresh results to evaluate.
+#   * Weekly schedule    -> re-scan with updated CodeQL queries even when the
+#     code is quiet, so newly published advisories are still caught.
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "27 4 * * 1"
+
+# Don't pile up redundant analyses for the same branch/PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (Go)
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to upload code-scanning results.
+      security-events: write
+      # Needed by the CodeQL action to read the workflow run on private repos.
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: go
+          # "security-and-quality" widens coverage beyond the default security
+          # queries; the ruleset only gates on error-level alerts.
+          queries: security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:go"

--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -107,14 +107,14 @@ jobs:
             arch: arm64
             runner: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
         if: needs.setup.outputs.push == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -122,7 +122,7 @@ jobs:
 
       - name: Image labels
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ needs.setup.outputs.image }}
 
@@ -130,7 +130,7 @@ jobs:
       - name: Build and push by digest
         if: needs.setup.outputs.push == 'true'
         id: push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -145,7 +145,7 @@ jobs:
       # runner's native arch, load it, and smoke-test the entrypoint.
       - name: Build and load for smoke test
         if: needs.setup.outputs.push != 'true'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -166,7 +166,7 @@ jobs:
 
       - name: Upload digest
         if: needs.setup.outputs.push == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digests-${{ matrix.variant }}-${{ matrix.arch }}
           path: /tmp/digests/*
@@ -194,17 +194,17 @@ jobs:
               suffix=-alpine,onlatest=true
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/digests
           pattern: digests-${{ matrix.variant }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -212,7 +212,7 @@ jobs:
 
       - name: Compute tags
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ needs.setup.outputs.image }}
           flavor: ${{ matrix.flavor }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,8 @@ jobs:
     name: Build and publish release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true


### PR DESCRIPTION
## Why

The repo's **Main** ruleset enforces a `code_scanning` rule (CodeQL, error-level threshold), but no code-scanning analysis was ever configured. As a result every PR stalls indefinitely on *"Waiting for Code Scanning results. Code Scanning may not be configured for the target branch."* and cannot merge (e.g. #38).

## What

- **Add a CodeQL workflow** (`.github/workflows/codeql.yml`) for Go, running on push to `main`, on pull requests, and weekly. This produces the analyses the merge gate requires.
- **Bump every GitHub Action to its latest major version** across all workflows:

  | Action | Was | Now |
  |---|---|---|
  | actions/checkout | v4 | v6 |
  | actions/setup-go | v5 | v6 |
  | actions/upload-artifact | v4 | v7 |
  | actions/download-artifact | v4 | v8 |
  | docker/setup-buildx-action | v3 | v4 |
  | docker/login-action | v3 | v4 |
  | docker/metadata-action | v5 | v6 |
  | docker/build-push-action | v6 | v7 |
  | hadolint/hadolint-action | v3.1.0 | v3.3.0 |

## Notes

Once this lands on `main` and CodeQL has run once, the `code_scanning` rule becomes satisfiable and PRs can merge again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)