### PR TITLE
fix(storage): let OverlayBackend's InventoryStore capability show through

### DIFF
--- a/docs/inventory-store.md
+++ b/docs/inventory-store.md
@@ -146,6 +146,13 @@ recomputes the destination's integrity head from its entries
 - **Filesystem, etcd, redis/valkey keep the blob.** They do not implement the
   interface; the type assertion fails and they behave exactly as before. Adding
   the capability to etcd/redis later is possible but not currently motivated.
+- **Wrapper backends unwrap to their base.** The probe is `asInventoryStore`,
+  not a bare `s.backend.(InventoryStore)`: it sees through wrappers such as
+  `OverlayBackend` (the `ca_cert_file`/`ca_key_file` local-override wrapper) via
+  their `Unwrap()` method, so a SQL backend underneath keeps its hash-chain
+  scheme rather than being downgraded to the whole-blob HMAC. Overriding only
+  the cert/key blobs never touches the inventory, so consulting the base is
+  always correct.
 - **OCSP is untouched**: the in-memory serial index is still built at startup
   and updated on signing.
 

--- a/docs/storage-backends.md
+++ b/docs/storage-backends.md
@@ -746,6 +746,19 @@ ca_key_file:  /etc/puppet-ca/secrets/ca_key.pem
 This override also works with the filesystem backend, e.g. to pull the CA
 key out of the cadir tree and onto a separately-mounted volume.
 
+> **Upgrading a pre-fix `ca_key_file` / `ca_cert_file` + database deployment.**
+> Builds from before the InventoryStore-unwrap fix computed the inventory
+> integrity value under the whole-blob HMAC scheme when a local cert/key
+> override wrapped a SQL backend, instead of that backend's hash chain. The
+> first start after upgrading such a deployment reports `ErrInventoryTampered`
+> even though nothing was tampered with — only the *scheme* changed, not the
+> data. The inventory rows are intact, so recompute the integrity head by
+> running `openvox-ca-ctl migrate` from the affected backend into a fresh
+> destination (the migration rewrites the head under the correct scheme; a
+> store cannot be migrated onto itself) and then serve from that destination.
+> This affects pre-release builds only; deployments created after the fix are
+> unaffected.
+
 ---
 
 ## Migrating between backends

--- a/internal/storage/backend.go
+++ b/internal/storage/backend.go
@@ -211,6 +211,27 @@ type InventoryStore interface {
 	PruneEntries(ctx context.Context, keep func(InventoryEntry) bool, recomputeHead func(survivors []InventoryEntry) []byte) ([]InventoryEntry, error)
 }
 
+// asInventoryStore probes b for the InventoryStore capability, unwrapping
+// wrapper backends (e.g. OverlayBackend) that don't implement InventoryStore
+// themselves but delegate KeyInventory to a base backend that does. Without
+// this, wrapping a SQL backend in OverlayBackend (e.g. via ca_cert_file/
+// ca_key_file) would silently downgrade its integrity scheme from the O(1)
+// hash chain to a whole-blob HMAC: StorageService picks the scheme via this
+// same type assertion in several places, and computing it one way while a
+// previously stored value used the other reads back as tampering.
+func asInventoryStore(b Backend) (InventoryStore, bool) {
+	for {
+		if store, ok := b.(InventoryStore); ok {
+			return store, true
+		}
+		unwrapper, ok := b.(interface{ Unwrap() Backend })
+		if !ok {
+			return nil, false
+		}
+		b = unwrapper.Unwrap()
+	}
+}
+
 // Locker is an optional Backend capability that provides a cross-node
 // distributed mutex. Backends implement it when they have a natural way
 // to coordinate a lock across replicas (etcd's concurrency.Mutex, Redis

--- a/internal/storage/overlay.go
+++ b/internal/storage/overlay.go
@@ -195,6 +195,15 @@ func (o *OverlayBackend) BaseDir() string {
 	return ""
 }
 
+// Unwrap returns the wrapped base backend, letting capability checks that
+// don't have their own OverlayBackend forwarding method (e.g. InventoryStore)
+// see through the wrapper to the concrete backend beneath it. Overriding only
+// KeyCACert/KeyCAKey never touches the inventory, so it is always correct for
+// such a check to consult base directly.
+func (o *OverlayBackend) Unwrap() Backend {
+	return o.base
+}
+
 // AcquireLock delegates to the base backend's Locker implementation when
 // present. Locks must span the whole cluster (e.g. "bootstrap" must serialise
 // across replicas even when the CA key sits on a local file), so it is the

