### PR TITLE
ci(renovate): allow bumping the go directive in go.mod

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -54,6 +54,19 @@
         "quay.io/centos/centos"
       ],
       "pinDigests": false
+    },
+    {
+      "description": "Allow Renovate to bump the 'go' directive in go.mod",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchDepNames": [
+        "go"
+      ],
+      "matchDepTypes": [
+        "golang"
+      ],
+      "rangeStrategy": "bump"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Renovate leaves the `go` directive in go.mod alone by default (it only proposes updates to a `toolchain` line, which we don't have)
- Add a packageRule so Renovate also proposes bumps to the `go` version directive itself

## Test plan
- [ ] Confirm Renovate opens a PR bumping the `go` directive next time a newer Go release is available