### PR TITLE
feat(cleanup): optional job to purge expired certs from inventory and CRL

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A drop-in replacement for Puppet Server's built-in CA, written in Go. It impleme
 - **CRL Distribution Points:** optionally embed a CRL URL in every issued certificate (`--crl-url`) so verifiers can automatically fetch the CRL
 - **Configurable CRL validity:** control how long each published CRL is valid (`crl_validity_days`)
 - **Automatic CRL refresh:** a background job re-signs the CRL before its validity lapses, so a low-churn CA never serves an expired CRL; safe across replicas (serialised on the shared CRL lock) and tunable or disablable. Operators can also force a refresh on demand via `puppet-ca-ctl reissue-crl`
+- **Expired-certificate cleanup (opt-in):** a background job removes certificates that expired more than a configurable grace period ago from the inventory and the CRL (and deletes their stored signed certificate), keeping both from growing without bound as nodes are decommissioned; safe across replicas (serialised on the shared CRL lock)
 - **OCSP responder:** built-in RFC 6960 OCSP responder; AIA extension embedded in issued certs when `--ocsp-url` is set; in-memory cache with nonce bypass
 - **Health probes:** `/healthz/live`, `/healthz/ready`, and `/healthz/startup` endpoints for Kubernetes-style liveness/readiness checks
 - **Graceful shutdown:** `SIGTERM`/`SIGINT` drains in-flight requests with a configurable window (25s default) before exiting; deferred storage and signer cleanup always runs
@@ -146,6 +147,13 @@ csr_rate_limit: 60    # max CSR submissions per IP per minute; 0 = disable rate 
 disable_crl_refresh: false     # true = never auto-refresh the CRL
 crl_refresh_interval_sec: 0    # how often to check; 0 = built-in default (1h)
 crl_refresh_before_sec: 0      # re-sign when remaining validity < this; 0 = crl_validity/3
+# Background expired-certificate cleanup (opt-in). When enabled, a job removes
+# certificates that expired more than the retention grace period ago from the
+# inventory and the CRL, and deletes their stored signed certificate. Safe to run
+# on every replica (serialised on the shared CRL lock).
+enable_expired_cert_cleanup: false       # true = run the cleanup job
+expired_cert_retention_sec: 0            # grace period after a cert's NotAfter before removal; 0 = built-in default (30d)
+expired_cert_cleanup_interval_sec: 0     # how often to run; 0 = built-in default (24h)
 # CA key encryption at rest.
 encrypt_ca_key: false           # encrypt the CA private key (AES-256-GCM + Argon2id)
 ca_key_passphrase_file: ""      # path to passphrase file; auto-generated if omitted
@@ -204,6 +212,9 @@ The CA key passphrase can also be provided via `PUPPET_CA_KEY_PASSPHRASE` (env v
 | `disable_crl_refresh` | `PUPPET_CA_DISABLE_CRL_REFRESH` |
 | `crl_refresh_interval_sec` | `PUPPET_CA_CRL_REFRESH_INTERVAL_SEC` |
 | `crl_refresh_before_sec` | `PUPPET_CA_CRL_REFRESH_BEFORE_SEC` |
+| `enable_expired_cert_cleanup` | `PUPPET_CA_ENABLE_EXPIRED_CERT_CLEANUP` |
+| `expired_cert_retention_sec` | `PUPPET_CA_EXPIRED_CERT_RETENTION_SEC` |
+| `expired_cert_cleanup_interval_sec` | `PUPPET_CA_EXPIRED_CERT_CLEANUP_INTERVAL_SEC` |
 | `shutdown_timeout_sec` | `PUPPET_CA_SHUTDOWN_TIMEOUT_SEC` |
 | `etcd_username` | `PUPPET_CA_ETCD_USERNAME` |
 | `etcd_password` | `PUPPET_CA_ETCD_PASSWORD` |

--- a/cmd/puppet-ca/cert_cleanup.go
+++ b/cmd/puppet-ca/cert_cleanup.go
@@ -1,0 +1,73 @@
+// Copyright (C) 2026 Chris Boot
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package main
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/tvaughan/puppet-ca/internal/ca"
+)
+
+// runCertCleaner periodically removes certificates that expired more than
+// retain ago from the inventory and the CRL (and deletes their stored signed
+// certificate). It is an optional, opt-in job for operators who want their
+// inventory and CRL to shed long-dead nodes automatically rather than growing
+// without bound. It runs in the frontend process, which signs the rebuilt CRL
+// via the isolated signer over IPC.
+//
+// Replica safety: CA.CleanupExpiredCerts does its inventory prune and CRL
+// re-sign under the shared cluster CRL lock, so when this runs on multiple
+// replicas only the first to acquire the lock prunes; the others observe an
+// already-clean inventory and remove nothing. No leader election is required.
+//
+// It returns when ctx is cancelled (i.e. on shutdown).
+func runCertCleaner(ctx context.Context, c *ca.CA, interval, retain time.Duration) {
+	slog.Info("Starting expired-certificate cleanup job", "interval", interval, "retention", retain)
+
+	// Run immediately at startup so a backlog that accrued while every replica
+	// was down is cleared without waiting a full interval.
+	cleanupExpiredOnce(ctx, c, retain)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Debug("Expired-certificate cleanup job stopping")
+			return
+		case <-ticker.C:
+			cleanupExpiredOnce(ctx, c, retain)
+		}
+	}
+}
+
+// cleanupExpiredOnce runs a single cleanup pass, logging the outcome. Errors are
+// logged and swallowed so a transient storage/lock failure does not stop the
+// job; the next tick will retry.
+func cleanupExpiredOnce(ctx context.Context, c *ca.CA, retain time.Duration) {
+	removed, err := c.CleanupExpiredCerts(ctx, retain)
+	switch {
+	case err != nil:
+		slog.Warn("Expired-certificate cleanup failed", "error", err)
+	case removed > 0:
+		slog.Info("Expired certificates cleaned up", "removed", removed)
+	default:
+		slog.Debug("Expired-certificate cleanup: nothing to remove")
+	}
+}

