### PR TITLE
Track mage and golangci-lint versions via Renovate custom manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,18 @@
       ],
       "depNameTemplate": "github.com/magefile/mage",
       "datasourceTemplate": "go"
+    },
+    {
+      "customType": "regex",
+      "description": "Update golangci-lint version pinned via 'go install' in GitHub Actions workflows",
+      "managerFilePatterns": [
+        "/^\\.github/workflows/.*\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "go install github\\.com/golangci/golangci-lint/v2/cmd/golangci-lint@(?<currentValue>v\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "github.com/golangci/golangci-lint/v2",
+      "datasourceTemplate": "go"
     }
   ],
 

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,21 @@
     "gomodTidy"
   ],
 
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update mage version pinned via 'go install' in GitHub Actions workflows",
+      "managerFilePatterns": [
+        "/^\\.github/workflows/.*\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "go install github\\.com/magefile/mage@(?<currentValue>v\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "github.com/magefile/mage",
+      "datasourceTemplate": "go"
+    }
+  ],
+
   "packageRules": [
     {
       "description": "openvox-ca-integ is built locally by mage and not published to any registry",


### PR DESCRIPTION
## Summary
- `go install github.com/magefile/mage@v1.15.0` and `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2` are pinned across GitHub Actions workflow steps in `ci.yml` and `release.yml`, but Renovate had no manager configured to detect or bump either version.
- Add two `customManagers` regex entries to `renovate.json`, one per tool, that match the pinned version in any `.github/workflows/*.yml` file and track it against the `go` datasource for the respective module (`github.com/magefile/mage` and `github.com/golangci/golangci-lint/v2`).

## Test plan
- [x] `gofmt`/`golangci-lint` pre-commit hooks passed
- [x] `go test ./...` passed via pre-push hook
- [ ] Confirm Renovate picks up both dependencies and opens version-bump PRs once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)