### PR TITLE
fix: statically link openvox-ca-ctl in container builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ COPY go.mod go.sum ./
 RUN GOTOOLCHAIN=auto go mod download
 
 COPY . .
-RUN GOTOOLCHAIN=auto CGO_ENABLED=0 GOOS=linux \
-    go build -ldflags="-s -w" -o /openvox-ca     ./cmd/openvox-ca/ && \
+ENV GOTOOLCHAIN=auto CGO_ENABLED=0 GOOS=linux
+RUN go build -ldflags="-s -w" -o /openvox-ca     ./cmd/openvox-ca/ && \
     go build -ldflags="-s -w" -o /openvox-ca-ctl ./cmd/openvox-ca-ctl/
 
 # ---- Runtime Stage ----

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -6,8 +6,8 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux \
-    go build -ldflags="-s -w" -o /openvox-ca     ./cmd/openvox-ca/ && \
+ENV CGO_ENABLED=0 GOOS=linux
+RUN go build -ldflags="-s -w" -o /openvox-ca     ./cmd/openvox-ca/ && \
     go build -ldflags="-s -w" -o /openvox-ca-ctl ./cmd/openvox-ca-ctl/
 
 # ---- Runtime Stage ----


### PR DESCRIPTION
## Summary
- `openvox-ca-ctl` was being built with cgo enabled and dynamically linked against glibc, because the `RUN CGO_ENABLED=0 GOOS=linux go build ... && go build ...` shell chain only applies the env var prefix to the first command
- This broke `openvox-ca-ctl` entirely on the Alpine image (musl libc, no glibc present): `ash: /usr/local/bin/openvox-ca-ctl: not found` when the dynamic loader path doesn't exist
- On the CentOS image it happened to still run (glibc is present there), but was silently inconsistent with `openvox-ca` and used glibc's NSS resolver instead of Go's pure resolver
- Fix: hoist `CGO_ENABLED`/`GOOS`(/`GOTOOLCHAIN`) into a Dockerfile `ENV` instruction so both `go build` invocations in the `RUN` pick them up

## Test plan
- [x] Built `Dockerfile.alpine` before the fix and confirmed `openvox-ca-ctl` was dynamically linked (`ldd` showed `libc.so.6`) while `openvox-ca` was static
- [x] Built `Dockerfile` (CentOS) before the fix and confirmed the same discrepancy
- [x] Rebuilt both images after the fix and confirmed both binaries report "not a dynamic executable" / "Not a valid dynamic program"
- [x] Ran `openvox-ca-ctl --help` in the rebuilt Alpine image successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)