--- a/cmd/puppet-ca/cert_cleanup_test.go
+++ b/cmd/puppet-ca/cert_cleanup_test.go
@@ -1,0 +1,94 @@
+// Copyright (C) 2026 Chris Boot
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tvaughan/puppet-ca/internal/storage"
+)
+
+// seedExpiredInventoryEntry appends an inventory entry whose NotAfter is two
+// years in the past, so a cleanup pass with any modest retention removes it.
+// (newRefresherTestCA is defined in crl_refresh_test.go in this package.)
+func seedExpiredInventoryEntry(t *testing.T, store *storage.StorageService, subject string) {
+	t.Helper()
+	past := time.Now().Add(-2 * 365 * 24 * time.Hour).Format("2006-01-02T15:04:05UTC")
+	entry := "ABCD " + past + " " + past + " /" + subject
+	if err := store.AppendInventory(context.Background(), entry); err != nil {
+		t.Fatalf("AppendInventory: %v", err)
+	}
+}
+
+func inventoryHas(t *testing.T, store *storage.StorageService, needle string) bool {
+	t.Helper()
+	data, err := store.ReadInventory(context.Background())
+	if err != nil {
+		t.Fatalf("ReadInventory: %v", err)
+	}
+	return strings.Contains(string(data), needle)
+}
+
+// cleanupExpiredOnce should remove an expired entry and leave a fresh one alone.
+func TestCleanupExpiredOnce(t *testing.T) {
+	c, store := newRefresherTestCA(t)
+	ctx := context.Background()
+
+	seedExpiredInventoryEntry(t, store, "expired-node")
+	if !inventoryHas(t, store, "/expired-node") {
+		t.Fatal("precondition: expired-node should be in the inventory")
+	}
+
+	cleanupExpiredOnce(ctx, c, time.Hour)
+	if inventoryHas(t, store, "/expired-node") {
+		t.Error("expired-node should have been removed from the inventory")
+	}
+}
+
+// runCertCleaner must perform an immediate cleanup at startup and then return
+// promptly once its context is cancelled.
+func TestRunCertCleanerStartupAndShutdown(t *testing.T) {
+	c, store := newRefresherTestCA(t)
+	seedExpiredInventoryEntry(t, store, "expired-node")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		runCertCleaner(ctx, c, time.Hour, time.Hour)
+		close(done)
+	}()
+
+	// The startup pass should prune the expired entry before we cancel; poll.
+	deadline := time.After(2 * time.Second)
+	for inventoryHas(t, store, "/expired-node") {
+		select {
+		case <-deadline:
+			t.Fatal("startup cleanup did not run within 2s")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runCertCleaner did not return after context cancellation")
+	}
+}

--- a/cmd/puppet-ca/config.go
+++ b/cmd/puppet-ca/config.go
@@ -90,6 +90,15 @@ type serverConfig struct {
 	CRLRefreshIntervalSec int  `yaml:"crl_refresh_interval_sec"` // how often to check; 0 = built-in default (1h)
 	CRLRefreshBeforeSec   int  `yaml:"crl_refresh_before_sec"`   // re-sign when remaining validity < this; 0 = crl_validity/3
 
+	// Background expired-certificate cleanup. Disabled by default: when enabled,
+	// a job periodically removes certificates that expired more than the
+	// retention grace period ago from the inventory and the CRL (and deletes
+	// their stored signed certificate). Safe to run on every replica: the work is
+	// serialised on the shared CRL lock, so only one replica prunes per cycle.
+	EnableExpiredCertCleanup      bool `yaml:"enable_expired_cert_cleanup"`       // true = run the cleanup job
+	ExpiredCertRetentionSec       int  `yaml:"expired_cert_retention_sec"`        // grace period after NotAfter before removal; 0 = built-in default (30d)
+	ExpiredCertCleanupIntervalSec int  `yaml:"expired_cert_cleanup_interval_sec"` // how often to run; 0 = built-in default (24h)
+
 	// CA key encryption at rest.
 	EncryptCAKey        bool   `yaml:"encrypt_ca_key"`         // encrypt the CA private key at rest (AES-256-GCM + Argon2id)
 	CAKeyPassphraseFile string `yaml:"ca_key_passphrase_file"` // path to file containing the CA key passphrase
@@ -157,6 +166,38 @@ func (c *serverConfig) crlRefreshInterval() time.Duration {
 		return time.Duration(c.CRLRefreshIntervalSec) * time.Second
 	}
 	return defaultCRLRefreshInterval
+}
+
+const (
+	// defaultExpiredCertRetention is how long past a certificate's NotAfter the
+	// expired-cert cleanup job waits before removing it when the operator has not
+	// configured a retention. 30 days gives operators a comfortable window to
+	// notice a node before its record disappears from the inventory and CRL.
+	defaultExpiredCertRetention = 30 * 24 * time.Hour
+	// defaultExpiredCertCleanupInterval is how often the cleanup job runs when no
+	// interval is configured. Daily is ample: expiry is a slow, day-scale event.
+	defaultExpiredCertCleanupInterval = 24 * time.Hour
+)
+
+// expiredCertRetention resolves the grace period the cleanup job applies after a
+// certificate's NotAfter before removing it, falling back to
+// defaultExpiredCertRetention when unset. A zero value selects the default; set
+// a negative ExpiredCertRetentionSec is not representable, so operators wanting
+// "remove as soon as expired" should set a small positive value.
+func (c *serverConfig) expiredCertRetention() time.Duration {
+	if c.ExpiredCertRetentionSec > 0 {
+		return time.Duration(c.ExpiredCertRetentionSec) * time.Second
+	}
+	return defaultExpiredCertRetention
+}
+
+// expiredCertCleanupInterval resolves how often the cleanup job runs, falling
+// back to defaultExpiredCertCleanupInterval when unset.
+func (c *serverConfig) expiredCertCleanupInterval() time.Duration {
+	if c.ExpiredCertCleanupIntervalSec > 0 {
+		return time.Duration(c.ExpiredCertCleanupIntervalSec) * time.Second
+	}
+	return defaultExpiredCertCleanupInterval
 }
 
 // applyServerEnv overlays PUPPET_CA_* environment variables onto cfg.
