### PR TITLE
ci(renovate): run go mod tidy after dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,9 @@
     "config:best-practices"
   ],
 
-  "rangeStrategy": "pin"
+  "rangeStrategy": "pin",
+
+  "postUpdateOptions": [
+    "gomodTidy"
+  ]
 }


### PR DESCRIPTION
## Problem

Renovate Go dependency PRs (e.g. #46) land an incomplete `go.sum` and fail every mage-based CI job with errors like:

```
magefile.go:44:2: missing go.sum entry for module providing package
  github.com/google/go-containerregistry/pkg/name
Error: error compiling magefiles
```

Renovate's default Go update runs the equivalent of `go get`, which only writes `go.sum` entries for packages reachable in the default build. `magefile.go` is behind a `//go:build mage` constraint, so modules imported solely from it (here `go-containerregistry`) never get their `h1:` module-zip hash written. CI then compiles the magefiles, needs that hash, and fails.

## Fix

Enable the `gomodTidy` post-update option so Renovate runs `go mod tidy` after each update. `go mod tidy` walks all build tags and writes complete `go.sum` entries.

This applies to future Renovate PRs; existing open PRs (such as #46) need a rebase/recreate to pick up the corrected `go.sum`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)