--- a/internal/storage/sql_inventory_test.go
+++ b/internal/storage/sql_inventory_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -183,5 +184,61 @@ var _ = Describe("InventoryMigrationRoundTrip", func() {
 		Expect(dst.InitHMAC(ctx)).NotTo(HaveOccurred(), "fs integrity after round-trip")
 		got, _ = dst.ReadInventory(ctx)
 		Expect(got).To(Equal(srcText), "round-tripped inventory")
+	})
+})
+
+// InventoryMigrationRoundTripOverlayDestination reproduces a real-world
+// "puppet-ca-ctl migrate" report: `migrate --dest-config` pointed at a plain
+// PostgreSQL config (no local overrides), but the actual server config kept
+// the CA key on local disk via ca_key_file — a common hardening choice, and
+// one the migrate config has no reason to mirror since migrate never touches
+// per-subject keys either. Both configs describe the very same database.
+//
+// After migrating, starting the server against ca_key_file failed with
+// ErrInventoryTampered on the very first boot. OverlayBackend (which
+// ca_key_file wraps the backend in) does not implement InventoryStore itself,
+// so the type assertion StorageService uses to pick the integrity scheme
+// failed on the wrapper even though the wrapped SQL backend supports the hash
+// chain. The server fell back to a whole-blob HMAC, which did not match the
+// hash-chain value RebuildInventoryHMAC had written into the same database
+// right after the copy (via the non-overlay migrate config).
+var _ = Describe("InventoryMigrationRoundTripOverlayDestination", func() {
+	It("lets a ca_key_file server start after migrate used a config without local overrides", func() {
+		ctx := context.Background()
+
+		src := New(GinkgoT().TempDir())
+		Expect(src.EnsureDirs(ctx)).NotTo(HaveOccurred(), "EnsureDirs")
+		Expect(src.SaveCACert(ctx, []byte("ca-cert-pem"))).NotTo(HaveOccurred(), "SaveCACert")
+		Expect(src.TouchInventory(ctx)).NotTo(HaveOccurred(), "TouchInventory")
+		Expect(src.InitHMAC(ctx)).NotTo(HaveOccurred(), "InitHMAC")
+		for _, line := range sampleInventoryLines {
+			Expect(src.AppendInventory(ctx, line)).NotTo(HaveOccurred(), "AppendInventory")
+		}
+
+		// migrate --dest-config: a bare SQL backend, no local overrides.
+		dsn := "file:" + filepath.Join(GinkgoT().TempDir(), "ca.db")
+		migrateBackend, err := NewSQLBackend(SQLConfig{Dialect: SQLitePure, DSN: dsn})
+		Expect(err).NotTo(HaveOccurred(), "NewSQLBackend (migrate)")
+		migrateDst := NewWithBackend(migrateBackend, "")
+		_, err = MigrateService(ctx, src, migrateDst, MigrateOptions{})
+		Expect(err).NotTo(HaveOccurred(), "MigrateService fs->sqlite")
+		Expect(migrateBackend.Close()).To(Succeed())
+
+		// The real server's config: the same database, but wrapped in
+		// OverlayBackend because ca_key_file is set. A brand-new connection,
+		// exactly like the separate signer process the launcher spawns.
+		serverBackend, err := NewSQLBackend(SQLConfig{Dialect: SQLitePure, DSN: dsn})
+		Expect(err).NotTo(HaveOccurred(), "NewSQLBackend (server)")
+		defer serverBackend.Close()
+		overlay, err := NewOverlayBackend(serverBackend, map[string]string{
+			KeyCAKey: filepath.Join(GinkgoT().TempDir(), "ca_key.pem"),
+		})
+		Expect(err).NotTo(HaveOccurred(), "NewOverlayBackend")
+		server := NewWithBackend(overlay, GinkgoT().TempDir())
+
+		// This is the exact call the CA signer process makes on every start
+		// (internal/ca/init.go Init -> InitHMAC -> VerifyInventoryHMAC). It
+		// must succeed, not report ErrInventoryTampered.
+		Expect(server.InitHMAC(ctx)).NotTo(HaveOccurred(), "InitHMAC on ca_key_file server after migrate")
 	})
 })

