### PR TITLE
ci: add fan-in "CI success" job for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,3 +255,29 @@ jobs:
         env:
           MAGE_TARGET: ${{ matrix.mage_target }}
         run: mage "$MAGE_TARGET"
+
+  # -- Aggregate result ---------------------------------------------------------
+  # Single fan-in job so branch protection only has to name one required check,
+  # instead of every matrix leg above (which would also have to be updated by
+  # hand each time a leg is added/renamed/removed).
+  ci:
+    name: CI success
+    if: always()
+    needs:
+      - check
+      - hadolint
+      - unit
+      - puppet
+      - migration
+      - backends-redis
+      - backends-redis-go
+      - backends-postgres
+      - backends-mysql
+      - backends-etcd
+      - compose
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Summary
- The "Main" ruleset currently has no `required_status_checks` rule, so a PR can be merged even if every CI job is red (only reviews/signatures/CodeQL/code-quality are gated today).
- Add a single `ci` job (`name: CI success`) that `needs:` every other job in this workflow and reports pass/fail via [`re-actors/alls-green`](https://github.com/re-actors/alls-green), following the same fan-in pattern used in [voxpupuli/gha-puppet's `beaker.yml`](https://github.com/voxpupuli/gha-puppet/blob/v4/.github/workflows/beaker.yml#L177-L183).
- This makes branch protection only need to name **one** required check, instead of all 17 individual matrix legs (which would also need hand-updating every time a leg is added/renamed/removed).

This PR only wires up the workflow side. Once merged, an org admin still needs to add `CI success` as a required status check on the `Main` ruleset — I don't have admin on this repo to do that myself.

## Test plan
- [x] Confirm the `CI success` check appears on this PR and only goes green once all other jobs succeed
- [x] After merge, an admin adds `CI success` to the `Main` ruleset's required status checks