### PR TITLE
Fix postgres tmpfs mount for PostgreSQL 18+

### DIFF
--- a/compose-backends-postgres.yml
+++ b/compose-backends-postgres.yml
@@ -28,4 +28,7 @@ services:
       retries: 30
     tmpfs:
       # Ephemeral storage: the test database never needs to survive a restart.
-      - /var/lib/postgresql/data
+      # Mount the whole /var/lib/postgresql tree: postgres 18+ stores data in a
+      # major-version-specific subdirectory and refuses to start if it finds an
+      # "unused" mount at the old /var/lib/postgresql/data path.
+      - /var/lib/postgresql


### PR DESCRIPTION
## Problem

The PostgreSQL 18 Docker image stores its data in a major-version-specific subdirectory under `/var/lib/postgresql` and **refuses to start** if it finds an "unused" mount/volume at the old `/var/lib/postgresql/data` path (see [docker-library/postgres#1259](https://github.com/docker-library/postgres/pull/1259)):

```
Error: in 18+, these Docker images are configured to store database data in a
       format which is compatible with "pg_ctlcluster" ...
       Counter to that, there appears to be PostgreSQL data in:
         /var/lib/postgresql/data (unused mount/volume)
```

`compose-backends-postgres.yml` mounts an ephemeral tmpfs at `/var/lib/postgresql/data`, so the **Storage backend tests (PostgreSQL)** job fails the moment the image is bumped to 18.x. This blocks #63 (Renovate: `docker.io/postgres` → v18).

The other two postgres services (`compose-puppet.yml`, `compose-backends-redis.yml`) have no data mount — only an init-script mount — so they are unaffected.

## Fix

Move the tmpfs mount up to `/var/lib/postgresql` so postgres 18+ can lay out its own subdirectory. Verified locally that `postgres:18.4-alpine` starts and becomes ready in ~2s with this mount.

This is split out as a standalone fix so #63 can merge cleanly once it picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)