### PR TITLE
ci(container): always build images on pull requests

### DIFF
--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -8,13 +8,13 @@ name: Container images
 #   * Push to main            -> build + push the rolling "edge" (and "main") tags.
 #   * Release tags (v*)        -> build + push versioned + latest tags.
 #   * Manual (workflow_dispatch) -> build, push only if the "push" input is set.
-#   * Pull requests, on demand -> apply the "build-images" label to a PR to
-#     build both variants on both architectures as a validation check. Same-repo
-#     PRs additionally push a throwaway pr-<n> tag; fork PRs build only (their
-#     GITHUB_TOKEN is read-only and cannot write packages).
+#   * Pull requests, always    -> build both variants on both architectures as a
+#     validation check. Same-repo PRs additionally push a throwaway pr-<n> tag;
+#     fork PRs build only and discard the result (their GITHUB_TOKEN is
+#     read-only and cannot write packages).
 #
 # See docs/container-images.md for the one-time repository setup the owner must
-# perform (enabling GHCR, the build-images label, and package visibility).
+# perform (enabling GHCR and package visibility).
 
 on:
   push:
@@ -23,7 +23,7 @@ on:
     tags:
       - "v*"
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
     inputs:
       push:
@@ -47,10 +47,6 @@ jobs:
   # -- Decide whether this run pushes, and compute the image name -------------─
   setup:
     name: Configure
-    # PR runs only proceed when explicitly opted in via the build-images label.
-    if: >-
-      github.event_name != 'pull_request' ||
-      contains(github.event.pull_request.labels.*.name, 'build-images')
     runs-on: ubuntu-latest
     outputs:
       push: ${{ steps.cfg.outputs.push }}

--- a/docs/container-images.md
+++ b/docs/container-images.md
@@ -25,7 +25,7 @@ $ docker pull ghcr.io/<owner>/openvox-ca:latest-alpine   # Alpine
 | **Push to `main`** | Builds both variants on both architectures and pushes the rolling `edge` (and `main`) tags, plus their `-alpine` counterparts. `edge` always points at the latest default-branch build. |
 | **Release tag** (`git push` of a `v*` tag) | Builds both variants on both architectures and pushes the semver tags (`1.2.3`, `1.2`, `1`), `latest`, and their `-alpine` counterparts. |
 | **Manual** (Actions → *Container images* → *Run workflow*) | Builds everything. Pushes only if you tick the **push** input; otherwise it builds and smoke-tests without publishing. |
-| **Pull request** | Builds nothing by default. Apply the **`build-images`** label to a PR to build both variants on both architectures as a validation check. Same-repo PRs also push a throwaway `pr-<n>` tag; fork PRs build only (their token cannot write packages). |
+| **Pull request** | Always builds both variants on both architectures as a validation check. Same-repo PRs also push a throwaway `pr-<n>` tag; fork PRs build only and discard the result (their token cannot write packages). |
 
 Architecture builds run on native GitHub-hosted runners — `ubuntu-latest`
 (amd64) and `ubuntu-24.04-arm` (arm64) — and the per-architecture digests are
@@ -51,20 +51,15 @@ validation builds will still work (they don't push).
    **Public**. The package is automatically linked to this repository via the
    `org.opencontainers.image.source` label.
 
-3. **Create the `build-images` label.**
-   Issues → *Labels* → *New label*, name it exactly `build-images`. Maintainers
-   apply this label to a PR to opt it into a container build. Because applying a
-   label requires triage/write access, contributors cannot self-trigger builds.
-
-4. **arm64 runners.**
+3. **arm64 runners.**
    The `ubuntu-24.04-arm` runner used for arm64 is free for **public**
    repositories. For a private repository you must provision arm64 runners
    (GitHub-hosted larger runners or self-hosted) or the arm64 build jobs will
    queue indefinitely.
 
-5. **Fork pull-request approval (the build "gate").**
+4. **Fork pull-request approval (the build "gate").**
    GitHub holds workflow runs on PRs from first-time contributors until a
    maintainer approves them (Settings → Actions → General → *Fork pull request
-   workflows from outside collaborators*). Combined with the `build-images`
-   label, this means fork PRs only build after a maintainer both approves the
-   run and applies the label — and even then they never push.
+   workflows from outside collaborators*). Fork PRs still build once approved,
+   but their `GITHUB_TOKEN` is read-only, so the build result is discarded
+   rather than pushed.


### PR DESCRIPTION
Removes the `build-images` label gate so container images build on every PR as a validation check, rather than only on demand. The push policy is unchanged: same-repo PRs still push a throwaway `pr-<n>` tag, while fork PRs build only and discard the result, since their `GITHUB_TOKEN` is read-only and cannot write packages.

Also removes the now-unneeded `build-images` label setup step from the docs and the `labeled` PR trigger event.