### PR TITLE
Pin OpenVox Server to a working version

### DIFF
--- a/compose-migration.yml
+++ b/compose-migration.yml
@@ -25,7 +25,7 @@ services:
 
   # -- Old Puppet Server (OpenVox Server, JVM) -------------------------------
   old-puppet:
-    image: ghcr.io/openvoxproject/openvoxserver:latest
+    image: ghcr.io/openvoxproject/openvoxserver:8.13.0-main@sha256:c49843bd94e4caae5e23fcf790afb28a44629ac55f99db489df77cab7fa0b77c
     hostname: old-puppet
     environment:
       OPENVOXSERVER_HOSTNAME: old-puppet


### PR DESCRIPTION
Recent versions of the openvoxserver image have made significant changes to the container layout which unfortunately breaks our tests with errors like the following:

```
Attaching to old-puppet-1, test-runner-1
old-puppet-1   | Entrypoint PID 7
old-puppet-1   | Running /container-custom-entrypoint.d/pre-default/00-fix-cadir-ownership.sh
old-puppet-1   | chown: changing ownership of '/etc/puppetlabs/puppetserver/ca': Operation not permitted (os error 1)
Aborting on container exit...
```

This works around the problem for the time being.