### PR TITLE
chore(compose): pin registry images to full versions

### DIFF
--- a/compose-backends-mysql.yml
+++ b/compose-backends-mysql.yml
@@ -14,7 +14,7 @@ name: openvox-ca-backends-mysql
 
 services:
   mysql:
-    image: docker.io/mysql:8
+    image: docker.io/mysql:8.4.10
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: puppetca

--- a/compose-backends-postgres.yml
+++ b/compose-backends-postgres.yml
@@ -13,7 +13,7 @@ name: openvox-ca-backends-postgres
 
 services:
   postgres:
-    image: docker.io/postgres:16-alpine
+    image: docker.io/postgres:16.14-alpine
     environment:
       POSTGRES_USER: puppetca
       POSTGRES_PASSWORD: puppetca

--- a/compose-backends-redis-go.yml
+++ b/compose-backends-redis-go.yml
@@ -15,7 +15,7 @@ name: openvox-ca-backends-redis-go
 
 services:
   redis:
-    image: docker.io/redis:7-alpine
+    image: docker.io/redis:7.4.9-alpine
     ports:
       # Host 56379 -> container 6379, matching PUPPET_CA_TEST_REDIS_ADDR used by
       # the mage target. Distinct from any other compose stack's mappings.

--- a/compose-backends-redis.yml
+++ b/compose-backends-redis.yml
@@ -37,7 +37,7 @@ services:
 
   # -- Redis (CA storage backend) -----------------------------------------─
   redis:
-    image: docker.io/redis:7-alpine
+    image: docker.io/redis:7.4.9-alpine
     hostname: redis
     # Redis 7 default config is fine: standalone, no auth, in-memory only.
     # The integration test does not require persistence -- if the redis
@@ -172,7 +172,7 @@ services:
 
   # -- PostgreSQL backend for OpenVoxDB -----------------------------------
   postgres:
-    image: docker.io/postgres:17-alpine
+    image: docker.io/postgres:17.10-alpine
     hostname: postgres
     environment:
       POSTGRES_DB: openvoxdb
@@ -188,7 +188,7 @@ services:
 
   # -- OpenVoxDB (PuppetDB) -----------------------------------------------
   openvoxdb:
-    image: ghcr.io/openvoxproject/openvoxdb:latest
+    image: ghcr.io/openvoxproject/openvoxdb:8.14.0
     hostname: openvoxdb
     environment:
       USE_OPENVOXSERVER: "true"

--- a/compose-bench.yml
+++ b/compose-bench.yml
@@ -41,7 +41,7 @@ services:
 
   # -- k6 load runner --------------------------------------------------------
   k6:
-    image: grafana/k6:latest
+    image: grafana/k6:2.0.0
     tty: true       # allocate a PTY so k6 uses its live updating progress display
     command:
       - run

--- a/compose-puppet.yml
+++ b/compose-puppet.yml
@@ -90,7 +90,7 @@ services:
 
   # -- PostgreSQL backend for OpenVoxDB ------------------------------------
   postgres:
-    image: docker.io/postgres:17-alpine
+    image: docker.io/postgres:17.10-alpine
     hostname: postgres
     environment:
       POSTGRES_DB: openvoxdb
@@ -106,7 +106,7 @@ services:
 
   # -- OpenVoxDB (PuppetDB) ------------------------------------------------
   openvoxdb:
-    image: ghcr.io/openvoxproject/openvoxdb:latest
+    image: ghcr.io/openvoxproject/openvoxdb:8.14.0
     hostname: openvoxdb
     environment:
       USE_OPENVOXSERVER: "true"

--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,15 @@
 
   "postUpdateOptions": [
     "gomodTidy"
+  ],
+
+  "packageRules": [
+    {
+      "description": "openvox-ca-integ is built locally by mage and not published to any registry",
+      "matchPackageNames": [
+        "openvox-ca-integ"
+      ],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
## What

Expand the coarse image tags in the compose files to full versions, and stop Renovate from churning on the locally-built image.

| Image | Before | After |
| --- | --- | --- |
| mysql | `8` | `8.4.10` |
| postgres (16) | `16-alpine` | `16.14-alpine` |
| postgres (17) | `17-alpine` | `17.10-alpine` |
| redis | `7-alpine` | `7.4.9-alpine` |
| openvoxdb | `latest` | `8.14.0` |
| grafana/k6 | `latest` | `2.0.0` |

The mysql/postgres/redis versions were resolved by digest-matching the tag each coarse tag currently points to on Docker Hub, so this is a no-op in image content while making the version explicit. `openvoxdb` and `k6` move off `latest` to a fixed release.

> [!NOTE]
> `grafana/k6:2.0.0` is the current newest stable, a new major versus the rolling `latest` the bench harness was on.

## Renovate

Adds a `packageRules` entry disabling updates for `openvox-ca-integ`, which is built locally by mage and not published to any registry, so Renovate won't try to manage it.

This pairs with #52 (full-semver comments on pinned Action digests) but is kept as a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)