@@ -288,6 +329,21 @@ func applyServerEnv(cfg *serverConfig) {
 	if v := os.Getenv("PUPPET_CA_CRL_REFRESH_BEFORE_SEC"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			cfg.CRLRefreshBeforeSec = n
+		}
+	}
+	if v := os.Getenv("PUPPET_CA_ENABLE_EXPIRED_CERT_CLEANUP"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.EnableExpiredCertCleanup = b
+		}
+	}
+	if v := os.Getenv("PUPPET_CA_EXPIRED_CERT_RETENTION_SEC"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.ExpiredCertRetentionSec = n
+		}
+	}
+	if v := os.Getenv("PUPPET_CA_EXPIRED_CERT_CLEANUP_INTERVAL_SEC"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.ExpiredCertCleanupIntervalSec = n
 		}
 	}
 	if v := os.Getenv("PUPPET_CA_CSR_RATE_LIMIT"); v != "" {

--- a/cmd/puppet-ca/config_test.go
+++ b/cmd/puppet-ca/config_test.go
@@ -55,6 +55,9 @@ var serverEnvVars = []string{
 	"PUPPET_CA_DISABLE_CRL_REFRESH",
 	"PUPPET_CA_CRL_REFRESH_INTERVAL_SEC",
 	"PUPPET_CA_CRL_REFRESH_BEFORE_SEC",
+	"PUPPET_CA_ENABLE_EXPIRED_CERT_CLEANUP",
+	"PUPPET_CA_EXPIRED_CERT_RETENTION_SEC",
+	"PUPPET_CA_EXPIRED_CERT_CLEANUP_INTERVAL_SEC",
 }
 
 // clearServerEnv unsets all PUPPET_CA_* vars and restores them after the test.
@@ -233,6 +236,64 @@ func TestCRLRefreshIntervalRejectsNonPositive(t *testing.T) {
 	}
 	if got := cfg.crlRefreshInterval(); got != defaultCRLRefreshInterval {
 		t.Errorf("crlRefreshInterval() with 0 = %v; want default %v", got, defaultCRLRefreshInterval)
+	}
+}
+
+// --- expired-cert cleanup resolvers ---
+
+func TestExpiredCertCleanupDefaults(t *testing.T) {
+	clearServerEnv(t)
+
+	cfg, err := loadServerConfig("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.EnableExpiredCertCleanup {
+		t.Error("EnableExpiredCertCleanup should default to false (opt-in)")
+	}
+	if got := cfg.expiredCertRetention(); got != defaultExpiredCertRetention {
+		t.Errorf("expiredCertRetention() = %v; want default %v", got, defaultExpiredCertRetention)
+	}
+	if got := cfg.expiredCertCleanupInterval(); got != defaultExpiredCertCleanupInterval {
+		t.Errorf("expiredCertCleanupInterval() = %v; want default %v", got, defaultExpiredCertCleanupInterval)
+	}
+}
+
+func TestExpiredCertCleanupEnvOverride(t *testing.T) {
+	clearServerEnv(t)
+	t.Setenv("PUPPET_CA_ENABLE_EXPIRED_CERT_CLEANUP", "true")
+	t.Setenv("PUPPET_CA_EXPIRED_CERT_RETENTION_SEC", "3600")
+	t.Setenv("PUPPET_CA_EXPIRED_CERT_CLEANUP_INTERVAL_SEC", "900")
+
+	cfg, err := loadServerConfig("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.EnableExpiredCertCleanup {
+		t.Error("EnableExpiredCertCleanup = false; want true")
+	}
+	if got, want := cfg.expiredCertRetention(), time.Hour; got != want {
+		t.Errorf("expiredCertRetention() = %v; want %v", got, want)
+	}
+	if got, want := cfg.expiredCertCleanupInterval(), 900*time.Second; got != want {
+		t.Errorf("expiredCertCleanupInterval() = %v; want %v", got, want)
+	}
+}
+
+func TestExpiredCertCleanupRejectsNonPositive(t *testing.T) {
+	clearServerEnv(t)
+	t.Setenv("PUPPET_CA_EXPIRED_CERT_RETENTION_SEC", "0")
+	t.Setenv("PUPPET_CA_EXPIRED_CERT_CLEANUP_INTERVAL_SEC", "-5")
+
+	cfg, err := loadServerConfig("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := cfg.expiredCertRetention(); got != defaultExpiredCertRetention {
+		t.Errorf("expiredCertRetention() with 0 = %v; want default %v", got, defaultExpiredCertRetention)
+	}
+	if got := cfg.expiredCertCleanupInterval(); got != defaultExpiredCertCleanupInterval {
+		t.Errorf("expiredCertCleanupInterval() with -5 = %v; want default %v", got, defaultExpiredCertCleanupInterval)
 	}
 }
 

--- a/cmd/puppet-ca/main.go
+++ b/cmd/puppet-ca/main.go
@@ -603,6 +603,14 @@ func newRootCmd() *cobra.Command {
 				slog.Info("CRL auto-refresh disabled by configuration")
 			}
 
