### PR TITLE
Revert "chore(deps): update go module directive to v1.26.5"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/voxpupuli/openvox-ca
 
-go 1.26.5
+go 1.26.4
 
 require (
 	github.com/alicebob/miniredis/v2 v2.38.0


### PR DESCRIPTION
Reverts voxpupuli/openvox-ca#100

This broke the Alpine container builds. Oops!