### PR TITLE
feat(metrics): Prometheus exporter and Jsonnet alerting mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A drop-in replacement for Puppet Server's built-in CA, written in Go. It impleme
 - **Automatic CRL refresh:** a background job re-signs the CRL before its validity lapses, so a low-churn CA never serves an expired CRL; safe across replicas (serialised on the shared CRL lock) and tunable or disablable. Operators can also force a refresh on demand via `puppet-ca-ctl reissue-crl`
 - **OCSP responder:** built-in RFC 6960 OCSP responder; AIA extension embedded in issued certs when `--ocsp-url` is set; in-memory cache with nonce bypass
 - **Health probes:** `/healthz/live`, `/healthz/ready`, and `/healthz/startup` endpoints for Kubernetes-style liveness/readiness checks
+- **Prometheus exporter:** optional `/metrics` listener (`--metrics-listen`) exposing Go runtime/process and HTTP metrics plus CA certificate, CRL, and per–leaf-certificate expiry and issuance-status series; ships with a [Jsonnet alerting mixin](mixin/). See [metrics & monitoring](docs/metrics.md)
 - **Graceful shutdown:** `SIGTERM`/`SIGINT` drains in-flight requests with a configurable window (25s default) before exiting; deferred storage and signer cleanup always runs
 - **FIPS-compatible:** standard library only (`crypto/x509`, `net/http`); no CGO by default; FIPS build available via `GOEXPERIMENT=boringcrypto`
 - **`puppet-ca-ctl`:** operator CLI matching `tvaughan-server-ca` subcommands
@@ -77,6 +78,7 @@ mage build:fips   # → bin/puppet-ca + bin/puppet-ca-ctl  (GOEXPERIMENT=boringc
 | `--allow-public-status` | `false` | Allow unauthenticated `GET /certificate_status`; by default this endpoint requires a CA-signed client cert |
 | `--ocsp-url` | `""` | OCSP responder URL to embed in issued certificates |
 | `--crl-url` | `""` | CRL distribution point URL to embed in issued certificates |
+| `--metrics-listen` | `""` | Address for the Prometheus exporter (e.g. `127.0.0.1:9140`); empty disables it. See [metrics & monitoring](docs/metrics.md) |
 | `--encrypt-ca-key` | `false` | Encrypt the CA private key at rest (AES-256-GCM + Argon2id) |
 | `--ca-key-passphrase-file` | `""` | Path to file containing the CA key passphrase (first line used) |
 | `--csr-rate-limit` | `60` | Max CSR submissions per IP per minute on the public `PUT /certificate_request` endpoint (0 disables) |
@@ -173,6 +175,7 @@ puppet_datetime_format: false   # use Puppet CA style "2006-01-02T15:04:05MST" i
 | `--allow-public-status` | `PUPPET_CA_ALLOW_PUBLIC_STATUS` |
 | `--ocsp-url` | `PUPPET_CA_OCSP_URL` |
 | `--crl-url` | `PUPPET_CA_CRL_URL` |
+| `--metrics-listen` | `PUPPET_CA_METRICS_LISTEN` |
 | `--csr-rate-limit` | `PUPPET_CA_CSR_RATE_LIMIT` |
 | `--encrypt-ca-key` | `PUPPET_CA_ENCRYPT_CA_KEY` |
 | `--ca-key-passphrase-file` | `PUPPET_CA_KEY_PASSPHRASE_FILE` |