+			// Background expired-certificate cleanup (opt-in): prunes certs that
+			// expired more than the retention grace period ago from the inventory
+			// and CRL. Safe on every replica (serialised on the shared CRL lock).
+			// Bound to ctx so it stops on shutdown.
+			if cfg.EnableExpiredCertCleanup {
+				go runCertCleaner(ctx, myCA, cfg.expiredCertCleanupInterval(), cfg.expiredCertRetention())
+			}
+
 			shutdownDone := make(chan struct{})
 			go func() {
 				<-ctx.Done()

--- a/internal/ca/cleanup.go
+++ b/internal/ca/cleanup.go
@@ -1,0 +1,170 @@
+// Copyright (C) 2026 Chris Boot
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package ca
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"log/slog"
+	"math/big"
+	"time"
+
+	"github.com/tvaughan/puppet-ca/internal/storage"
+)
+
+// inventoryTimeFormat is the layout the signing path writes NotBefore/NotAfter
+// with (see signCSR). It is parsed back here to decide which inventory entries
+// have expired. The trailing "UTC" is a literal in the layout (Go's zone token
+// is "MST"), so parsing yields a UTC time with the recorded wall-clock digits.
+const inventoryTimeFormat = "2006-01-02T15:04:05UTC"
+
+// CleanupExpiredCerts removes certificates whose NotAfter is older than retain
+// ago from the inventory, drops their entries from the CRL, deletes their stored
+// signed certificate (when the on-disk cert still has the expired serial, so a
+// renewal under the same subject is preserved), and invalidates the in-memory
+// serial index and OCSP cache for the removed serials. It reports how many
+// certificates were removed.
+//
+// retain is a grace period measured from each certificate's NotAfter: a cert is
+// eligible only once now-retain has passed its expiry. retain may be zero (purge
+// as soon as expired); negative values are treated as zero.
+//
+// Replica safety: the whole operation runs under the cluster-wide CRL lock, so
+// it serialises with Revoke and the CRL refresher across replicas. The inventory
+// rewrite itself is atomic per backend (see StorageService.PruneInventory). An
+// entry that cannot be time-parsed is conservatively kept, never dropped.
+func (c *CA) CleanupExpiredCerts(ctx context.Context, retain time.Duration) (int, error) {
+	if retain < 0 {
+		retain = 0
+	}
+	cutoff := time.Now().Add(-retain)
+
+	ctx, cancel := context.WithTimeout(ctx, lockTimeout)
+	defer cancel()
+
+	var removed int
+	err := c.Storage.WithLock(ctx, lockNameCRL, func() error {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+
+		// Prune the inventory first; the returned entries tell us exactly which
+		// serials to drop from the CRL and which caches/blobs to clean up.
+		dropped, err := c.Storage.PruneInventory(ctx, func(e storage.InventoryEntry) bool {
+			notAfter, perr := time.Parse(inventoryTimeFormat, e.NotAfter)
+			if perr != nil {
+				slog.Warn("Cleanup: keeping inventory entry with unparseable NotAfter",
+					"serial", e.Serial, "subject", e.Subject, "not_after", e.NotAfter, "error", perr)
+				return true
+			}
+			return !notAfter.Before(cutoff)
+		})
+		if err != nil {
+			return err
+		}
+		if len(dropped) == 0 {
+			return nil
+		}
+
+		// Collect the removed serials (normalised) and refresh in-memory caches.
+		removedSerials := make(map[string]*big.Int, len(dropped))
+		for _, e := range dropped {
+			n := new(big.Int)
+			if _, ok := n.SetString(e.Serial, 16); !ok {
+				slog.Warn("Cleanup: malformed serial in pruned inventory entry, skipping CRL/cache cleanup",
+					"serial", e.Serial, "subject", e.Subject)
+				continue
+			}
+			key := serialHexStr(n)
+			removedSerials[key] = n
+			delete(c.serialIndex, key)
+			delete(c.ocspCache, key)
+		}
+
+		if err := c.dropCRLEntriesLocked(ctx, removedSerials); err != nil {
+			return err
+		}
+
+		// Delete the stored signed cert for each removed subject, but only when
+		// the cert still on file carries the expired serial (otherwise the
+		// subject has been renewed and the current cert must be preserved).
+		for _, e := range dropped {
+			c.deleteStoredCertIfSerialMatches(ctx, e.Subject, e.Serial)
+		}
+
+		removed = len(dropped)
+		return nil
+	})
+	return removed, err
+}
+
+// dropCRLEntriesLocked re-signs the CRL with every revocation entry whose serial
+// is in removed filtered out. It is a no-op (no re-sign) when none of the
+// removed serials currently appear in the CRL. The cluster CRL lock and c.mu
+// must both be held by the caller.
+func (c *CA) dropCRLEntriesLocked(ctx context.Context, removed map[string]*big.Int) error {
+	crl, err := c.readStoredCRL(ctx)
+	if err != nil {
+		return err
+	}
+
+	kept := make([]x509.RevocationListEntry, 0, len(crl.RevokedCertificateEntries))
+	changed := false
+	for _, entry := range crl.RevokedCertificateEntries {
+		if _, drop := removed[serialHexStr(entry.SerialNumber)]; drop {
+			changed = true
+			continue
+		}
+		kept = append(kept, entry)
+	}
+	if !changed {
+		return nil
+	}
+	return c.signCRLLocked(ctx, crl.Number, kept)
+}
+
+// deleteStoredCertIfSerialMatches deletes the signed certificate stored for
+// subject only when its serial equals expectSerial (case-insensitive hex match
+// via serialHexStr). Failures are logged and swallowed: the inventory/CRL have
+// already been updated, and a leftover cert blob is harmless clutter the next
+// run will not retry (the inventory entry is gone). The caller must hold c.mu.
+func (c *CA) deleteStoredCertIfSerialMatches(ctx context.Context, subject, expectSerial string) {
+	certPEM, err := c.Storage.GetCert(ctx, subject)
+	if err != nil {
+		return // no stored cert (or unreadable); nothing to delete
+	}
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		return
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return
+	}
+	want := new(big.Int)
+	if _, ok := want.SetString(expectSerial, 16); !ok {
+		return
+	}
+	if serialHexStr(cert.SerialNumber) != serialHexStr(want) {
+		// Subject was renewed since this entry was issued; keep the current cert.
+		return
+	}
+	if err := c.Storage.DeleteCert(ctx, subject); err != nil {
+		slog.Warn("Cleanup: failed to delete expired signed certificate",
+			"subject", subject, "serial", expectSerial, "error", err)
+	}
+}

