### PR TITLE
ci(renovate): pin GitHub Action digests to full semver

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
 
   "extends": [
-    "config:best-practices"
+    "config:best-practices",
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
 
   "rangeStrategy": "pin",


### PR DESCRIPTION
## What

Extend Renovate with the `helpers:pinGitHubActionDigestsToSemver` preset so that the version comment beside each pinned GitHub Action digest carries the full semver (e.g. `# v7.0.0`) instead of the major-only tag (e.g. `# v7`).

## Why

`config:best-practices` already pins Action digests via `helpers:pinGitHubActionDigests`, but it keeps the trailing comment at whatever precision the tag was written with — so an update to `actions/checkout@v7` lands as `…@<sha> # v7`. The `…ToSemver` variant adds an `extractVersion`/`versioning` pair so the comment is maintained at full semver, making it clear exactly which release a digest corresponds to.

## Notes

- Applies going forward: existing major-only comments are rewritten the next time each action gets an update PR (or when re-pinned manually).
- Actions that only publish a major tag won't gain a fuller comment, since the semver extraction won't match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)