### PR TITLE
Don't pin CentOS Stream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ---- Build Stage ----
-FROM quay.io/centos/centos:stream10@sha256:7a900af2eda5734d920204da916648821ca6525fd3f06db0606f63cd87017b12 AS builder
+FROM quay.io/centos/centos:stream10 AS builder
 
 RUN dnf install -y golang git && dnf clean all
 
@@ -15,7 +15,7 @@ RUN GOTOOLCHAIN=auto CGO_ENABLED=0 GOOS=linux \
     go build -ldflags="-s -w" -o /openvox-ca-ctl ./cmd/openvox-ca-ctl/
 
 # ---- Runtime Stage ----
-FROM quay.io/centos/centos:stream10@sha256:7a900af2eda5734d920204da916648821ca6525fd3f06db0606f63cd87017b12
+FROM quay.io/centos/centos:stream10
 
 # curl: health checks and agent CSR submission
 # openssl: CSR generation and cert verification in integration tests

--- a/Dockerfile.run
+++ b/Dockerfile.run
@@ -10,7 +10,7 @@
 # Integration test targets (mage test:integCompose, etc.) handle
 # both steps automatically.
 
-FROM quay.io/centos/centos:stream10@sha256:7a900af2eda5734d920204da916648821ca6525fd3f06db0606f63cd87017b12
+FROM quay.io/centos/centos:stream10
 
 # curl: health checks and agent CSR submission
 # openssl: CSR generation and cert verification in integration tests

--- a/docker/puppet/Dockerfile
+++ b/docker/puppet/Dockerfile
@@ -7,7 +7,7 @@
 # The entrypoint.sh bootstraps TLS certificates from the Go CA, configures
 # webserver.conf and puppet.conf, then starts `puppetserver foreground`.
 
-FROM quay.io/centos/centos:stream10@sha256:7a900af2eda5734d920204da916648821ca6525fd3f06db0606f63cd87017b12
+FROM quay.io/centos/centos:stream10
 
 # Install OpenVox Server + PuppetDB terminus + runtime tools.
 RUN dnf -y install https://yum.voxpupuli.org/openvox8-release-el-10.noarch.rpm && \

--- a/docker/puppet/Dockerfile.client
+++ b/docker/puppet/Dockerfile.client
@@ -4,7 +4,7 @@
 # curl, and openssl.  The entrypoint keeps the container alive so the host-side
 # test script can drive it with `$engine exec`.
 
-FROM quay.io/centos/centos:stream10@sha256:7a900af2eda5734d920204da916648821ca6525fd3f06db0606f63cd87017b12
+FROM quay.io/centos/centos:stream10
 
 RUN dnf -y install https://yum.voxpupuli.org/openvox8-release-el-10.noarch.rpm && \
     dnf -y install openvox-agent curl openssl && \

--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,13 @@
         "openvox-ca-integ"
       ],
       "enabled": false
+    },
+    {
+      "description": "Don't pin CentOS Stream, old digests aren't retained after updates",
+      "matchPackageNames": [
+        "quay.io/centos/centos"
+      ],
+      "rangeStrategy": "auto"
     }
   ]
 }


### PR DESCRIPTION
Old digests aren't retained after updates, so anything that pins an old digest breaks until the digest is bumped. Instead we have to take CentOS Stream for what it is: a moving target.