--- a/internal/ca/cleanup_test.go
+++ b/internal/ca/cleanup_test.go
@@ -1,0 +1,215 @@
+// Copyright (C) 2026 Chris Boot
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package ca_test
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"os"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/tvaughan/puppet-ca/internal/ca"
+	"github.com/tvaughan/puppet-ca/internal/storage"
+	"github.com/tvaughan/puppet-ca/internal/testutil"
+)
+
+// cleanupInventoryFormat matches the layout the signing path writes and
+// CleanupExpiredCerts parses.
+const cleanupInventoryFormat = "2006-01-02T15:04:05UTC"
+
+var _ = Describe("CA CleanupExpiredCerts", func() {
+	var (
+		ctx    = context.Background()
+		tmpDir string
+		myCA   *ca.CA
+		store  *storage.StorageService
+		caKey  crypto.Signer
+		caCert *x509.Certificate
+	)
+
+	// signLive issues a real certificate for subject via the normal path; its
+	// NotAfter is in the future (capped to the CA's remaining lifetime).
+	signLive := func(subject string) {
+		csrPEM, err := testutil.GenerateCSR(subject)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = myCA.SaveRequest(ctx, subject, csrPEM)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = myCA.Sign(ctx, subject)
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	// seedCert creates a leaf certificate signed by the cached test CA with the
+	// given serial and NotAfter, saves it as the stored cert for subject, appends
+	// a matching inventory entry, and revokes it so its serial lands in the CRL.
+	// notAfter may be in the past, which the normal signing path cannot produce.
+	seedCert := func(subject string, serial *big.Int, notAfter time.Time) {
+		csrPEM, err := testutil.GenerateCSR(subject)
+		Expect(err).NotTo(HaveOccurred())
+		block, _ := pem.Decode(csrPEM)
+		csr, err := x509.ParseCertificateRequest(block.Bytes)
+		Expect(err).NotTo(HaveOccurred())
+
+		template := &x509.Certificate{
+			SerialNumber: serial,
+			Subject:      csr.Subject,
+			NotBefore:    notAfter.Add(-365 * 24 * time.Hour),
+			NotAfter:     notAfter,
+		}
+		der, err := x509.CreateCertificate(rand.Reader, template, caCert, csr.PublicKey, caKey)
+		Expect(err).NotTo(HaveOccurred())
+		certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+		Expect(store.SaveCert(ctx, subject, certPEM)).To(Succeed())
+
+		entry := fmt.Sprintf("%s %s %s /%s",
+			serial.Text(16),
+			template.NotBefore.Format(cleanupInventoryFormat),
+			notAfter.Format(cleanupInventoryFormat),
+			subject)
+		Expect(store.AppendInventory(ctx, entry)).To(Succeed())
+
+		// Revoke so the serial is present in the CRL (Revoke resolves the serial
+		// from the inventory entry just appended).
+		Expect(myCA.Revoke(ctx, subject)).To(Succeed())
+	}
+
+	inventoryString := func() string {
+		data, err := store.ReadInventory(ctx)
+		Expect(err).NotTo(HaveOccurred()) // also asserts the integrity head verifies
+		return string(data)
+	}
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "puppet-ca-cleanup-test")
+		Expect(err).NotTo(HaveOccurred())
+
+		store = storage.New(tmpDir)
+		myCA = ca.New(store, ca.AutosignConfig{Mode: "off"}, "puppet.test")
+
+		Expect(store.EnsureDirs(ctx)).To(Succeed())
+		Expect(store.SaveCAKey(ctx, cachedKeyPEM)).To(Succeed())
+		Expect(store.SaveCACert(ctx, cachedCrtPEM)).To(Succeed())
+		Expect(store.UpdateCRL(ctx, cachedCrlPEM)).To(Succeed())
+		Expect(store.WriteSerial(ctx, "0001")).To(Succeed())
+		Expect(store.TouchInventory(ctx)).To(Succeed())
+		Expect(myCA.Init(ctx)).To(Succeed())
+
+		keyBlock, _ := pem.Decode(cachedKeyPEM)
+		caKey, err = x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+		Expect(err).NotTo(HaveOccurred())
+		certBlock, _ := pem.Decode(cachedCrtPEM)
+		caCert, err = x509.ParseCertificate(certBlock.Bytes)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(tmpDir)
+	})
+
+	It("removes an expired cert from the inventory, the CRL, and storage", func() {
+		signLive("live-node")
+		expiredSerial := big.NewInt(0xABCD)
+		seedCert("expired-node", expiredSerial, time.Now().Add(-3*365*24*time.Hour))
+
+		// Precondition: the seeded cert is revoked and present everywhere.
+		Expect(parseStoredCRL(store).RevokedCertificateEntries).To(HaveLen(1))
+		Expect(store.HasCert(ctx, "expired-node")).To(BeTrue())
+		Expect(inventoryString()).To(ContainSubstring("/expired-node"))
+
+		removed, err := myCA.CleanupExpiredCerts(ctx, time.Hour)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(removed).To(Equal(1))
+
+		inv := inventoryString()
+		Expect(inv).NotTo(ContainSubstring("/expired-node"))
+		Expect(inv).To(ContainSubstring("/live-node"))
+		Expect(parseStoredCRL(store).RevokedCertificateEntries).To(BeEmpty())
+		Expect(store.HasCert(ctx, "expired-node")).To(BeFalse())
+		Expect(store.HasCert(ctx, "live-node")).To(BeTrue())
+	})
+
+	It("does not remove certs that are still within the retention grace period", func() {
+		// Expired only 1 hour ago, but retention is 30 days: must be kept.
+		seedCert("recent-node", big.NewInt(0x1234), time.Now().Add(-time.Hour))
+
+		removed, err := myCA.CleanupExpiredCerts(ctx, 30*24*time.Hour)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(removed).To(Equal(0))
+		Expect(inventoryString()).To(ContainSubstring("/recent-node"))
+		Expect(parseStoredCRL(store).RevokedCertificateEntries).To(HaveLen(1))
+	})
+
+	It("returns zero and changes nothing when no certs have expired", func() {
+		signLive("live-node")
+		before := inventoryString()
+
+		removed, err := myCA.CleanupExpiredCerts(ctx, time.Hour)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(removed).To(Equal(0))
+		Expect(inventoryString()).To(Equal(before))
+	})
+
+	It("keeps entries whose NotAfter cannot be parsed rather than dropping them", func() {
+		// A malformed NotAfter field must never be treated as expired.
+		Expect(store.AppendInventory(ctx, "00FF 2024-01-01T00:00:00UTC not-a-timestamp /weird-node")).To(Succeed())
+
+		removed, err := myCA.CleanupExpiredCerts(ctx, 0)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(removed).To(Equal(0))
+		Expect(inventoryString()).To(ContainSubstring("/weird-node"))
+	})
+
+	It("preserves a renewed cert under the same subject when an old serial expires", func() {
+		// Stored cert is the live (renewed) one; the expired entry carries a
+		// different, older serial. Cleanup must drop the old inventory/CRL entry
+		// but leave the current stored cert in place.
+		signLive("renewed-node")
+		liveCertBefore, err := store.GetCert(ctx, "renewed-node")
+		Expect(err).NotTo(HaveOccurred())
+
+		oldSerial := big.NewInt(0x5151)
+		// Append an old, expired inventory entry + CRL revocation for the same
+		// subject, without overwriting the stored (renewed) cert.
+		entry := fmt.Sprintf("%s %s %s /%s", oldSerial.Text(16),
+			time.Now().Add(-4*365*24*time.Hour).Format(cleanupInventoryFormat),
+			time.Now().Add(-3*365*24*time.Hour).Format(cleanupInventoryFormat),
+			"renewed-node")
+		Expect(store.AppendInventory(ctx, entry)).To(Succeed())
+
+		removed, err := myCA.CleanupExpiredCerts(ctx, time.Hour)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(removed).To(Equal(1))
+
+		// The current cert for the subject survived because its serial differs
+		// from the expired one.
+		liveCertAfter, err := store.GetCert(ctx, "renewed-node")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(liveCertAfter).To(Equal(liveCertBefore))
+
+		inv := inventoryString()
+		Expect(inv).To(ContainSubstring("/renewed-node"))
+		Expect(strings.Count(inv, "/renewed-node")).To(Equal(1))
+	})
+})