--- a/internal/storage/sql_inventory_test.go
+++ b/internal/storage/sql_inventory_test.go
@@ -188,7 +188,7 @@ var _ = Describe("InventoryMigrationRoundTrip", func() {
 })
 
 // InventoryMigrationRoundTripOverlayDestination reproduces a real-world
-// "puppet-ca-ctl migrate" report: `migrate --dest-config` pointed at a plain
+// "openvox-ca-ctl migrate" report: `migrate --dest-config` pointed at a plain
 // PostgreSQL config (no local overrides), but the actual server config kept
 // the CA key on local disk via ca_key_file — a common hardening choice, and
 // one the migrate config has no reason to mirror since migrate never touches
@@ -241,11 +241,11 @@ var _ = Describe("InventoryMigrationRoundTripOverlayDestination", func() {
 		// must succeed, not report ErrInventoryTampered.
 		Expect(server.InitHMAC(ctx)).NotTo(HaveOccurred(), "InitHMAC on ca_key_file server after migrate")
 
-		// Reading back through the same overlay-wrapped server exercises two
-		// further asInventoryStore unwrap sites (inventoryEntriesLocked via
-		// ReadInventory, and LatestSerialForSubject) and confirms the inventory
-		// is served correctly through the wrapper, not merely that InitHMAC did
-		// not error.
+		// Reading back through the same overlay-wrapped server re-exercises the
+		// asInventoryStore unwrap: ReadInventory re-runs computeInventoryHMAC (via
+		// verifyInventoryHMACLocked), and LatestSerialForSubject takes its own
+		// indexed-lookup unwrap site. Together they confirm the inventory is served
+		// correctly through the wrapper, not merely that InitHMAC did not error.
 		srcText, err := src.ReadInventory(ctx)
 		Expect(err).NotTo(HaveOccurred(), "ReadInventory(src)")
 		got, err := server.ReadInventory(ctx)

--- a/internal/storage/sql_inventory_test.go
+++ b/internal/storage/sql_inventory_test.go
@@ -240,5 +240,20 @@ var _ = Describe("InventoryMigrationRoundTripOverlayDestination", func() {
 		// (internal/ca/init.go Init -> InitHMAC -> VerifyInventoryHMAC). It
 		// must succeed, not report ErrInventoryTampered.
 		Expect(server.InitHMAC(ctx)).NotTo(HaveOccurred(), "InitHMAC on ca_key_file server after migrate")
+
+		// Reading back through the same overlay-wrapped server exercises two
+		// further asInventoryStore unwrap sites (inventoryEntriesLocked via
+		// ReadInventory, and LatestSerialForSubject) and confirms the inventory
+		// is served correctly through the wrapper, not merely that InitHMAC did
+		// not error.
+		srcText, err := src.ReadInventory(ctx)
+		Expect(err).NotTo(HaveOccurred(), "ReadInventory(src)")
+		got, err := server.ReadInventory(ctx)
+		Expect(err).NotTo(HaveOccurred(), "ReadInventory through overlay")
+		Expect(got).To(Equal(srcText), "inventory read back through overlay")
+
+		serial, err := server.LatestSerialForSubject(ctx, "node1")
+		Expect(err).NotTo(HaveOccurred(), "LatestSerialForSubject(node1) through overlay")
+		Expect(serial).To(Equal("0003"), "latest serial for node1 through overlay")
 	})
 })

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -924,6 +924,17 @@ func (s *StorageService) verifyInventoryHMACLocked(ctx context.Context, hmacKey 
 	}
 
 	if !hmac.Equal(storedMAC, computedMAC) {
+		// Name the integrity scheme we computed under. A mismatch usually means
+		// genuine tampering, but it also fires when a backend is served under a
+		// different scheme than the stored value was written with (e.g. a
+		// ca_key_file/ca_cert_file server on a build before the InventoryStore
+		// unwrap fix stored a whole-blob HMAC over what is now read as a hash
+		// chain). Surfacing the scheme lets an operator tell the two apart.
+		scheme := "whole-blob-hmac"
+		if _, ok := asInventoryStore(s.backend); ok {
+			scheme = "hash-chain"
+		}
+		slog.Warn("inventory HMAC mismatch; integrity check failed", "scheme", scheme)
 		return ErrInventoryTampered
 	}
 	return nil

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -199,7 +199,7 @@ func (s *StorageService) AppendInventory(ctx context.Context, entry string) erro
 		return fmt.Errorf("malformed inventory entry %q", entry)
 	}
 