--- a/cmd/puppet-ca/config.go
+++ b/cmd/puppet-ca/config.go
@@ -51,6 +51,13 @@ type serverConfig struct {
 	OCSPUrl           string `yaml:"ocsp_url"`
 	CRLUrl            string `yaml:"crl_url"`
 
+	// MetricsListen, when non-empty, enables the Prometheus exporter on the
+	// given address (e.g. "127.0.0.1:9140" or ":9140"). The exporter serves
+	// /metrics over plain HTTP on a separate listener from the Puppet API and is
+	// disabled by default because it reveals certificate subjects (node
+	// hostnames); restrict it to a trusted network or loopback.
+	MetricsListen string `yaml:"metrics_listen"`
+
 	// ShutdownTimeoutSec bounds the frontend's graceful HTTP-drain budget on
 	// SIGTERM: the time in-flight requests are given to complete before the
 	// listener is torn down. 0 selects the built-in default (defaultShutdownDrain).
@@ -218,6 +225,9 @@ func applyServerEnv(cfg *serverConfig) {
 	}
 	if v := os.Getenv("PUPPET_CA_CRL_URL"); v != "" {
 		cfg.CRLUrl = v
+	}
+	if v := os.Getenv("PUPPET_CA_METRICS_LISTEN"); v != "" {
+		cfg.MetricsListen = v
 	}
 	if v := os.Getenv("PUPPET_CA_SHUTDOWN_TIMEOUT_SEC"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {

--- a/cmd/puppet-ca/main.go
+++ b/cmd/puppet-ca/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tvaughan/puppet-ca/internal/api"
 	"github.com/tvaughan/puppet-ca/internal/ca"
+	"github.com/tvaughan/puppet-ca/internal/metrics"
 	"github.com/tvaughan/puppet-ca/internal/signer"
 	"github.com/tvaughan/puppet-ca/internal/storage"
 )
@@ -169,6 +170,7 @@ func newRootCmd() *cobra.Command {
 		allowPublicStatus       bool
 		ocspURL                 string
 		crlURL                  string
+		metricsListen           string
 		csrRateLimit            int
 		configFile              string
 		encryptCAKey            bool
@@ -251,6 +253,9 @@ func newRootCmd() *cobra.Command {
 			}
 			if cmd.Flags().Changed("crl-url") {
 				cfg.CRLUrl = crlURL
+			}
+			if cmd.Flags().Changed("metrics-listen") {
+				cfg.MetricsListen = metricsListen
 			}
 			if cmd.Flags().Changed("csr-rate-limit") {
 				cfg.CSRRateLimit = csrRateLimit
@@ -546,14 +551,42 @@ func newRootCmd() *cobra.Command {
 			addr := fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)
 			slog.Info("Listening", "address", addr)
 
+			// --- Prometheus exporter ---
+			// The exporter owns a private registry holding the Go/process
+			// collectors, the CA/CRL/leaf certificate collector, and the HTTP
+			// request metrics. When enabled, the API handler is instrumented so
+			// puppetca_http_* counts requests to the Puppet API, while /metrics is
+			// served on a separate listener (see metricsServer below).
+			handler := srv.Routes()
+			var exporter *metrics.Exporter
+			if cfg.MetricsListen != "" {
+				exporter = metrics.NewExporter(myCA)
+				handler = exporter.InstrumentHandler(handler)
+			}
+
 			server := &http.Server{
 				Addr:              addr,
-				Handler:           srv.Routes(),
+				Handler:           handler,
 				ReadHeaderTimeout: 10 * time.Second,
 				ReadTimeout:       30 * time.Second,
 				WriteTimeout:      60 * time.Second,
 				IdleTimeout:       120 * time.Second,
 				MaxHeaderBytes:    1 << 20,
+			}
+
+			// Start the metrics exporter on its own listener. It runs over plain
+			// HTTP regardless of the API's TLS configuration; operators should
+			// bind it to loopback or a trusted management network. A bind failure
+			// is logged but does not stop the CA from serving its primary API.
+			var metricsServer *http.Server
+			if exporter != nil {
+				metricsServer = exporter.NewServer(cfg.MetricsListen)
+				slog.Info("Prometheus metrics exporter enabled", "address", cfg.MetricsListen, "path", "/metrics")
+				go func() {
+					if err := metricsServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+						slog.Error("Metrics exporter failed", "error", err)
+					}
+				}()
 			}
 
 			if cfg.TLSCert != "" && cfg.TLSKey != "" {
@@ -609,6 +642,11 @@ func newRootCmd() *cobra.Command {
 				slog.Info("Shutting down")
 				shutdownCtx, cancel := context.WithTimeout(context.Background(), cfg.shutdownDrain())
 				defer cancel()
+				if metricsServer != nil {
+					if err := metricsServer.Shutdown(shutdownCtx); err != nil {
+						slog.Warn("Metrics exporter shutdown error", "error", err)
+					}
+				}
 				if err := server.Shutdown(shutdownCtx); err != nil {
 					slog.Warn("HTTP server shutdown error", "error", err)
 				}
@@ -648,6 +686,7 @@ func newRootCmd() *cobra.Command {
 	f.BoolVar(&allowPublicStatus, "allow-public-status", false, "Allow unauthenticated GET /certificate_status (by default, requires a CA-signed client cert)")
 	f.StringVar(&ocspURL, "ocsp-url", "", "OCSP responder URL to embed in issued certificates (e.g. http://puppet-ca:8140/ocsp)")
 	f.StringVar(&crlURL, "crl-url", "", "CRL distribution point URL to embed in issued certificates (e.g. http://puppet-ca:8140/puppet-ca/v1/certificate_revocation_list/ca)")
+	f.StringVar(&metricsListen, "metrics-listen", "", "Address for the Prometheus metrics exporter (e.g. 127.0.0.1:9140 or :9140); empty disables it. Serves /metrics over plain HTTP on a separate listener; restrict to a trusted network as it reveals node hostnames")
 	f.IntVar(&csrRateLimit, "csr-rate-limit", 60, "Max CSR submissions per IP per minute on the public PUT /certificate_request endpoint (0 disables)")
 	f.BoolVar(&encryptCAKey, "encrypt-ca-key", false, "Encrypt the CA private key at rest (AES-256-GCM + Argon2id); a passphrase is auto-generated if not provided")
 	f.StringVar(&caKeyPassphraseFile, "ca-key-passphrase-file", "", "Path to file containing the CA key passphrase (first line used)")

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,131 @@
+# Metrics & monitoring
+
+The puppet-ca server ships with an optional [Prometheus](https://prometheus.io/)
+exporter. When enabled it serves the standard Go runtime/process metrics and
+HTTP request metrics expected of a Go web service, plus CA-specific series
+describing the **CA certificate**, its **CRL**, and every known (non-deleted)
+**leaf certificate** — including issue/expiry timestamps and issuance status.
+
+A ready-to-import [Jsonnet alerting mixin](../mixin/) is included for alerting on
+impending CA, CRL, and leaf-certificate expiry, and on pending certificate
+requests.
+
+## Enabling the exporter
+
+The exporter is **disabled by default**. Enable it by setting a listen address:
+
+| Flag | Env | Config (YAML) |
+|------|-----|---------------|
+| `--metrics-listen 127.0.0.1:9140` | `PUPPET_CA_METRICS_LISTEN=127.0.0.1:9140` | `metrics_listen: 127.0.0.1:9140` |
+
+```sh
+puppet-ca --cadir /var/lib/puppet-ca --metrics-listen 127.0.0.1:9140
+```
+
+The exporter runs on a **separate listener** from the Puppet API and always
+serves plain HTTP at `/metrics`, regardless of the API's TLS configuration. In
+the default isolated-process mode it runs inside the frontend process (the
+signer process has no network exposure).
+
+> **Security:** the leaf-certificate metrics expose node hostnames (certificate
+> subjects) as label values. Bind the exporter to loopback or a trusted
+> management network — e.g. `127.0.0.1:9140` scraped via a node exporter sidecar,
+> or a dedicated interface protected by a network policy — rather than a public
+> address.
+
+### Prometheus scrape config
+
+```yaml
+scrape_configs:
+  - job_name: puppet-ca
+    static_configs:
+      - targets: ['puppet-ca.internal:9140']
+```
+
+The `job_name` is referenced by the alerting mixin's selector (default
+`job="puppet-ca"`).
+
+## Metric reference
+
+All CA-specific metrics use the `puppetca_` prefix. Timestamps are seconds since
+the Unix epoch, the Prometheus convention for `*_timestamp_seconds` gauges.
+
+### Standard Go / web-application metrics
+
+| Metric | Description |
+|--------|-------------|
+| `go_*` | Go runtime metrics (goroutines, GC, memory) from the standard Go collector. |
+| `process_*` | Process metrics (CPU, resident memory, open FDs) where supported by the platform. |
+| `puppetca_http_requests_total{method,code}` | Total CA API requests, by HTTP method and response code. |
+| `puppetca_http_request_duration_seconds{method,code}` | CA API request latency histogram. |
+| `puppetca_http_requests_in_flight` | CA API requests currently being served. |
+
+> HTTP request metrics are intentionally **not** labelled by URL path: Puppet CA
+> paths embed per-node subjects (e.g. `/certificate_status/<hostname>`), which
+> would otherwise explode metric cardinality.
+
+### Exporter health
+
+| Metric | Description |
+|--------|-------------|
+| `puppetca_ca_ready` | `1` when the CA has finished initialising, else `0`. |
+| `puppetca_collector_scrape_success` | `1` if the last CA-state gather succeeded, else `0` (e.g. storage unavailable). |
+| `puppetca_collector_scrape_duration_seconds` | Time taken to gather the CA, CRL and leaf metrics. |
+
+### CA certificate
+
+| Metric | Labels | Description |
+|--------|--------|-------------|
+| `puppetca_ca_certificate_info` | `common_name`, `serial`, `issuer` | Constant `1`; carries CA identity in labels. |
+| `puppetca_ca_certificate_not_before_timestamp_seconds` | — | CA certificate issue time. |
+| `puppetca_ca_certificate_not_after_timestamp_seconds` | — | CA certificate expiry time. |
+
+### CRL
+
+| Metric | Description |
+|--------|-------------|
+| `puppetca_crl_number` | Monotonic CRL sequence number (`cRLNumber`). |
+| `puppetca_crl_this_update_timestamp_seconds` | CRL `ThisUpdate` time. |
+| `puppetca_crl_next_update_timestamp_seconds` | CRL `NextUpdate` (expiry) time. |
+| `puppetca_crl_revoked_certificates` | Number of certificates currently listed in the CRL. |
+
+### Leaf certificates
+
+One series per known (non-deleted) leaf certificate or pending request. Cleaned
+(`puppet cert clean`) certificates drop out of these series even though their
+inventory line persists. The `state` label is one of `requested` (a pending CSR
+with no issued certificate), `signed`, or `revoked`.
+
+| Metric | Labels | Description |
+|--------|--------|-------------|
+| `puppetca_leaf_certificate_info` | `subject`, `serial`, `state` | Constant `1`. For `requested`, `serial` is empty. |
+| `puppetca_leaf_certificate_not_before_timestamp_seconds` | `subject`, `serial`, `state` | Issue time. Not emitted for `requested`. |
+| `puppetca_leaf_certificate_not_after_timestamp_seconds` | `subject`, `serial`, `state` | Expiry time. Not emitted for `requested`. |
+| `puppetca_leaf_certificates` | `state` | Count of leaf certificates per state. |
+
+> Expiry is **not** a `state`: it is derived from the `not_after` timestamp by
+> alerting rules, so a certificate can be both `signed`/`revoked` and expired.
+> To alert on expiry while ignoring revoked certs, filter on `state!="revoked"`,
+> as the mixin does.
+
+## Example queries
+
+```promql
+# CA certificate days until expiry
+(puppetca_ca_certificate_not_after_timestamp_seconds - time()) / 86400
+
+# Non-revoked leaf certificates expiring within 7 days
+puppetca_leaf_certificate_not_after_timestamp_seconds{state!="revoked"} - time() < 7 * 86400
+
+# Pending certificate requests
+puppetca_leaf_certificate_info{state="requested"} == 1
+
+# CA API error rate
+sum(rate(puppetca_http_requests_total{code=~"5.."}[5m]))
+```
+
+## Alerting
+
+See the [`mixin/`](../mixin/) directory for the Jsonnet monitoring mixin and
+instructions for rendering or importing it. It alerts on exporter availability,
+CA/CRL/leaf expiry, and pending requests, with all thresholds configurable.

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,8 @@ require (
 	github.com/magefile/mage v1.15.0
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
+	github.com/prometheus/client_golang v1.20.5
+	github.com/prometheus/client_model v0.6.1
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/spf13/cobra v1.10.2
 	github.com/uptrace/bun v1.2.18
@@ -81,8 +83,6 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.20.5 // indirect
-	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/puzpuzpuz/xsync/v3 v3.5.1 // indirect

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -1,0 +1,399 @@
+// Copyright (C) 2026 Chris Boot
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+// Package metrics exposes a Prometheus exporter for the Puppet CA. In addition
+// to the standard Go runtime / process collectors and HTTP request metrics
+// (wired up in metrics.go), it provides a custom collector that, on every
+// scrape, reports the state of the CA certificate, its CRL, and every known
+// (non-deleted) leaf certificate — including issue/expiry timestamps and
+// issuance status — so operators can alert on impending expiry and pending
+// requests.
+package metrics
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"log/slog"
+	"math/big"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/tvaughan/puppet-ca/internal/ca"
+)
+
+// namespace is the common Prometheus metric prefix for every CA-specific
+// series. It is deliberately distinct from the Go/process collectors so that
+// puppetca_* groups the exporter's domain metrics together.
+const namespace = "puppetca"
+
+// Leaf certificate issuance states reported via the `state` label. "expired" is
+// intentionally not a state: expiry is derived by alerting rules from the
+// not_after timestamp metric, which keeps a single source of truth and lets the
+// same certificate be both signed/revoked and expired.
+const (
+	stateRequested = "requested" // a pending CSR with no issued certificate yet
+	stateSigned    = "signed"    // an issued certificate not present in the CRL
+	stateRevoked   = "revoked"   // an issued certificate listed in the CRL
+)
+
+// defaultGatherTimeout bounds a single scrape's storage access. prometheus
+// Collect has no context of its own, so the collector imposes its own deadline
+// to avoid a slow/unavailable backend wedging the scrape indefinitely.
+const defaultGatherTimeout = 10 * time.Second
+
+// Collector implements prometheus.Collector, translating the CA's live state
+// into metrics on each scrape. It reads through the CA's StorageService, so it
+// observes whichever backend (filesystem, etcd, redis, SQL) the CA is using.
+type Collector struct {
+	ca      *ca.CA
+	timeout time.Duration
+
+	// Descriptors, built once in NewCollector and reused on every scrape.
+	scrapeSuccess  *prometheus.Desc
+	scrapeDuration *prometheus.Desc
+	caReady        *prometheus.Desc
+
+	caInfo      *prometheus.Desc
+	caNotBefore *prometheus.Desc
+	caNotAfter  *prometheus.Desc
+
+	crlNumber     *prometheus.Desc
+	crlThisUpdate *prometheus.Desc
+	crlNextUpdate *prometheus.Desc
+	crlRevoked    *prometheus.Desc
+
+	leafInfo       *prometheus.Desc
+	leafNotBefore  *prometheus.Desc
+	leafNotAfter   *prometheus.Desc
+	leafStateCount *prometheus.Desc
+}
+
+// NewCollector returns a Collector for the given CA. The CA need not be fully
+// initialised yet: until it is, the exporter reports puppetca_ca_ready 0 and
+// omits the CA/CRL/leaf series rather than failing the scrape.
+func NewCollector(c *ca.CA) *Collector {
+	return &Collector{
+		ca:      c,
+		timeout: defaultGatherTimeout,
+		scrapeSuccess: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "collector", "scrape_success"),
+			"1 if the most recent CA metrics scrape succeeded, 0 otherwise.",
+			nil, nil),
+		scrapeDuration: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "collector", "scrape_duration_seconds"),
+			"Time taken to gather the CA, CRL and leaf certificate metrics.",
+			nil, nil),
+		caReady: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "", "ca_ready"),
+			"1 when the CA has finished initialising and can serve requests, 0 otherwise.",
+			nil, nil),
+		caInfo: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "ca_certificate", "info"),
+			"Static information about the CA certificate; constant value 1.",
+			[]string{"common_name", "serial", "issuer"}, nil),
+		caNotBefore: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "ca_certificate", "not_before_timestamp_seconds"),
+			"NotBefore (issue) time of the CA certificate, in seconds since the Unix epoch.",
+			nil, nil),
+		caNotAfter: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "ca_certificate", "not_after_timestamp_seconds"),
+			"NotAfter (expiry) time of the CA certificate, in seconds since the Unix epoch.",
+			nil, nil),
+		crlNumber: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "crl", "number"),
+			"Monotonically increasing CRL sequence number (X.509 cRLNumber extension).",
+			nil, nil),
+		crlThisUpdate: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "crl", "this_update_timestamp_seconds"),
+			"ThisUpdate time of the current CRL, in seconds since the Unix epoch.",
+			nil, nil),
+		crlNextUpdate: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "crl", "next_update_timestamp_seconds"),
+			"NextUpdate (expiry) time of the current CRL, in seconds since the Unix epoch.",
+			nil, nil),
+		crlRevoked: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "crl", "revoked_certificates"),
+			"Number of certificates currently listed in the CRL.",
+			nil, nil),
+		leafInfo: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "leaf_certificate", "info"),
+			"One series per known (non-deleted) leaf certificate or pending request; constant value 1. "+
+				"For pending requests the serial label is empty.",
+			[]string{"subject", "serial", "state"}, nil),
+		leafNotBefore: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "leaf_certificate", "not_before_timestamp_seconds"),
+			"NotBefore (issue) time of a leaf certificate, in seconds since the Unix epoch. "+
+				"Not emitted for pending requests, which have no issued certificate.",
+			[]string{"subject", "serial", "state"}, nil),
+		leafNotAfter: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "leaf_certificate", "not_after_timestamp_seconds"),
+			"NotAfter (expiry) time of a leaf certificate, in seconds since the Unix epoch. "+
+				"Not emitted for pending requests, which have no issued certificate.",
+			[]string{"subject", "serial", "state"}, nil),
+		leafStateCount: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "", "leaf_certificates"),
+			"Number of known (non-deleted) leaf certificates by issuance state.",
+			[]string{"state"}, nil),
+	}
+}
+
+// Describe implements prometheus.Collector. The exporter uses an unchecked
+// collector model (it emits dynamic, per-certificate label sets each scrape),
+// but advertising the descriptors still lets the registry detect duplicate
+// metric names at registration time.
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.scrapeSuccess
+	ch <- c.scrapeDuration
+	ch <- c.caReady
+	ch <- c.caInfo
+	ch <- c.caNotBefore
+	ch <- c.caNotAfter
+	ch <- c.crlNumber
+	ch <- c.crlThisUpdate
+	ch <- c.crlNextUpdate
+	ch <- c.crlRevoked
+	ch <- c.leafInfo
+	ch <- c.leafNotBefore
+	ch <- c.leafNotAfter
+	ch <- c.leafStateCount
+}
+
+// Collect implements prometheus.Collector. It gathers a fresh snapshot of CA
+// state under its own deadline and emits the corresponding metrics. A gather
+// failure is reported via puppetca_collector_scrape_success rather than
+// aborting the whole /metrics response, so the Go/process/HTTP metrics still
+// scrape even when storage is momentarily unavailable.
+func (c *Collector) Collect(ch chan<- prometheus.Metric) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+
+	start := time.Now()
+	snap, err := c.gather(ctx)
+	duration := time.Since(start)
+
+	ch <- prometheus.MustNewConstMetric(c.scrapeDuration, prometheus.GaugeValue, duration.Seconds())
+	if err != nil {
+		slog.Warn("Prometheus CA metrics scrape failed", "error", err)
+		ch <- prometheus.MustNewConstMetric(c.scrapeSuccess, prometheus.GaugeValue, 0)
+		return
+	}
+	ch <- prometheus.MustNewConstMetric(c.scrapeSuccess, prometheus.GaugeValue, 1)
+
+	ch <- prometheus.MustNewConstMetric(c.caReady, prometheus.GaugeValue, boolToFloat(snap.caReady))
+
+	if snap.haveCA {
+		ch <- prometheus.MustNewConstMetric(c.caInfo, prometheus.GaugeValue, 1,
+			snap.caCommonName, snap.caSerial, snap.caIssuer)
+		ch <- prometheus.MustNewConstMetric(c.caNotBefore, prometheus.GaugeValue, timestamp(snap.caNotBefore))
+		ch <- prometheus.MustNewConstMetric(c.caNotAfter, prometheus.GaugeValue, timestamp(snap.caNotAfter))
+	}
+
+	if snap.haveCRL {
+		ch <- prometheus.MustNewConstMetric(c.crlNumber, prometheus.GaugeValue, snap.crlNumber)
+		ch <- prometheus.MustNewConstMetric(c.crlThisUpdate, prometheus.GaugeValue, timestamp(snap.crlThisUpdate))
+		ch <- prometheus.MustNewConstMetric(c.crlNextUpdate, prometheus.GaugeValue, timestamp(snap.crlNextUpdate))
+		ch <- prometheus.MustNewConstMetric(c.crlRevoked, prometheus.GaugeValue, float64(snap.crlRevokedCount))
+	}
+
+	stateCounts := map[string]int{stateRequested: 0, stateSigned: 0, stateRevoked: 0}
+	for _, leaf := range snap.leaves {
+		stateCounts[leaf.state]++
+		ch <- prometheus.MustNewConstMetric(c.leafInfo, prometheus.GaugeValue, 1,
+			leaf.subject, leaf.serial, leaf.state)
+		if leaf.hasCert {
+			ch <- prometheus.MustNewConstMetric(c.leafNotBefore, prometheus.GaugeValue,
+				timestamp(leaf.notBefore), leaf.subject, leaf.serial, leaf.state)
+			ch <- prometheus.MustNewConstMetric(c.leafNotAfter, prometheus.GaugeValue,
+				timestamp(leaf.notAfter), leaf.subject, leaf.serial, leaf.state)
+		}
+	}
+	for state, count := range stateCounts {
+		ch <- prometheus.MustNewConstMetric(c.leafStateCount, prometheus.GaugeValue, float64(count), state)
+	}
+}
+
+// leafCert is one row of the per-certificate snapshot.
+type leafCert struct {
+	subject   string
+	serial    string
+	state     string
+	notBefore time.Time
+	notAfter  time.Time
+	hasCert   bool // false for pending requests (no issued certificate)
+}
+
+// snapshot is the immutable view of CA state captured by a single scrape.
+type snapshot struct {
+	caReady bool
+
+	haveCA       bool
+	caCommonName string
+	caSerial     string
+	caIssuer     string
+	caNotBefore  time.Time
+	caNotAfter   time.Time
+
+	haveCRL         bool
+	crlNumber       float64
+	crlThisUpdate   time.Time
+	crlNextUpdate   time.Time
+	crlRevokedCount int
+
+	leaves []leafCert
+}
+
+// gather reads the CA certificate, CRL and every known leaf certificate from
+// storage and returns them as a snapshot. It returns an error only for failures
+// that prevent enumerating certificates at all (e.g. the signed-cert listing
+// fails); a missing or unparseable CRL is tolerated and simply omits the CRL
+// metrics, since a freshly bootstrapped CA may not have published one yet.
+func (c *Collector) gather(ctx context.Context) (snapshot, error) {
+	var snap snapshot
+
+	snap.caReady = c.ca.IsReady()
+	// CACert is written once during Init and not mutated afterwards, so reading
+	// it after IsReady reports true is safe without holding the CA lock.
+	if snap.caReady && c.ca.CACert != nil {
+		cert := c.ca.CACert
+		snap.haveCA = true
+		snap.caCommonName = cert.Subject.CommonName
+		snap.caSerial = serialHex(cert.SerialNumber)
+		snap.caIssuer = cert.Issuer.CommonName
+		snap.caNotBefore = cert.NotBefore
+		snap.caNotAfter = cert.NotAfter
+	}
+
+	// Parse the CRL once. The set of revoked serials drives leaf state below, so
+	// we avoid CA.IsRevoked (which re-reads and re-parses each cert from storage).
+	revoked := map[string]bool{}
+	if crlPEM, err := c.ca.Storage.GetCRL(ctx); err == nil {
+		if crl, perr := parseCRL(crlPEM); perr == nil {
+			snap.haveCRL = true
+			if crl.Number != nil {
+				// CRL numbers can exceed float64's exact-integer range in theory;
+				// in practice they are small counters, so float64 is fine and
+				// keeps the metric a plain gauge.
+				snap.crlNumber, _ = new(big.Float).SetInt(crl.Number).Float64()
+			}
+			snap.crlThisUpdate = crl.ThisUpdate
+			snap.crlNextUpdate = crl.NextUpdate
+			snap.crlRevokedCount = len(crl.RevokedCertificateEntries)
+			for _, entry := range crl.RevokedCertificateEntries {
+				revoked[serialHex(entry.SerialNumber)] = true
+			}
+		} else {
+			slog.Warn("Prometheus exporter: failed to parse CRL", "error", perr)
+		}
+	}
+
+	// Signed certificates: enumerate the live (non-deleted) signed set. A cleaned
+	// certificate is removed from this listing even though its inventory line
+	// persists, which is exactly the "known (non-deleted)" set the operator wants.
+	signed, err := c.ca.Storage.ListCerts(ctx)
+	if err != nil {
+		return snapshot{}, fmt.Errorf("listing signed certificates: %w", err)
+	}
+	seen := make(map[string]bool, len(signed))
+	for _, subject := range signed {
+		seen[subject] = true
+		certPEM, err := c.ca.Storage.GetCert(ctx, subject)
+		if err != nil {
+			// The cert was deleted between listing and reading, or is briefly
+			// unreadable; skip it rather than failing the whole scrape.
+			slog.Debug("Prometheus exporter: skipping unreadable certificate", "subject", subject, "error", err)
+			continue
+		}
+		cert, err := parseCert(certPEM)
+		if err != nil {
+			slog.Warn("Prometheus exporter: skipping unparseable certificate", "subject", subject, "error", err)
+			continue
+		}
+		serial := serialHex(cert.SerialNumber)
+		state := stateSigned
+		if revoked[serial] {
+			state = stateRevoked
+		}
+		snap.leaves = append(snap.leaves, leafCert{
+			subject:   subject,
+			serial:    serial,
+			state:     state,
+			notBefore: cert.NotBefore,
+			notAfter:  cert.NotAfter,
+			hasCert:   true,
+		})
+	}
+
+	// Pending requests: CSRs without a corresponding signed certificate. These
+	// carry no issued cert, so only the info/count series describe them.
+	pending, err := c.ca.Storage.ListCSRs(ctx)
+	if err != nil {
+		return snapshot{}, fmt.Errorf("listing certificate requests: %w", err)
+	}
+	for _, subject := range pending {
+		if seen[subject] {
+			continue
+		}
+		snap.leaves = append(snap.leaves, leafCert{
+			subject: subject,
+			state:   stateRequested,
+		})
+	}
+
+	return snap, nil
+}
+
+// parseCert decodes a PEM-encoded X.509 certificate.
+func parseCert(pemData []byte) (*x509.Certificate, error) {
+	block, _ := pem.Decode(pemData)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found")
+	}
+	return x509.ParseCertificate(block.Bytes)
+}
+
+// parseCRL decodes a PEM-encoded X.509 CRL.
+func parseCRL(pemData []byte) (*x509.RevocationList, error) {
+	block, _ := pem.Decode(pemData)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found")
+	}
+	return x509.ParseRevocationList(block.Bytes)
+}
+
+// serialHex formats a serial number as uppercase hexadecimal without leading
+// zeros, matching the representation used in the CA's inventory file and CRL so
+// that labels line up with the operator's other tooling.
+func serialHex(n *big.Int) string {
+	return fmt.Sprintf("%X", n)
+}
+
+// timestamp renders t as fractional seconds since the Unix epoch, the
+// convention for Prometheus *_timestamp_seconds gauges. A zero time yields 0.
+func timestamp(t time.Time) float64 {
+	if t.IsZero() {
+		return 0
+	}
+	return float64(t.UnixNano()) / 1e9
+}
+
+func boolToFloat(b bool) float64 {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/internal/metrics/collector_test.go
+++ b/internal/metrics/collector_test.go
@@ -1,0 +1,201 @@
+// Copyright (C) 2026 Chris Boot
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package metrics_test
+
+import (
+	"context"
+
+	dto "github.com/prometheus/client_model/go"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/tvaughan/puppet-ca/internal/ca"
+	"github.com/tvaughan/puppet-ca/internal/metrics"
+	"github.com/tvaughan/puppet-ca/internal/storage"
+	"github.com/tvaughan/puppet-ca/internal/testutil"
+)
+
+// gathered indexes a Prometheus gather result by metric family name.
+type gathered map[string]*dto.MetricFamily
+
+func gather(c prometheus.Collector) gathered {
+	reg := prometheus.NewRegistry()
+	ExpectWithOffset(1, reg.Register(c)).To(Succeed())
+	mfs, err := reg.Gather()
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	out := make(gathered, len(mfs))
+	for _, mf := range mfs {
+		out[mf.GetName()] = mf
+	}
+	return out
+}
+
+// labelsOf flattens a metric's label pairs into a map for easy assertions.
+func labelsOf(m *dto.Metric) map[string]string {
+	out := make(map[string]string, len(m.GetLabel()))
+	for _, lp := range m.GetLabel() {
+		out[lp.GetName()] = lp.GetValue()
+	}
+	return out
+}
+
+// findByLabels returns the first metric in family whose labels match every
+// key/value in want, or nil when none match.
+func (g gathered) findByLabels(name string, want map[string]string) *dto.Metric {
+	mf := g[name]
+	if mf == nil {
+		return nil
+	}
+	for _, m := range mf.GetMetric() {
+		got := labelsOf(m)
+		match := true
+		for k, v := range want {
+			if got[k] != v {
+				match = false
+				break
+			}
+		}
+		if match {
+			return m
+		}
+	}
+	return nil
+}
+
+func gaugeValue(m *dto.Metric) float64 { return m.GetGauge().GetValue() }
+
+var _ = Describe("Collector", func() {
+	var (
+		ctx   context.Context
+		myCA  *ca.CA
+		store *storage.StorageService
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		store = storage.New(GinkgoT().TempDir())
+		myCA = ca.New(store, ca.AutosignConfig{Mode: "off"}, "puppet.test")
+		Expect(myCA.Init(ctx)).To(Succeed())
+	})
+
+	signCert := func(subject string) {
+		csrPEM, err := testutil.GenerateCSR(subject)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = myCA.SaveRequest(ctx, subject, csrPEM)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = myCA.Sign(ctx, subject)
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	requestCert := func(subject string) {
+		csrPEM, err := testutil.GenerateCSR(subject)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = myCA.SaveRequest(ctx, subject, csrPEM)
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	It("reports CA certificate and CRL metrics", func() {
+		g := gather(metrics.NewCollector(myCA))
+
+		Expect(gaugeValue(g.findByLabels("puppetca_collector_scrape_success", nil))).To(Equal(1.0))
+		Expect(gaugeValue(g.findByLabels("puppetca_ca_ready", nil))).To(Equal(1.0))
+
+		caInfo := g.findByLabels("puppetca_ca_certificate_info", nil)
+		Expect(caInfo).NotTo(BeNil())
+		Expect(labelsOf(caInfo)).To(HaveKeyWithValue("common_name", ContainSubstring("Puppet CA")))
+		Expect(gaugeValue(caInfo)).To(Equal(1.0))
+
+		notAfter := g.findByLabels("puppetca_ca_certificate_not_after_timestamp_seconds", nil)
+		Expect(notAfter).NotTo(BeNil())
+		Expect(gaugeValue(notAfter)).To(BeNumerically(">", gaugeValue(
+			g.findByLabels("puppetca_ca_certificate_not_before_timestamp_seconds", nil))))
+
+		// A freshly bootstrapped CA has published an (empty) CRL.
+		Expect(g.findByLabels("puppetca_crl_next_update_timestamp_seconds", nil)).NotTo(BeNil())
+		Expect(gaugeValue(g.findByLabels("puppetca_crl_revoked_certificates", nil))).To(Equal(0.0))
+	})
+
+	It("reports per-leaf metrics with issuance state", func() {
+		signCert("signed-node")
+		signCert("revoked-node")
+		requestCert("pending-node")
+		Expect(myCA.Revoke(ctx, "revoked-node")).To(Succeed())
+
+		g := gather(metrics.NewCollector(myCA))
+
+		signed := g.findByLabels("puppetca_leaf_certificate_info", map[string]string{"subject": "signed-node"})
+		Expect(signed).NotTo(BeNil())
+		Expect(labelsOf(signed)).To(HaveKeyWithValue("state", "signed"))
+		Expect(labelsOf(signed)["serial"]).NotTo(BeEmpty())
+
+		revoked := g.findByLabels("puppetca_leaf_certificate_info", map[string]string{"subject": "revoked-node"})
+		Expect(revoked).NotTo(BeNil())
+		Expect(labelsOf(revoked)).To(HaveKeyWithValue("state", "revoked"))
+
+		pending := g.findByLabels("puppetca_leaf_certificate_info", map[string]string{"subject": "pending-node"})
+		Expect(pending).NotTo(BeNil())
+		Expect(labelsOf(pending)).To(HaveKeyWithValue("state", "requested"))
+		Expect(labelsOf(pending)["serial"]).To(BeEmpty())
+
+		// Pending requests carry no issued certificate, so they have no expiry series.
+		Expect(g.findByLabels("puppetca_leaf_certificate_not_after_timestamp_seconds",
+			map[string]string{"subject": "pending-node"})).To(BeNil())
+		// Signed certs do.
+		Expect(g.findByLabels("puppetca_leaf_certificate_not_after_timestamp_seconds",
+			map[string]string{"subject": "signed-node"})).NotTo(BeNil())
+
+		// The CRL now lists exactly the one revoked serial.
+		Expect(gaugeValue(g.findByLabels("puppetca_crl_revoked_certificates", nil))).To(Equal(1.0))
+
+		// Aggregate per-state counts.
+		Expect(gaugeValue(g.findByLabels("puppetca_leaf_certificates",
+			map[string]string{"state": "signed"}))).To(Equal(1.0))
+		Expect(gaugeValue(g.findByLabels("puppetca_leaf_certificates",
+			map[string]string{"state": "revoked"}))).To(Equal(1.0))
+		Expect(gaugeValue(g.findByLabels("puppetca_leaf_certificates",
+			map[string]string{"state": "requested"}))).To(Equal(1.0))
+	})
+
+	It("excludes cleaned (deleted) certificates from the live set", func() {
+		signCert("keep-node")
+		signCert("clean-node")
+		Expect(myCA.Clean(ctx, "clean-node")).To(Succeed())
+
+		g := gather(metrics.NewCollector(myCA))
+
+		Expect(g.findByLabels("puppetca_leaf_certificate_info",
+			map[string]string{"subject": "keep-node"})).NotTo(BeNil())
+		Expect(g.findByLabels("puppetca_leaf_certificate_info",
+			map[string]string{"subject": "clean-node"})).To(BeNil())
+	})
+
+	It("exposes Go and process collectors plus HTTP request metrics via the exporter", func() {
+		exp := metrics.NewExporter(myCA)
+		mfs, err := exp.Registry().Gather()
+		Expect(err).NotTo(HaveOccurred())
+
+		names := map[string]bool{}
+		for _, mf := range mfs {
+			names[mf.GetName()] = true
+		}
+		Expect(names).To(HaveKey("go_goroutines"))
+		Expect(names).To(HaveKey("puppetca_ca_certificate_info"))
+		Expect(names).To(HaveKey("puppetca_http_requests_in_flight"))
+	})
+})

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,134 @@
+// Copyright (C) 2026 Chris Boot
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package metrics
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/tvaughan/puppet-ca/internal/ca"
+)
+
+// Exporter bundles a dedicated Prometheus registry with the HTTP request
+// instrumentation that shares it. Keeping a private registry (rather than the
+// global default) means the exporter's metrics are self-contained and tests can
+// construct independent instances without cross-talk.
+type Exporter struct {
+	registry *prometheus.Registry
+	inFlight prometheus.Gauge
+	requests *prometheus.CounterVec
+	duration *prometheus.HistogramVec
+}
+
+// NewExporter builds an Exporter for the given CA. The registry is populated
+// with:
+//
+//   - the standard Go runtime collector (go_*),
+//   - the process collector (process_*),
+//   - build-info (puppetca_build_info via the version collector is omitted; the
+//     Go collector already exposes go_info),
+//   - the CA/CRL/leaf certificate collector (puppetca_*), and
+//   - HTTP server request metrics (puppetca_http_*), applied to whatever handler
+//     is wrapped with InstrumentHandler.
+//
+// Together these cover both the "usual" Go web-application metrics and the
+// CA-specific certificate/CRL series.
+func NewExporter(c *ca.CA) *Exporter {
+	reg := prometheus.NewRegistry()
+
+	// Standard Go web-application metrics.
+	reg.MustRegister(
+		collectors.NewGoCollector(),
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
+	)
+
+	// CA-specific metrics.
+	reg.MustRegister(NewCollector(c))
+
+	e := &Exporter{
+		registry: reg,
+		inFlight: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: "http",
+			Name:      "requests_in_flight",
+			Help:      "Number of HTTP requests currently being served by the CA API.",
+		}),
+		requests: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "http",
+			Name:      "requests_total",
+			Help:      "Total number of HTTP requests handled by the CA API, by method and response code.",
+		}, []string{"method", "code"}),
+		duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: "http",
+			Name:      "request_duration_seconds",
+			Help:      "HTTP request latency for the CA API, by method and response code.",
+			Buckets:   prometheus.DefBuckets,
+		}, []string{"method", "code"}),
+	}
+	reg.MustRegister(e.inFlight, e.requests, e.duration)
+
+	return e
+}
+
+// Registry returns the exporter's Prometheus registry, e.g. for serving via a
+// custom promhttp handler or for test gathering.
+func (e *Exporter) Registry() *prometheus.Registry { return e.registry }
+
+// Handler returns an http.Handler that serves the exporter's metrics in the
+// Prometheus text/OpenMetrics exposition format. Mount it at /metrics.
+func (e *Exporter) Handler() http.Handler {
+	return promhttp.HandlerFor(e.registry, promhttp.HandlerOpts{
+		ErrorHandling:     promhttp.ContinueOnError,
+		EnableOpenMetrics: true,
+	})
+}
+
+// InstrumentHandler wraps next so that every request it serves is counted and
+// timed into the puppetca_http_* metrics. Only the request method and response
+// status code are used as labels — never the URL path — because Puppet CA paths
+// embed per-node subjects (e.g. /certificate_status/<hostname>) and would
+// otherwise explode metric cardinality.
+func (e *Exporter) InstrumentHandler(next http.Handler) http.Handler {
+	return promhttp.InstrumentHandlerInFlight(e.inFlight,
+		promhttp.InstrumentHandlerCounter(e.requests,
+			promhttp.InstrumentHandlerDuration(e.duration, next)))
+}
+
+// NewServer builds an *http.Server that serves the exporter's metrics at
+// /metrics on addr. The caller owns its lifecycle (ListenAndServe / Shutdown).
+// Timeouts mirror the main API server's conservative defaults so a stuck
+// scraper cannot tie up a connection indefinitely.
+func (e *Exporter) NewServer(addr string) *http.Server {
+	mux := http.NewServeMux()
+	mux.Handle("GET /metrics", e.Handler())
+	// A trivial root response makes it obvious the listener is the metrics
+	// endpoint when probed by a human or a liveness check.
+	mux.HandleFunc("GET /", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		_, _ = w.Write([]byte("Puppet CA metrics exporter\nSee /metrics\n"))
+	})
+	return &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+}