--- a/internal/storage/backend.go
+++ b/internal/storage/backend.go
@@ -199,6 +199,15 @@ type InventoryStore interface {
 	// LatestSerialForSubject returns the most recently issued serial for
 	// subject. Wraps os.ErrNotExist when the subject has no entry.
 	LatestSerialForSubject(ctx context.Context, subject string) (string, error)
+
+	// PruneEntries removes every entry for which keep returns false and
+	// recomputes the integrity head over the survivors, atomically in one
+	// transaction so the rows and the chained head can never be observed out of
+	// sync by another replica. recomputeHead folds the hash chain over the
+	// surviving entries in issuance order; a nil recomputeHead means integrity is
+	// disabled and the stored head is left untouched. It returns the removed
+	// entries in issuance order, or an empty slice when nothing matched.
+	PruneEntries(ctx context.Context, keep func(InventoryEntry) bool, recomputeHead func(survivors []InventoryEntry) []byte) ([]InventoryEntry, error)
 }
 
 // Locker is an optional Backend capability that provides a cross-node

--- a/internal/storage/prune_inventory_test.go
+++ b/internal/storage/prune_inventory_test.go
@@ -1,0 +1,131 @@
+// Copyright (C) 2026 Chris Boot
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package storage
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+// newFilesystemInventoryService returns a StorageService over a fresh
+// filesystem backend with the inventory touched, integrity initialised, and
+// sampleInventoryLines appended. It mirrors newInventoryService (SQLite) so the
+// prune tests can exercise both the structured and blob inventory paths.
+func newFilesystemInventoryService(t *testing.T) *StorageService {
+	t.Helper()
+	ctx := context.Background()
+	svc := New(t.TempDir())
+	if err := svc.EnsureDirs(ctx); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+	if err := svc.TouchInventory(ctx); err != nil {
+		t.Fatalf("TouchInventory: %v", err)
+	}
+	if err := svc.InitHMAC(ctx); err != nil {
+		t.Fatalf("InitHMAC: %v", err)
+	}
+	for _, line := range sampleInventoryLines {
+		if err := svc.AppendInventory(ctx, line); err != nil {
+			t.Fatalf("AppendInventory(%q): %v", line, err)
+		}
+	}
+	return svc
+}
+
+// keepNotSerial returns a predicate that keeps every entry except the one with
+// the given serial.
+func keepNotSerial(serial string) func(InventoryEntry) bool {
+	return func(e InventoryEntry) bool { return e.Serial != serial }
+}
+
+// TestPruneInventory exercises StorageService.PruneInventory against both the
+// structured (SQLite) and blob (filesystem) backends. The critical property is
+// that after a prune the integrity head is rewritten so ReadInventory — which
+// verifies the HMAC/hash chain — still succeeds; a stale head would surface as
+// ErrInventoryTampered.
+func TestPruneInventory(t *testing.T) {
+	backends := map[string]func(t *testing.T) *StorageService{
+		"sqlite": func(t *testing.T) *StorageService {
+			svc, _ := newInventoryService(t)
+			return svc
+		},
+		"filesystem": newFilesystemInventoryService,
+	}
+
+	for name, mk := range backends {
+		t.Run(name, func(t *testing.T) {
+			t.Run("removes matching entries and rewrites the integrity head", func(t *testing.T) {
+				ctx := context.Background()
+				svc := mk(t)
+
+				// Drop serial 0002 (node2); node1's 0001 and 0003 must survive in order.
+				removed, err := svc.PruneInventory(ctx, keepNotSerial("0002"))
+				if err != nil {
+					t.Fatalf("PruneInventory: %v", err)
+				}
+				if len(removed) != 1 || removed[0].Serial != "0002" || removed[0].Subject != "node2" {
+					t.Fatalf("removed = %+v; want one entry serial 0002 subject node2", removed)
+				}
+
+				// ReadInventory verifies the integrity head before returning, so a
+				// successful read proves the chain/HMAC was rewritten for the survivors.
+				got, err := svc.ReadInventory(ctx)
+				if err != nil {
+					t.Fatalf("ReadInventory after prune: %v (head not rewritten?)", err)
+				}
+				want := "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1\n" +
+					"0003 2024-01-03T00:00:00UTC 2029-01-03T00:00:00UTC /node1\n"
+				if !bytes.Equal(got, []byte(want)) {
+					t.Errorf("inventory after prune = %q, want %q", got, want)
+				}
+
+				// A subsequent append must extend the rewritten chain cleanly.
+				if err := svc.AppendInventory(ctx, "0004 2024-01-04T00:00:00UTC 2029-01-04T00:00:00UTC /node3"); err != nil {
+					t.Fatalf("AppendInventory after prune: %v", err)
+				}
+				if _, err := svc.ReadInventory(ctx); err != nil {
+					t.Fatalf("ReadInventory after post-prune append: %v", err)
+				}
+			})
+
+			t.Run("no match leaves inventory and head untouched", func(t *testing.T) {
+				ctx := context.Background()
+				svc := mk(t)
+
+				before, err := svc.ReadInventory(ctx)
+				if err != nil {
+					t.Fatalf("ReadInventory: %v", err)
+				}
+				removed, err := svc.PruneInventory(ctx, func(InventoryEntry) bool { return true })
+				if err != nil {
+					t.Fatalf("PruneInventory: %v", err)
+				}
+				if len(removed) != 0 {
+					t.Fatalf("removed = %+v; want none", removed)
+				}
+				after, err := svc.ReadInventory(ctx)
+				if err != nil {
+					t.Fatalf("ReadInventory after no-op prune: %v", err)
+				}
+				if !bytes.Equal(before, after) {
+					t.Errorf("inventory changed by no-op prune: before %q after %q", before, after)
+				}
+			})
+		})
+	}
+}

