### PR TITLE
Add 2-day minimum release age for dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
   ],
 
   "rangeStrategy": "pin",
+  "minimumReleaseAge": "2 days",
 
   "postUpdateOptions": [
     "gomodTidy"


### PR DESCRIPTION
## Summary

Configure Renovate to hold back dependency updates until they are at least 2 days old, avoiding freshly published versions that may be yanked or hotfixed shortly after release. This mirrors the spirit of Renovate's npm `unpublishSafe` behaviour, applied across all datasources.

## Behaviour

- Applies to all datasources (Go modules, Docker tags, GitHub Actions, etc.).
- Uses the default `internalChecksFilter: strict` (from `config:best-practices`), so pending-age updates still appear in the **Dependency Dashboard** under "Pending Status Checks" and can be promoted to a PR early on demand when it makes sense.
- Digest-only re-pins are unaffected, since they have no meaningful release date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)