--- a/internal/metrics/metrics_suite_test.go
+++ b/internal/metrics/metrics_suite_test.go
@@ -1,0 +1,29 @@
+// Copyright (C) 2026 Chris Boot
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package metrics_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMetrics(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Metrics Suite")
+}

--- a/mixin/README.md
+++ b/mixin/README.md
@@ -1,0 +1,89 @@
+# Puppet CA monitoring mixin
+
+A [monitoring mixin](https://monitoring.mixins.dev/) providing Prometheus
+alerting rules for the Puppet CA exporter. It alerts on:
+
+- the exporter being down or unable to read CA state, and the CA not being ready;
+- the **CA certificate** nearing expiry (warning) or expiring imminently (critical);
+- the **CRL** approaching its `NextUpdate` (warning) or having lapsed (critical);
+- **leaf certificates** nearing/at expiry — excluding revoked ones — and
+  certificate **requests that stay pending** too long.
+
+All thresholds and the target selector live in [`config.libsonnet`](config.libsonnet)
+and can be overridden without editing the rules.
+
+## Enabling the exporter
+
+The alerts assume the puppet-ca Prometheus exporter is enabled and scraped. Start
+the server with `--metrics-listen` (or `PUPPET_CA_METRICS_LISTEN` /
+`metrics_listen:` in the config file):
+
+```sh
+puppet-ca --cadir /var/lib/puppet-ca --metrics-listen 127.0.0.1:9140
+```
+
+The exporter serves `/metrics` over plain HTTP on its own listener. It exposes
+node hostnames as label values, so bind it to loopback or a trusted management
+network and scrape it from there. A matching Prometheus scrape config:
+
+```yaml
+scrape_configs:
+  - job_name: puppet-ca
+    static_configs:
+      - targets: ['puppet-ca.internal:9140']
+```
+
+The `job_name` must match `puppetCASelector` in the mixin config (default
+`job="puppet-ca"`).
+
+## Rendering the alerts standalone
+
+With [`jsonnet`](https://github.com/google/go-jsonnet) installed:
+
+```sh
+jsonnet -S -e "std.manifestYamlDoc((import 'mixin.libsonnet').prometheusAlerts)" \
+  > puppet_ca_alerts.yaml
+promtool check rules puppet_ca_alerts.yaml
+```
+
+## Importing into another repo
+
+Vendor the mixin with [jsonnet-bundler](https://github.com/jsonnet-bundler/jsonnet-bundler):
+
+```sh
+jb install https://github.com/tvaughan/puppet-ca/mixin@main
+```
+
+Then combine it with your overrides:
+
+```jsonnet
+// mixin.jsonnet
+local puppetca = (import 'vendor/puppet-ca/mixin.libsonnet') + {
+  _config+:: {
+    puppetCASelector: 'job="pki/puppet-ca"',
+    caExpiryWarningSeconds: 45 * 24 * 3600,
+  },
+};
+
+{
+  'puppet_ca_alerts.yaml': std.manifestYamlDoc(puppetca.prometheusAlerts),
+}
+```
+
+```sh
+jsonnet -J vendor -m . mixin.jsonnet
+```
+
+## Configurable thresholds
+
+| Key | Default | Meaning |
+| --- | --- | --- |
+| `puppetCASelector` | `job="puppet-ca"` | Label selector matching the exporter targets. |
+| `alertLabels` | `{}` | Extra labels merged onto every alert (e.g. routing labels). |
+| `caExpiryWarningSeconds` | 30 days | CA certificate expiry warning threshold. |
+| `caExpiryCriticalSeconds` | 7 days | CA certificate expiry critical threshold. |
+| `crlExpiryWarningSeconds` | 3 days | CRL `NextUpdate` warning threshold. |
+| `leafExpiryWarningSeconds` | 7 days | Leaf certificate expiry warning threshold. |
+| `leafExpiryCriticalSeconds` | 1 day | Leaf certificate expiry critical threshold. |
+| `pendingFor` | `1h` | How long a request may stay pending before alerting. |
+| `expiryFor` / `scrapeFor` / `readyFor` / `downFor` | `1h` / `15m` / `10m` / `5m` | `for:` debounce durations. |

--- a/mixin/alerts.libsonnet
+++ b/mixin/alerts.libsonnet
@@ -1,0 +1,179 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'puppet-ca-availability',
+        rules: [
+          {
+            alert: 'PuppetCAExporterDown',
+            // 'up == 0' only matches an existing series; if the target is absent
+            // from service discovery entirely there is no 'up' series to compare,
+            // so OR in absent() to catch a wholly-missing exporter too.
+            expr: |||
+              up{%(selector)s} == 0
+              or
+              absent(up{%(selector)s})
+            ||| % { selector: $._config.puppetCASelector },
+            'for': $._config.downFor,
+            labels: { severity: 'critical' } + $._config.alertLabels,
+            annotations: {
+              summary: 'Puppet CA metrics exporter is down.',
+              description: 'Prometheus cannot scrape the Puppet CA exporter on {{ $labels.instance }}. Certificate and CRL expiry can no longer be monitored.',
+            },
+          },
+          {
+            alert: 'PuppetCAScrapeFailing',
+            // The exporter answered but could not read CA state from storage.
+            expr: 'puppetca_collector_scrape_success{%(selector)s} == 0' % { selector: $._config.puppetCASelector },
+            'for': $._config.scrapeFor,
+            labels: { severity: 'warning' } + $._config.alertLabels,
+            annotations: {
+              summary: 'Puppet CA exporter cannot read CA state.',
+              description: 'The Puppet CA exporter on {{ $labels.instance }} is failing to gather certificate metrics from storage (puppetca_collector_scrape_success=0).',
+            },
+          },
+          {
+            alert: 'PuppetCANotReady',
+            expr: 'puppetca_ca_ready{%(selector)s} == 0' % { selector: $._config.puppetCASelector },
+            'for': $._config.readyFor,
+            labels: { severity: 'warning' } + $._config.alertLabels,
+            annotations: {
+              summary: 'Puppet CA is not ready.',
+              description: 'The Puppet CA on {{ $labels.instance }} has been reporting not-ready (puppetca_ca_ready=0) and cannot serve signing requests.',
+            },
+          },
+        ],
+      },
+      {
+        name: 'puppet-ca-certificate-expiry',
+        rules: [
+          {
+            alert: 'PuppetCACertificateExpiringSoon',
+            expr: |||
+              puppetca_ca_certificate_not_after_timestamp_seconds{%(selector)s} - time() < %(warn)d
+              and
+              puppetca_ca_certificate_not_after_timestamp_seconds{%(selector)s} - time() >= %(crit)d
+            ||| % {
+              selector: $._config.puppetCASelector,
+              warn: $._config.caExpiryWarningSeconds,
+              crit: $._config.caExpiryCriticalSeconds,
+            },
+            'for': $._config.expiryFor,
+            labels: { severity: 'warning' } + $._config.alertLabels,
+            annotations: {
+              summary: 'Puppet CA certificate is approaching expiry.',
+              description: 'The CA certificate ({{ $labels.common_name }}) on {{ $labels.instance }} expires in {{ $value | humanizeDuration }}.',
+            },
+          },
+          {
+            alert: 'PuppetCACertificateExpiringCritical',
+            expr: 'puppetca_ca_certificate_not_after_timestamp_seconds{%(selector)s} - time() < %(crit)d' % {
+              selector: $._config.puppetCASelector,
+              crit: $._config.caExpiryCriticalSeconds,
+            },
+            'for': $._config.expiryFor,
+            labels: { severity: 'critical' } + $._config.alertLabels,
+            annotations: {
+              summary: 'Puppet CA certificate expires imminently.',
+              description: 'The CA certificate ({{ $labels.common_name }}) on {{ $labels.instance }} expires in {{ $value | humanizeDuration }}. Re-keying the CA is disruptive; act now.',
+            },
+          },
+        ],
+      },
+      {
+        name: 'puppet-ca-crl-expiry',
+        rules: [
+          {
+            alert: 'PuppetCACRLExpiringSoon',
+            expr: |||
+              puppetca_crl_next_update_timestamp_seconds{%(selector)s} - time() < %(warn)d
+              and
+              puppetca_crl_next_update_timestamp_seconds{%(selector)s} - time() > 0
+            ||| % {
+              selector: $._config.puppetCASelector,
+              warn: $._config.crlExpiryWarningSeconds,
+            },
+            'for': $._config.expiryFor,
+            labels: { severity: 'warning' } + $._config.alertLabels,
+            annotations: {
+              summary: 'Puppet CA CRL is approaching its NextUpdate.',
+              description: 'The CRL on {{ $labels.instance }} reaches NextUpdate in {{ $value | humanizeDuration }}. The CA normally auto-refreshes it; check the CRL refresher.',
+            },
+          },
+          {
+            alert: 'PuppetCACRLExpired',
+            expr: 'puppetca_crl_next_update_timestamp_seconds{%(selector)s} - time() <= 0' % { selector: $._config.puppetCASelector },
+            'for': $._config.expiryFor,
+            labels: { severity: 'critical' } + $._config.alertLabels,
+            annotations: {
+              summary: 'Puppet CA CRL has expired.',
+              description: 'The CRL on {{ $labels.instance }} is past its NextUpdate. Relying parties may reject it and fail revocation checks.',
+            },
+          },
+        ],
+      },
+      {
+        name: 'puppet-ca-leaf-certificates',
+        rules: [
+          {
+            alert: 'PuppetCALeafCertificateExpiringSoon',
+            // state!="revoked" excludes certificates that have been revoked: a
+            // revoked cert nearing expiry is expected and not actionable.
+            expr: |||
+              puppetca_leaf_certificate_not_after_timestamp_seconds{%(selector)s,state!="revoked"} - time() < %(warn)d
+              and
+              puppetca_leaf_certificate_not_after_timestamp_seconds{%(selector)s,state!="revoked"} - time() >= %(crit)d
+            ||| % {
+              selector: $._config.puppetCASelector,
+              warn: $._config.leafExpiryWarningSeconds,
+              crit: $._config.leafExpiryCriticalSeconds,
+            },
+            'for': $._config.expiryFor,
+            labels: { severity: 'warning' } + $._config.alertLabels,
+            annotations: {
+              summary: 'A leaf certificate is approaching expiry.',
+              description: 'Certificate for {{ $labels.subject }} (serial {{ $labels.serial }}) expires in {{ $value | humanizeDuration }}. The node may have stopped renewing.',
+            },
+          },
+          {
+            alert: 'PuppetCALeafCertificateExpiringCritical',
+            expr: |||
+              puppetca_leaf_certificate_not_after_timestamp_seconds{%(selector)s,state!="revoked"} - time() < %(crit)d
+              and
+              puppetca_leaf_certificate_not_after_timestamp_seconds{%(selector)s,state!="revoked"} - time() > 0
+            ||| % {
+              selector: $._config.puppetCASelector,
+              crit: $._config.leafExpiryCriticalSeconds,
+            },
+            'for': $._config.expiryFor,
+            labels: { severity: 'critical' } + $._config.alertLabels,
+            annotations: {
+              summary: 'A leaf certificate expires imminently.',
+              description: 'Certificate for {{ $labels.subject }} (serial {{ $labels.serial }}) expires in {{ $value | humanizeDuration }}.',
+            },
+          },
+          {
+            alert: 'PuppetCALeafCertificateExpired',
+            expr: 'puppetca_leaf_certificate_not_after_timestamp_seconds{%(selector)s,state!="revoked"} - time() <= 0' % { selector: $._config.puppetCASelector },
+            'for': $._config.expiryFor,
+            labels: { severity: 'warning' } + $._config.alertLabels,
+            annotations: {
+              summary: 'A non-revoked leaf certificate has expired.',
+              description: 'Certificate for {{ $labels.subject }} (serial {{ $labels.serial }}) on {{ $labels.instance }} has expired but is not revoked.',
+            },
+          },
+          {
+            alert: 'PuppetCACertificateRequestPending',
+            expr: 'puppetca_leaf_certificate_info{%(selector)s,state="requested"} == 1' % { selector: $._config.puppetCASelector },
+            'for': $._config.pendingFor,
+            labels: { severity: 'warning' } + $._config.alertLabels,
+            annotations: {
+              summary: 'A certificate request has been pending too long.',
+              description: 'The request for {{ $labels.subject }} on {{ $labels.instance }} has been awaiting signing for more than %(pendingFor)s.' % { pendingFor: $._config.pendingFor },
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/mixin/config.libsonnet
+++ b/mixin/config.libsonnet
@@ -1,0 +1,41 @@
+{
+  _config+:: {
+    // puppetCASelector matches the Prometheus targets that scrape the
+    // puppet-ca exporter. Override it to pin the alerts to a specific job,
+    // namespace, or instance — e.g. 'job="puppet-ca",namespace="pki"'.
+    puppetCASelector: 'job="puppet-ca"',
+
+    // alertLabels are merged onto every alert (e.g. a team or severity routing
+    // label). 'severity' is set per-alert below and should not be put here.
+    alertLabels: {},
+
+    // --- CA certificate expiry ---
+    // Warn well ahead of CA expiry (re-keying a CA is disruptive); page when it
+    // becomes urgent. Values are in seconds.
+    caExpiryWarningSeconds: 30 * 24 * 3600,  // 30 days
+    caExpiryCriticalSeconds: 7 * 24 * 3600,  // 7 days
+
+    // --- CRL expiry ---
+    // The CA auto-refreshes its CRL, so an approaching NextUpdate usually means
+    // the refresher is wedged. Warn a few days out; page once it has lapsed.
+    crlExpiryWarningSeconds: 3 * 24 * 3600,  // 3 days
+
+    // --- Leaf certificate expiry ---
+    // Agents normally auto-renew; a leaf nearing expiry indicates a node that
+    // has stopped checking in. Revoked certs are excluded by the alert exprs.
+    leafExpiryWarningSeconds: 7 * 24 * 3600,  // 7 days
+    leafExpiryCriticalSeconds: 24 * 3600,  // 1 day
+
+    // --- Pending requests ---
+    // How long a certificate request may sit unsigned before alerting. Set to a
+    // larger value (or silence the alert) on CAs that sign manually by policy.
+    pendingFor: '1h',
+
+    // 'for' durations applied to the expiry alerts to debounce flapping at the
+    // threshold boundary.
+    expiryFor: '1h',
+    scrapeFor: '15m',
+    readyFor: '10m',
+    downFor: '5m',
+  },
+}

--- a/mixin/jsonnetfile.json
+++ b/mixin/jsonnetfile.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "dependencies": [],
+  "legacyImports": true
+}

--- a/mixin/mixin.libsonnet
+++ b/mixin/mixin.libsonnet
@@ -1,0 +1,14 @@
+// Puppet CA monitoring mixin.
+//
+// A monitoring-mixin (https://monitoring.mixins.dev/) bundling Prometheus
+// alerting rules for the Puppet CA exporter. Import it from another repository
+// with jsonnet-bundler and render the alerts with jsonnet — see README.md.
+//
+// Override anything in _config (see config.libsonnet) to tune selectors and
+// thresholds, e.g.:
+//
+//   (import 'puppet-ca-mixin/mixin.libsonnet') + {
+//     _config+:: { puppetCASelector: 'job="pki/puppet-ca"' },
+//   }
+(import 'config.libsonnet') +
+(import 'alerts.libsonnet')


### PR DESCRIPTION
## Summary

Adds an optional Prometheus exporter to `puppet-ca`, plus a Jsonnet monitoring mixin with sample alerts. Enabled with `--metrics-listen` (`PUPPET_CA_METRICS_LISTEN` / `metrics_listen:`); **disabled by default** because leaf metrics reveal node hostnames. It serves `/metrics` over plain HTTP on a separate listener from the frontend process.

### Metrics
Alongside the usual Go runtime, process, and HTTP request metrics, a custom collector reads CA state through the `StorageService` (works on every backend) and exports:

- **CA certificate:** `puppetca_ca_certificate_info{common_name,serial,issuer}`, `..._not_before/not_after_timestamp_seconds`
- **CRL:** `puppetca_crl_number`, `..._this_update/next_update_timestamp_seconds`, `..._revoked_certificates`
- **Per known (non-deleted) leaf certificate:** `puppetca_leaf_certificate_info` + `..._not_before/not_after_timestamp_seconds`, labelled `subject,serial,state` (`requested`/`signed`/`revoked`); plus `puppetca_leaf_certificates{state}` counts
- **Health:** `puppetca_ca_ready`, `puppetca_collector_scrape_success/_duration_seconds`

HTTP request metrics are labelled only by method + response code (never path) to avoid cardinality blow-up from per-node subjects in Puppet CA URLs.

### Alerting mixin (`mixin/`)
Standard monitoring-mixin layout with configurable thresholds/selector. 11 alerts: CA expiry (warn/crit), CRL near-expiry/lapsed, leaf near-expiry/expired (revoked excluded via `state!="revoked"`), pending requests, and exporter availability. Validated with `jsonnetfmt`, `jsonnet`, and `promtool check rules`.

### Docs
`docs/metrics.md` (metric reference + example queries) and README feature/flag/env updates.

## Testing
- Ginkgo tests in `internal/metrics` covering CA/CRL series, the three leaf states, and revoked/cleaned exclusion.
- `go build`, `go vet`, `gofmt`, `golangci-lint` (0 issues), full `go test` suite — all pass.
- Manually ran the binary, submitted a CSR, and scraped `/metrics` to confirm all series render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)