--- a/internal/storage/sql_inventory.go
+++ b/internal/storage/sql_inventory.go
@@ -181,6 +181,86 @@ func (b *SQLBackend) LatestSerialForSubject(ctx context.Context, subject string)
 	return row.Serial, nil
 }
 
+// PruneEntries removes the rows for which keep returns false and rewrites the
+// integrity head over the survivors in a single transaction, so a concurrent
+// reader on another replica never observes the rows and the chained head out of
+// sync. Survivors keep their original ids (and thus issuance order); only the
+// dropped rows are deleted. The presence-marker row is locked first so this
+// serialises with AppendEntry across replicas, exactly as appends do.
+func (b *SQLBackend) PruneEntries(ctx context.Context, keep func(InventoryEntry) bool, recomputeHead func(survivors []InventoryEntry) []byte) ([]InventoryEntry, error) {
+	b.appendMu.Lock()
+	defer b.appendMu.Unlock()
+
+	ctx, cancel := b.callCtx(ctx)
+	defer cancel()
+
+	const maxAttempts = 10
+	for attempt := 0; ; attempt++ {
+		removed, err := b.pruneEntriesOnce(ctx, keep, recomputeHead)
+		if err == nil {
+			return removed, nil
+		}
+		if attempt+1 >= maxAttempts || !isRetryableSQLError(err) {
+			return nil, err
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(time.Duration(attempt+1) * 5 * time.Millisecond):
+		}
+	}
+}
+
+func (b *SQLBackend) pruneEntriesOnce(ctx context.Context, keep func(InventoryEntry) bool, recomputeHead func(survivors []InventoryEntry) []byte) ([]InventoryEntry, error) {
+	var removed []InventoryEntry
+	err := b.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+		removed = nil // reset so a retried transaction does not double-count
+
+		// Lock the presence marker to serialise with appends before reading rows.
+		if _, err := b.blobDataTx(ctx, tx, KeyInventory, true); err != nil {
+			return err
+		}
+
+		var rows []sqlInventoryRow
+		if err := tx.NewSelect().Model(&rows).Order("id ASC").Scan(ctx); err != nil {
+			return err
+		}
+
+		survivors := make([]InventoryEntry, 0, len(rows))
+		var removeIDs []int64
+		for _, r := range rows {
+			e := r.entry()
+			if keep(e) {
+				survivors = append(survivors, e)
+			} else {
+				removed = append(removed, e)
+				removeIDs = append(removeIDs, r.ID)
+			}
+		}
+		if len(removeIDs) == 0 {
+			return nil
+		}
+
+		if _, err := tx.NewDelete().Model((*sqlInventoryRow)(nil)).Where("id IN (?)", bun.List(removeIDs)).Exec(ctx); err != nil {
+			return err
+		}
+
+		if recomputeHead != nil {
+			return b.upsert(ctx, tx, &sqlBlob{
+				Key:        KeyInventoryHMAC,
+				Data:       recomputeHead(survivors),
+				Kind:       int(BlobPrivate),
+				ModifiedAt: time.Now(),
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return removed, nil
+}
+
 // --- KeyInventory blob shim ---
 //
 // A structured backend must still serve the KeyInventory logical key through

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -248,6 +248,115 @@ func (s *StorageService) ReadInventory(ctx context.Context) ([]byte, error) {
 	return s.backend.Get(ctx, KeyInventory)
 }
 
+// inventoryEntriesLocked returns every inventory entry in issuance order. On
+// InventoryStore backends it reads the structured rows; otherwise it parses the
+// rendered blob. Caller must hold inventoryMu (read or write).
+func (s *StorageService) inventoryEntriesLocked(ctx context.Context) ([]InventoryEntry, error) {
+	if store, ok := s.backend.(InventoryStore); ok {
+		return store.Entries(ctx)
+	}
+	data, err := s.readInventoryForHMAC(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var entries []InventoryEntry
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		if e, ok := parseInventoryEntry(line); ok {
+			entries = append(entries, e)
+		}
+	}
+	return entries, nil
+}
+
+// PruneInventory removes every inventory entry for which keep returns false,
+// rewriting the inventory and its integrity head together under the inventory
+// write lock. It returns the removed entries (in issuance order) so the caller
+// can act on them — drop their CRL revocations, invalidate caches, delete the
+// stored cert. When nothing is removed the inventory and head are left
+// untouched and (nil, nil) is returned.
+//
+// The current inventory integrity is verified before pruning, so a tampered
+// inventory surfaces ErrInventoryTampered rather than being silently rewritten.
+//
+// Concurrency: appends (AppendInventory) and reads (ReadInventory) take the same
+// inventoryMu, so within a process a prune never interleaves with them. The
+// rewrite is a single Backend.Put on KeyInventory, which structured backends
+// service as an atomic table replacement and blob backends as an atomic file
+// swap; callers needing cross-replica serialisation against revocation should
+// hold the cluster CRL lock around this (see ca.CA.CleanupExpiredCerts).
+func (s *StorageService) PruneInventory(ctx context.Context, keep func(InventoryEntry) bool) ([]InventoryEntry, error) {
+	s.inventoryMu.Lock()
+	defer s.inventoryMu.Unlock()
+
+	if s.hmacKey != nil {
+		if err := s.verifyInventoryHMACLocked(ctx, s.hmacKey); err != nil {
+			return nil, err
+		}
+	}
+
+	// Structured backends prune rows and rewrite the chained integrity head in a
+	// single transaction, so the two can never be observed out of sync across
+	// replicas (mirroring the atomic AppendEntry path).
+	if store, ok := s.backend.(InventoryStore); ok {
+		var recomputeHead func(survivors []InventoryEntry) []byte
+		if s.hmacKey != nil {
+			key := s.hmacKey
+			recomputeHead = func(survivors []InventoryEntry) []byte {
+				var head []byte
+				for _, e := range survivors {
+					head = chainInventoryMAC(key, head, canonicalInventoryLine(e))
+				}
+				return head
+			}
+		}
+		return store.PruneEntries(ctx, keep, recomputeHead)
+	}
+
+	// Blob backends: read, filter, and rewrite the whole inventory, then
+	// recompute the whole-blob HMAC. This matches their (non-atomic) append path
+	// and is correct for the single-node filesystem backend, the only blob
+	// backend without distributed appends.
+	entries, err := s.inventoryEntriesLocked(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	kept := make([]InventoryEntry, 0, len(entries))
+	var removed []InventoryEntry
+	for _, e := range entries {
+		if keep(e) {
+			kept = append(kept, e)
+		} else {
+			removed = append(removed, e)
+		}
+	}
+	if len(removed) == 0 {
+		return nil, nil
+	}
+
+	var buf strings.Builder
+	for _, e := range kept {
+		buf.WriteString(canonicalInventoryLine(e))
+		buf.WriteByte('\n')
+	}
+	if err := s.backend.Put(ctx, KeyInventory, []byte(buf.String()), BlobPrivate); err != nil {
+		return nil, fmt.Errorf("rewriting inventory: %w", err)
+	}
+
+	if s.hmacKey != nil {
+		if err := s.updateInventoryHMACLocked(ctx, s.hmacKey); err != nil {
+			// The inventory is already rewritten but the stored head now lags it;
+			// surface the failure so the operator/job can react rather than leave
+			// a mismatch that the next verify would flag as tampering.
+			return nil, fmt.Errorf("updating inventory HMAC after prune: %w", err)
+		}
+	}
+	return removed, nil
+}
+
 // TouchInventory creates an empty inventory blob if one does not already
 // exist. Called during CA bootstrap and import to seed the inventory.
 func (s *StorageService) TouchInventory(ctx context.Context) error {


### PR DESCRIPTION
## Summary

Adds an **opt-in background job** that periodically removes certificates which expired more than a configurable grace period ago. Removed certs are pruned from the **inventory** and the **CRL**, their stored signed certificate is deleted (only when its serial still matches, so a renewal under the same subject is preserved), and the in-memory serial index and OCSP cache are invalidated.

The job mirrors the existing CRL refresher: **disabled by default**, runs in the frontend process, and serialises on the cluster-wide CRL lock, so it is safe on any number of replicas — only the first to acquire the lock prunes per cycle.

## Inventory integrity across deletion

Deleting records means the inventory's integrity head must be rewritten:

- **Structured (SQL) backends:** a new `InventoryStore.PruneEntries` deletes the expired rows **and recomputes the chained integrity head in a single transaction** (locking the presence-marker row, exactly like `AppendEntry`). This prevents a cross-replica window where another replica's `ReadInventory` could compute the new head against a stale stored head and falsely report tampering.
- **Blob backends (filesystem):** rewrite the inventory and whole-blob HMAC under the inventory lock, matching their existing append path.

## Configuration

All disabled by default; defaults apply only when enabled.

| Config key | Env var | Default |
|---|---|---|
| `enable_expired_cert_cleanup` | `PUPPET_CA_ENABLE_EXPIRED_CERT_CLEANUP` | `false` |
| `expired_cert_retention_sec` | `PUPPET_CA_EXPIRED_CERT_RETENTION_SEC` | 30 days |
| `expired_cert_cleanup_interval_sec` | `PUPPET_CA_EXPIRED_CERT_CLEANUP_INTERVAL_SEC` | 24h |

## Behaviour notes

- Inventory entries with an unparseable `NotAfter` are conservatively **kept**, never dropped.
- Retention is a grace period measured from each certificate's `NotAfter`.

## Tests

- `internal/storage`: `PruneInventory` across **both** SQLite (atomic chain rewrite) and filesystem (blob) backends, asserting the integrity head verifies after a prune.
- `internal/ca`: `CleanupExpiredCerts` — removal from inventory/CRL/storage, retention grace, no-op when nothing expired, unparseable-`NotAfter` kept, and renewal preservation.
- `cmd/puppet-ca`: job runner startup/shutdown and config resolvers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)