-	if store, ok := s.backend.(InventoryStore); ok {
+	if store, ok := asInventoryStore(s.backend); ok {
 		var newHead func(prev []byte) []byte
 		if s.hmacKey != nil {
 			key := s.hmacKey
@@ -293,7 +293,7 @@ func (s *StorageService) SerialExists(ctx context.Context, serial string) (bool,
 // inventory blob (verifying its HMAC first, via ReadInventory). Wraps
 // os.ErrNotExist when the subject has no entry.
 func (s *StorageService) LatestSerialForSubject(ctx context.Context, subject string) (string, error) {
-	if store, ok := s.backend.(InventoryStore); ok {
+	if store, ok := asInventoryStore(s.backend); ok {
 		s.inventoryMu.RLock()
 		defer s.inventoryMu.RUnlock()
 		return store.LatestSerialForSubject(ctx, subject)
@@ -322,7 +322,7 @@ func (s *StorageService) ReadInventory(ctx context.Context) ([]byte, error) {
 // InventoryStore backends it reads the structured rows; otherwise it parses the
 // rendered blob. Caller must hold inventoryMu (read or write).
 func (s *StorageService) inventoryEntriesLocked(ctx context.Context) ([]InventoryEntry, error) {
-	if store, ok := s.backend.(InventoryStore); ok {
+	if store, ok := asInventoryStore(s.backend); ok {
 		return store.Entries(ctx)
 	}
 	data, err := s.readInventoryForHMAC(ctx)
@@ -370,7 +370,7 @@ func (s *StorageService) PruneInventory(ctx context.Context, keep func(Inventory
 	// Structured backends prune rows and rewrite the chained integrity head in a
 	// single transaction, so the two can never be observed out of sync across
 	// replicas (mirroring the atomic AppendEntry path).
-	if store, ok := s.backend.(InventoryStore); ok {
+	if store, ok := asInventoryStore(s.backend); ok {
 		var recomputeHead func(survivors []InventoryEntry) []byte
 		if s.hmacKey != nil {
 			key := s.hmacKey
@@ -750,7 +750,7 @@ func (s *StorageService) EnsureHMACKey(ctx context.Context) ([]byte, error) {
 // missing blob hashes the same as an empty one.
 // Caller must hold inventoryMu.
 func (s *StorageService) computeInventoryHMAC(ctx context.Context, hmacKey []byte) ([]byte, error) {
-	if store, ok := s.backend.(InventoryStore); ok {
+	if store, ok := asInventoryStore(s.backend); ok {
 		entries, err := store.Entries(ctx)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
- `OverlayBackend` (used whenever `ca_cert_file`/`ca_key_file` is configured) wraps its base backend in a plain field rather than embedding it, so it never satisfied `InventoryStore` itself even when the SQL backend beneath it does.
- `StorageService` picks its inventory-integrity scheme (O(1) hash chain vs. whole-blob HMAC) via a type assertion on `s.backend`, so wrapping a SQL backend silently downgraded it to the whole-blob scheme.
- This only becomes visible once two callers disagree on the scheme for the same database: `openvox-ca-ctl migrate` has no reason to set `ca_cert_file`/`ca_key_file` (it never touches per-subject keys), so it writes a hash-chain baseline via `RebuildInventoryHMAC`. A server configured with `ca_key_file` then opens the same database through `OverlayBackend`, falls back to a whole-blob HMAC, and fails to start with `inventory file integrity check failed: HMAC mismatch (possible tampering)`.
- Fix: add `OverlayBackend.Unwrap()` and an `asInventoryStore()` helper that walks through wrapper backends before the capability check, used at every call site that previously asserted `s.backend.(InventoryStore)` directly.

Reproduced end-to-end against real Redis + PostgreSQL containers driving the actual `openvox-ca`/`openvox-ca-ctl` binaries (same error text as reported), then distilled into a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)