### PR TITLE
Support wire-compatible auto-renewal (no CSR) on /certificate_renewal

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,8 +393,10 @@ All endpoints are served under both the bare path and `/puppet-ca/v1/<path>`, so
 
 Requires a valid CA-signed client certificate. The new certificate is issued immediately without entering the pending-CSR queue or autosign evaluation.
 
-- **CSR body (re-key):** the CSR Common Name must match the authenticated client CN — an agent can only renew its own certificate, not another's. Issues a certificate for the new key in the CSR.
-- **Empty body (wire-compatible auto-renewal):** matches the request real Puppet/OpenVox agents send by default (`hostcert_renewal_interval`, and the `puppet ssl renew_cert` CLI action). Identity and key possession come solely from the mTLS-presented client certificate; the same public key is reissued with a fresh serial and validity, carrying forward the original certificate's SANs and Puppet OID extensions unchanged. This mirrors the behaviour of OpenVox Server's own (Clojure) CA: the certificate being replaced is not revoked, so it remains valid for the same key until it naturally expires.
+- **CSR body (re-key):** the CSR Common Name must match the authenticated client CN — an agent can only renew its own certificate, not another's. Issues a certificate for the new key in the CSR. Puppet OID extensions are copied from the CSR **except** authorization-arc OIDs (`1.3.6.1.4.1.34380.1.3.*`, such as `pp_cli_auth`), which are stripped so a submitted CSR cannot request elevated privileges.
+- **Empty body (wire-compatible auto-renewal):** matches the request real Puppet/OpenVox agents send by default (`hostcert_renewal_interval`, and the `puppet ssl renew_cert` CLI action). Identity and key possession come solely from the mTLS-presented client certificate; the same public key is reissued with a fresh serial and validity, carrying forward the original certificate's SANs and Puppet OID extensions unchanged. Unlike the CSR path, this **preserves authorization-arc OIDs** (e.g. `pp_cli_auth`): they were already vetted when the presented certificate was issued, so a cert that legitimately holds them keeps them across renewal. This mirrors the behaviour of OpenVox Server's own (Clojure) CA: the certificate being replaced is not revoked, so it remains valid for the same key until it naturally expires.
+
+If the presented certificate's (or CSR's) key falls below the CA key-strength policy — for example an RSA-1024 key imported from a legacy CA — the request is rejected with `422 Unprocessable Entity` rather than renewed; the agent must re-key via the CSR path with a compliant key.
 
 ### Bulk signing
 

--- a/README.md
+++ b/README.md
@@ -389,9 +389,12 @@ All endpoints are served under both the bare path and `/puppet-ca/v1/<path>`, so
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `POST` | `/certificate_renewal` | Renew an existing certificate; body: raw CSR PEM; returns new certificate PEM |
+| `POST` | `/certificate_renewal` | Renew an existing certificate; body: raw CSR PEM, or empty; returns new certificate PEM |
 
-Requires a valid CA-signed client certificate. The CSR Common Name must match the authenticated client CN — an agent can only renew its own certificate, not another's. The new certificate is issued immediately without entering the pending-CSR queue or autosign evaluation.
+Requires a valid CA-signed client certificate. The new certificate is issued immediately without entering the pending-CSR queue or autosign evaluation.
+
+- **CSR body (re-key):** the CSR Common Name must match the authenticated client CN — an agent can only renew its own certificate, not another's. Issues a certificate for the new key in the CSR.
+- **Empty body (wire-compatible auto-renewal):** matches the request real Puppet/OpenVox agents send by default (`hostcert_renewal_interval`, and the `puppet ssl renew_cert` CLI action). Identity and key possession come solely from the mTLS-presented client certificate; the same public key is reissued with a fresh serial and validity, carrying forward the original certificate's SANs and Puppet OID extensions unchanged. This mirrors the behaviour of OpenVox Server's own (Clojure) CA: the certificate being replaced is not revoked, so it remains valid for the same key until it naturally expires.
 
 ### Bulk signing
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1309,6 +1309,26 @@ var _ = Describe("API Workflow", func() {
 			Expect(renewed.SerialNumber.Cmp(clientCert.SerialNumber)).NotTo(Equal(0))
 		})
 
+		// The routing decision uses strings.TrimSpace, so a whitespace-only body
+		// (some clients send a trailing newline) must take the same auto-renewal
+		// path as a truly-empty one — not be treated as a malformed CSR. Guards
+		// against the check regressing to a bare len(body)==0.
+		It("should auto-renew when the body is whitespace only", func() {
+			req := httptest.NewRequest("POST", "/certificate_renewal", bytes.NewReader([]byte("  \n\t")))
+			req.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{clientCert}}
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+			Expect(rr.Code).To(Equal(http.StatusOK))
+
+			block, _ := pem.Decode(rr.Body.Bytes())
+			Expect(block).NotTo(BeNil())
+			renewed, err := x509.ParseCertificate(block.Bytes)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(renewed.PublicKey).To(Equal(clientCert.PublicKey),
+				"whitespace-only body must route to auto-renewal and reissue the same key")
+			Expect(renewed.SerialNumber.Cmp(clientCert.SerialNumber)).NotTo(Equal(0))
+		})
+
 		// A legacy-imported node may present a cert whose key predates this CA's
 		// key-strength policy. The empty-body auto-renewal path must surface that
 		// as a client-actionable 422 (re-key via CSR), not mask it behind a 500.

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -28,6 +28,7 @@ import (
 	"encoding/asn1"
 	"encoding/json"
 	"encoding/pem"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1306,6 +1307,51 @@ var _ = Describe("API Workflow", func() {
 			Expect(renewed.PublicKey).To(Equal(clientCert.PublicKey),
 				"auto-renewal via empty body must not rotate the key")
 			Expect(renewed.SerialNumber.Cmp(clientCert.SerialNumber)).NotTo(Equal(0))
+		})
+
+		// A legacy-imported node may present a cert whose key predates this CA's
+		// key-strength policy. The empty-body auto-renewal path must surface that
+		// as a client-actionable 422 (re-key via CSR), not mask it behind a 500.
+		// This guards the errors.Is(err, ca.ErrKeyPolicy) mapping at the HTTP
+		// layer, which the CA-layer AutoRenew test cannot exercise.
+		It("should return 422 when the presented certificate's key is below policy (empty body)", func() {
+			weakKey, err := rsa.GenerateKey(rand.Reader, 1024)
+			Expect(err).NotTo(HaveOccurred())
+			template := &x509.Certificate{
+				SerialNumber: big.NewInt(1),
+				Subject:      pkix.Name{CommonName: subject},
+				NotBefore:    time.Now().Add(-time.Hour),
+				NotAfter:     time.Now().Add(time.Hour),
+				DNSNames:     []string{subject},
+			}
+			der, err := x509.CreateCertificate(rand.Reader, template, template, &weakKey.PublicKey, weakKey)
+			Expect(err).NotTo(HaveOccurred())
+			weakCert, err := x509.ParseCertificate(der)
+			Expect(err).NotTo(HaveOccurred())
+
+			req := httptest.NewRequest("POST", "/certificate_renewal", bytes.NewReader(nil))
+			req.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{weakCert}}
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+			Expect(rr.Code).To(Equal(http.StatusUnprocessableEntity))
+		})
+
+		// The same key-strength policy applies to a re-key CSR: a CSR carrying a
+		// sub-policy key must yield 422, not the generic 400 (invalid CSR) or a
+		// 500. Guards the second errors.Is(err, ca.ErrKeyPolicy) branch.
+		It("should return 422 when the renewal CSR key is below policy", func() {
+			weakKey, err := rsa.GenerateKey(rand.Reader, 1024)
+			Expect(err).NotTo(HaveOccurred())
+			csrDER, err := x509.CreateCertificateRequest(rand.Reader,
+				&x509.CertificateRequest{Subject: pkix.Name{CommonName: subject}}, weakKey)
+			Expect(err).NotTo(HaveOccurred())
+			weakCSR := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER})
+
+			req := httptest.NewRequest("POST", "/certificate_renewal", bytes.NewReader(weakCSR))
+			req.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{clientCert}}
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+			Expect(rr.Code).To(Equal(http.StatusUnprocessableEntity))
 		})
 	})
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1288,6 +1288,25 @@ var _ = Describe("API Workflow", func() {
 			mux.ServeHTTP(rr, req)
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
 		})
+
+		// Real Puppet/OpenVox agents POST an empty body by default
+		// (hostcert_renewal_interval), relying solely on the mTLS-presented
+		// client cert. This must reissue the SAME key, not require a CSR.
+		It("should auto-renew the presented certificate's own key when the body is empty", func() {
+			req := httptest.NewRequest("POST", "/certificate_renewal", bytes.NewReader(nil))
+			req.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{clientCert}}
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+			Expect(rr.Code).To(Equal(http.StatusOK))
+
+			block, _ := pem.Decode(rr.Body.Bytes())
+			Expect(block).NotTo(BeNil())
+			renewed, err := x509.ParseCertificate(block.Bytes)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(renewed.PublicKey).To(Equal(clientCert.PublicKey),
+				"auto-renewal via empty body must not rotate the key")
+			Expect(renewed.SerialNumber.Cmp(clientCert.SerialNumber)).NotTo(Equal(0))
+		})
 	})
 
 	Context("PuppetDateTimeFormat", func() {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -920,8 +920,10 @@ func (s *Server) handlePostCertificateRenewal(w http.ResponseWriter, r *http.Req
 		// (hostcert_renewal_interval) they POST an empty body here, relying
 		// solely on the mTLS-presented client cert to prove identity and key
 		// possession, and expect the SAME key reissued with a fresh serial
-		// and validity. clientCN(r) already established that r.TLS carries a
-		// verified, non-revoked peer certificate.
+		// and validity. Reissuing without a fresh proof-of-possession is safe
+		// because newAuthMiddleware (the tierAnyClient path guarding this
+		// route) has already verified r.TLS.PeerCertificates[0] chains to our
+		// CA and is not revoked; clientCN(r) only reads its CN.
 		certPEM, err = s.CA.AutoRenew(r.Context(), r.TLS.PeerCertificates[0])
 		if err != nil {
 			// A key-strength rejection is client-actionable: the presented

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -907,34 +907,50 @@ func (s *Server) handlePostCertificateRenewal(w http.ResponseWriter, r *http.Req
 
 	// SECURITY: Limit body to 1 MiB to prevent memory exhaustion.
 	// NIST 800-53: SC-5 (Denial-of-Service Protection)
-	csrPEM, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 	if err != nil {
-		slog.Error("read renewal CSR body failed", "client", cn, "error", err)
+		slog.Error("read renewal body failed", "client", cn, "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
 
-	csr, err := parseCSR(csrPEM)
-	if err != nil {
-		http.Error(w, "invalid CSR: "+err.Error(), http.StatusBadRequest)
-		return
-	}
+	var certPEM []byte
+	if strings.TrimSpace(string(body)) == "" {
+		// Wire-compatible with real Puppet/OpenVox agents: by default
+		// (hostcert_renewal_interval) they POST an empty body here, relying
+		// solely on the mTLS-presented client cert to prove identity and key
+		// possession, and expect the SAME key reissued with a fresh serial
+		// and validity. clientCN(r) already established that r.TLS carries a
+		// verified, non-revoked peer certificate.
+		certPEM, err = s.CA.AutoRenew(r.Context(), r.TLS.PeerCertificates[0])
+		if err != nil {
+			slog.Warn("Auto-renewal failed", "subject", cn, "error", err)
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+			return
+		}
+	} else {
+		csr, err := parseCSR(body)
+		if err != nil {
+			http.Error(w, "invalid CSR: "+err.Error(), http.StatusBadRequest)
+			return
+		}
 
-	// SECURITY: CSR CN must match the authenticated client CN. Without this
-	// check an agent could renew another agent's certificate by sending a CSR
-	// with a different CN while authenticating as itself.
-	// NIST 800-53: IA-5(2) (PKI-Based Authentication)
-	if csr.Subject.CommonName != cn {
-		slog.Warn("Renewal rejected: CN mismatch", "client_cn", cn, "csr_cn", csr.Subject.CommonName)
-		http.Error(w, "CSR CN does not match authenticated client CN", http.StatusForbidden)
-		return
-	}
+		// SECURITY: CSR CN must match the authenticated client CN. Without this
+		// check an agent could renew another agent's certificate by sending a CSR
+		// with a different CN while authenticating as itself.
+		// NIST 800-53: IA-5(2) (PKI-Based Authentication)
+		if csr.Subject.CommonName != cn {
+			slog.Warn("Renewal rejected: CN mismatch", "client_cn", cn, "csr_cn", csr.Subject.CommonName)
+			http.Error(w, "CSR CN does not match authenticated client CN", http.StatusForbidden)
+			return
+		}
 
-	certPEM, err := s.CA.Renew(r.Context(), cn, csrPEM)
-	if err != nil {
-		slog.Warn("Renewal failed", "subject", cn, "error", err)
-		http.Error(w, "internal server error", http.StatusInternalServerError)
-		return
+		certPEM, err = s.CA.Renew(r.Context(), cn, body)
+		if err != nil {
+			slog.Warn("Renewal failed", "subject", cn, "error", err)
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+			return
+		}
 	}
 
 	w.Header().Set("Content-Type", "text/plain")

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -924,6 +924,15 @@ func (s *Server) handlePostCertificateRenewal(w http.ResponseWriter, r *http.Req
 		// verified, non-revoked peer certificate.
 		certPEM, err = s.CA.AutoRenew(r.Context(), r.TLS.PeerCertificates[0])
 		if err != nil {
+			// A key-strength rejection is client-actionable: the presented
+			// cert (e.g. imported from a legacy CA) carries a key below policy
+			// and the agent must re-key via the CSR-based renewal path. Report
+			// it as such rather than masking it behind a 500.
+			if errors.Is(err, ca.ErrKeyPolicy) {
+				slog.Warn("Auto-renewal rejected: key policy", "subject", cn, "error", err)
+				http.Error(w, "certificate key does not meet policy; renew with a new CSR", http.StatusUnprocessableEntity)
+				return
+			}
 			slog.Warn("Auto-renewal failed", "subject", cn, "error", err)
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 			return
@@ -947,6 +956,13 @@ func (s *Server) handlePostCertificateRenewal(w http.ResponseWriter, r *http.Req
 
 		certPEM, err = s.CA.Renew(r.Context(), cn, body)
 		if err != nil {
+			// Same key-strength policy applies to the re-key CSR: surface it as
+			// a client error instead of a 500.
+			if errors.Is(err, ca.ErrKeyPolicy) {
+				slog.Warn("Renewal rejected: key policy", "subject", cn, "error", err)
+				http.Error(w, "CSR key does not meet policy", http.StatusUnprocessableEntity)
+				return
+			}
 			slog.Warn("Renewal failed", "subject", cn, "error", err)
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 			return

--- a/internal/ca/keys.go
+++ b/internal/ca/keys.go
@@ -26,8 +26,15 @@ import (
 	"crypto/sha1"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 )
+
+// ErrKeyPolicy is wrapped by validatePublicKey when a presented or submitted
+// public key fails the CA's key-strength policy. It lets callers distinguish a
+// client-actionable rejection (re-key with a stronger key) from an internal
+// fault, so the HTTP layer can answer 4xx rather than 5xx.
+var ErrKeyPolicy = errors.New("public key does not meet the CA key-strength policy")
 
 // KeyAlgo identifies the asymmetric key algorithm to use when generating a key.
 type KeyAlgo string
@@ -96,7 +103,7 @@ func validatePublicKey(pub crypto.PublicKey) error {
 	switch k := pub.(type) {
 	case *rsa.PublicKey:
 		if bits := k.N.BitLen(); bits < 2048 {
-			return fmt.Errorf("RSA public key size %d is below the minimum of 2048 bits", bits)
+			return fmt.Errorf("%w: RSA public key size %d is below the minimum of 2048 bits", ErrKeyPolicy, bits)
 		}
 		return nil
 	case *ecdsa.PublicKey:
@@ -108,10 +115,10 @@ func validatePublicKey(pub crypto.PublicKey) error {
 			if k.Curve != nil {
 				name = k.Curve.Params().Name
 			}
-			return fmt.Errorf("unsupported ECDSA curve %q (must be P-256, P-384, or P-521)", name)
+			return fmt.Errorf("%w: unsupported ECDSA curve %q (must be P-256, P-384, or P-521)", ErrKeyPolicy, name)
 		}
 	default:
-		return fmt.Errorf("unsupported public key type %T (must be RSA >= 2048 bits or ECDSA P-256/P-384/P-521)", pub)
+		return fmt.Errorf("%w: unsupported public key type %T (must be RSA >= 2048 bits or ECDSA P-256/P-384/P-521)", ErrKeyPolicy, pub)
 	}
 }
 

--- a/internal/ca/renew_test.go
+++ b/internal/ca/renew_test.go
@@ -340,4 +340,29 @@ var _ = Describe("CA AutoRenew", func() {
 		Expect(renewed.PublicKey).To(Equal(original.PublicKey))
 		Expect(renewed.SerialNumber.Cmp(original.SerialNumber)).NotTo(Equal(0))
 	})
+
+	It("rejects a sub-policy key with ErrKeyPolicy rather than a generic failure", func() {
+		// A legacy-CA cert may carry an RSA-1024 key that predates this CA's
+		// policy. Auto-renewal must refuse to perpetuate it, and the error
+		// must be classifiable so the HTTP layer answers 4xx, not 5xx.
+		key, err := rsa.GenerateKey(rand.Reader, 1024)
+		Expect(err).NotTo(HaveOccurred())
+		serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+		Expect(err).NotTo(HaveOccurred())
+		now := time.Now().UTC()
+		template := &x509.Certificate{
+			SerialNumber: serial,
+			Subject:      pkix.Name{CommonName: "weak-key-node"},
+			NotBefore:    now.Add(-24 * time.Hour),
+			NotAfter:     now.Add(365 * 24 * time.Hour),
+			DNSNames:     []string{"weak-key-node"},
+		}
+		der, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
+		Expect(err).NotTo(HaveOccurred())
+		original, err := x509.ParseCertificate(der)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = myCA.AutoRenew(ctx, original)
+		Expect(err).To(MatchError(ca.ErrKeyPolicy))
+	})
 })

--- a/internal/ca/renew_test.go
+++ b/internal/ca/renew_test.go
@@ -198,37 +198,50 @@ var _ = Describe("CA AutoRenew", func() {
 		return parseCertPEM(certPEM)
 	}
 
-	// seedCertWithoutCSR mints a leaf certificate directly with the cached
-	// test CA's key and stores it as subject's cert, without ever writing a
-	// CSR to storage — simulating a certificate imported from a migration
-	// (see the storage migrate command) or any other cert whose CSR has
-	// since been cleaned up. AutoRenew must work from the certificate alone.
-	seedCertWithoutCSR := func(subject string) *x509.Certificate {
-		key, err := rsa.GenerateKey(rand.Reader, 2048)
+	// mintLeaf signs a leaf certificate directly with the cached test CA key
+	// from template — generating an RSA key of keyBits and a random 128-bit
+	// serial when the template has none — and returns the parsed certificate.
+	// It does not touch storage; callers that need the cert on disk store it
+	// themselves. This collapses the key-gen / serial / CreateCertificate
+	// scaffolding shared by the direct-mint specs below (which simulate certs
+	// imported from a legacy CA, where AutoRenew works from the cert alone).
+	mintLeaf := func(keyBits int, template *x509.Certificate) *x509.Certificate {
+		key, err := rsa.GenerateKey(rand.Reader, keyBits)
 		Expect(err).NotTo(HaveOccurred())
-		serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
-		Expect(err).NotTo(HaveOccurred())
-		now := time.Now().UTC()
-		template := &x509.Certificate{
-			SerialNumber: serial,
-			Subject:      pkix.Name{CommonName: subject},
-			NotBefore:    now.Add(-24 * time.Hour),
-			NotAfter:     now.Add(365 * 24 * time.Hour),
-			DNSNames:     []string{subject},
+		if template.SerialNumber == nil {
+			serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+			Expect(err).NotTo(HaveOccurred())
+			template.SerialNumber = serial
 		}
 		der, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
 		Expect(err).NotTo(HaveOccurred())
-		certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+		return parseCertPEM(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+	}
+
+	// seedCertWithoutCSR mints a leaf certificate (via mintLeaf) and stores it
+	// as subject's cert, without ever writing a CSR to storage — simulating a
+	// certificate imported from a migration (see the storage migrate command)
+	// or any other cert whose CSR has since been cleaned up. AutoRenew must
+	// work from the certificate alone.
+	seedCertWithoutCSR := func(subject string) *x509.Certificate {
+		now := time.Now().UTC()
+		cert := mintLeaf(2048, &x509.Certificate{
+			Subject:   pkix.Name{CommonName: subject},
+			NotBefore: now.Add(-24 * time.Hour),
+			NotAfter:  now.Add(365 * 24 * time.Hour),
+			DNSNames:  []string{subject},
+		})
+		certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
 		Expect(store.SaveCert(ctx, subject, certPEM)).To(Succeed())
 
 		entry := fmt.Sprintf("%s %s %s /%s",
-			serial.Text(16),
-			template.NotBefore.Format("2006-01-02T15:04:05UTC"),
-			template.NotAfter.Format("2006-01-02T15:04:05UTC"),
+			cert.SerialNumber.Text(16),
+			cert.NotBefore.Format("2006-01-02T15:04:05UTC"),
+			cert.NotAfter.Format("2006-01-02T15:04:05UTC"),
 			subject)
 		Expect(store.AppendInventory(ctx, entry)).To(Succeed())
 
-		return parseCertPEM(certPEM)
+		return cert
 	}
 
 	BeforeEach(func() {
@@ -278,7 +291,34 @@ var _ = Describe("CA AutoRenew", func() {
 			"stored cert must match the auto-renewed serial")
 	})
 
-	It("carries the original certificate's SANs forward unchanged", func() {
+	It("extends the validity window, not just the serial", func() {
+		// The whole point of a renewal is a later expiry. Seed a nearly-expired
+		// cert (a few minutes of life left) so the reissue's fresh window — even
+		// after being capped to the test CA cert's own remaining lifetime — is
+		// unambiguously later. This can't rely on the happy-path spec, where the
+		// original and renewed windows differ only by the sub-second gap between
+		// two signings and both round to the same second. Guards a regression
+		// that reissued with the same or a shorter validity, leaving the agent's
+		// cert to expire on its original schedule despite a "successful" renewal.
+		now := time.Now().UTC()
+		original := mintLeaf(2048, &x509.Certificate{
+			Subject:   pkix.Name{CommonName: "autorenew-expiry-node"},
+			NotBefore: now.Add(-1 * time.Hour),
+			NotAfter:  now.Add(5 * time.Minute),
+			DNSNames:  []string{"autorenew-expiry-node"},
+		})
+
+		renewedPEM, err := myCA.AutoRenew(ctx, original)
+		Expect(err).NotTo(HaveOccurred())
+		renewed := parseCertPEM(renewedPEM)
+
+		Expect(renewed.NotAfter).To(BeTemporally(">", original.NotAfter),
+			"auto-renewal must extend validity, not just mint a new serial")
+	})
+
+	It("carries the original certificate's DNS SANs forward unchanged", func() {
+		// A CSR-issued openvox-ca cert carries only DNS SANs, so this asserts
+		// DNSNames; the IP/email/URI SAN types are covered by the next spec.
 		csrPEM, _ := buildCSR("autorenew-sans-node")
 		_, err := myCA.SaveRequest(ctx, "autorenew-sans-node", csrPEM)
 		Expect(err).NotTo(HaveOccurred())
@@ -297,15 +337,10 @@ var _ = Describe("CA AutoRenew", func() {
 		// openvox-ca only ever issues DNS SANs itself, but a leaf imported
 		// from a legacy CA can carry IP/email/URI SANs that services depend
 		// on. Mint such a cert directly and prove auto-renewal preserves them.
-		key, err := rsa.GenerateKey(rand.Reader, 2048)
-		Expect(err).NotTo(HaveOccurred())
-		serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
-		Expect(err).NotTo(HaveOccurred())
 		now := time.Now().UTC()
 		uri, err := url.Parse("spiffe://puppet.test/node/legacy-sans-node")
 		Expect(err).NotTo(HaveOccurred())
-		template := &x509.Certificate{
-			SerialNumber:   serial,
+		original := mintLeaf(2048, &x509.Certificate{
 			Subject:        pkix.Name{CommonName: "legacy-sans-node"},
 			NotBefore:      now.Add(-24 * time.Hour),
 			NotAfter:       now.Add(365 * 24 * time.Hour),
@@ -313,11 +348,7 @@ var _ = Describe("CA AutoRenew", func() {
 			IPAddresses:    []net.IP{net.ParseIP("10.0.0.1"), net.ParseIP("fd00::1")},
 			EmailAddresses: []string{"node@puppet.test"},
 			URIs:           []*url.URL{uri},
-		}
-		der, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
-		Expect(err).NotTo(HaveOccurred())
-		original, err := x509.ParseCertificate(der)
-		Expect(err).NotTo(HaveOccurred())
+		})
 
 		renewedPEM, err := myCA.AutoRenew(ctx, original)
 		Expect(err).NotTo(HaveOccurred())
@@ -346,24 +377,15 @@ var _ = Describe("CA AutoRenew", func() {
 		// A legacy-CA cert may carry an RSA-1024 key that predates this CA's
 		// policy. Auto-renewal must refuse to perpetuate it, and the error
 		// must be classifiable so the HTTP layer answers 4xx, not 5xx.
-		key, err := rsa.GenerateKey(rand.Reader, 1024)
-		Expect(err).NotTo(HaveOccurred())
-		serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
-		Expect(err).NotTo(HaveOccurred())
 		now := time.Now().UTC()
-		template := &x509.Certificate{
-			SerialNumber: serial,
-			Subject:      pkix.Name{CommonName: "weak-key-node"},
-			NotBefore:    now.Add(-24 * time.Hour),
-			NotAfter:     now.Add(365 * 24 * time.Hour),
-			DNSNames:     []string{"weak-key-node"},
-		}
-		der, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
-		Expect(err).NotTo(HaveOccurred())
-		original, err := x509.ParseCertificate(der)
-		Expect(err).NotTo(HaveOccurred())
+		original := mintLeaf(1024, &x509.Certificate{
+			Subject:   pkix.Name{CommonName: "weak-key-node"},
+			NotBefore: now.Add(-24 * time.Hour),
+			NotAfter:  now.Add(365 * 24 * time.Hour),
+			DNSNames:  []string{"weak-key-node"},
+		})
 
-		_, err = myCA.AutoRenew(ctx, original)
+		_, err := myCA.AutoRenew(ctx, original)
 		Expect(err).To(MatchError(ca.ErrKeyPolicy))
 	})
 
@@ -375,11 +397,6 @@ var _ = Describe("CA AutoRenew", func() {
 		// (e.g. OpenVox Server's own cert) must keep it across auto-renewal, or
 		// the puppetserver CA CLI stops authenticating. This locks in that
 		// deliberate asymmetry with the CSR path.
-		key, err := rsa.GenerateKey(rand.Reader, 2048)
-		Expect(err).NotTo(HaveOccurred())
-		serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
-		Expect(err).NotTo(HaveOccurred())
-
 		authVal, err := asn1.Marshal("true")
 		Expect(err).NotTo(HaveOccurred())
 		roleVal, err := asn1.Marshal("web")
@@ -390,21 +407,16 @@ var _ = Describe("CA AutoRenew", func() {
 		ppRole := asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 34380, 1, 1, 13}
 
 		now := time.Now().UTC()
-		template := &x509.Certificate{
-			SerialNumber: serial,
-			Subject:      pkix.Name{CommonName: "autorenew-oid-node"},
-			NotBefore:    now.Add(-24 * time.Hour),
-			NotAfter:     now.Add(365 * 24 * time.Hour),
-			DNSNames:     []string{"autorenew-oid-node"},
+		original := mintLeaf(2048, &x509.Certificate{
+			Subject:   pkix.Name{CommonName: "autorenew-oid-node"},
+			NotBefore: now.Add(-24 * time.Hour),
+			NotAfter:  now.Add(365 * 24 * time.Hour),
+			DNSNames:  []string{"autorenew-oid-node"},
 			ExtraExtensions: []pkix.Extension{
 				{Id: ca.OIDPpCliAuth, Value: authVal}, // auth-arc: CSR path would strip this
 				{Id: ppRole, Value: roleVal},          // node-attr arc: always carried
 			},
-		}
-		der, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
-		Expect(err).NotTo(HaveOccurred())
-		original, err := x509.ParseCertificate(der)
-		Expect(err).NotTo(HaveOccurred())
+		})
 
 		renewedPEM, err := myCA.AutoRenew(ctx, original)
 		Expect(err).NotTo(HaveOccurred())

--- a/internal/ca/renew_test.go
+++ b/internal/ca/renew_test.go
@@ -23,6 +23,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/asn1"
 	"encoding/pem"
 	"fmt"
 	"math/big"
@@ -364,5 +365,67 @@ var _ = Describe("CA AutoRenew", func() {
 
 		_, err = myCA.AutoRenew(ctx, original)
 		Expect(err).To(MatchError(ca.ErrKeyPolicy))
+	})
+
+	It("carries Puppet OID extensions forward, including auth OIDs the CSR path would strip", func() {
+		// Unlike the CSR signing path (which strips authorization-arc OIDs such
+		// as pp_cli_auth as an anti-escalation control), AutoRenew preserves
+		// every Puppet-arc OID because they were already vetted when the
+		// presented cert was issued. A cert legitimately carrying pp_cli_auth
+		// (e.g. OpenVox Server's own cert) must keep it across auto-renewal, or
+		// the puppetserver CA CLI stops authenticating. This locks in that
+		// deliberate asymmetry with the CSR path.
+		key, err := rsa.GenerateKey(rand.Reader, 2048)
+		Expect(err).NotTo(HaveOccurred())
+		serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+		Expect(err).NotTo(HaveOccurred())
+
+		authVal, err := asn1.Marshal("true")
+		Expect(err).NotTo(HaveOccurred())
+		roleVal, err := asn1.Marshal("web")
+		Expect(err).NotTo(HaveOccurred())
+		// pp_role lives in the node-attribute arc (…34380.1.1.*), not the auth
+		// arc, so both the CSR path and AutoRenew carry it; pp_cli_auth lives in
+		// the auth arc (…34380.1.3.*) that only AutoRenew preserves.
+		ppRole := asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 34380, 1, 1, 13}
+
+		now := time.Now().UTC()
+		template := &x509.Certificate{
+			SerialNumber: serial,
+			Subject:      pkix.Name{CommonName: "autorenew-oid-node"},
+			NotBefore:    now.Add(-24 * time.Hour),
+			NotAfter:     now.Add(365 * 24 * time.Hour),
+			DNSNames:     []string{"autorenew-oid-node"},
+			ExtraExtensions: []pkix.Extension{
+				{Id: ca.OIDPpCliAuth, Value: authVal}, // auth-arc: CSR path would strip this
+				{Id: ppRole, Value: roleVal},          // node-attr arc: always carried
+			},
+		}
+		der, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
+		Expect(err).NotTo(HaveOccurred())
+		original, err := x509.ParseCertificate(der)
+		Expect(err).NotTo(HaveOccurred())
+
+		renewedPEM, err := myCA.AutoRenew(ctx, original)
+		Expect(err).NotTo(HaveOccurred())
+		renewed := parseCertPEM(renewedPEM)
+
+		findExt := func(cert *x509.Certificate, oid asn1.ObjectIdentifier) (pkix.Extension, bool) {
+			for _, ext := range cert.Extensions {
+				if ext.Id.Equal(oid) {
+					return ext, true
+				}
+			}
+			return pkix.Extension{}, false
+		}
+
+		authExt, ok := findExt(renewed, ca.OIDPpCliAuth)
+		Expect(ok).To(BeTrue(),
+			"auto-renewal must carry the pp_cli_auth auth OID forward, unlike the CSR path")
+		Expect(authExt.Value).To(Equal(authVal))
+
+		roleExt, ok := findExt(renewed, ppRole)
+		Expect(ok).To(BeTrue(), "auto-renewal must carry the pp_role OID forward")
+		Expect(roleExt.Value).To(Equal(roleVal))
 	})
 })

--- a/internal/ca/renew_test.go
+++ b/internal/ca/renew_test.go
@@ -26,6 +26,8 @@ import (
 	"encoding/pem"
 	"fmt"
 	"math/big"
+	"net"
+	"net/url"
 	"os"
 	"time"
 
@@ -288,6 +290,42 @@ var _ = Describe("CA AutoRenew", func() {
 		renewed := parseCertPEM(renewedPEM)
 
 		Expect(renewed.DNSNames).To(Equal(original.DNSNames))
+	})
+
+	It("carries non-DNS SANs (IP, email, URI) forward, e.g. from a legacy-CA cert", func() {
+		// openvox-ca only ever issues DNS SANs itself, but a leaf imported
+		// from a legacy CA can carry IP/email/URI SANs that services depend
+		// on. Mint such a cert directly and prove auto-renewal preserves them.
+		key, err := rsa.GenerateKey(rand.Reader, 2048)
+		Expect(err).NotTo(HaveOccurred())
+		serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+		Expect(err).NotTo(HaveOccurred())
+		now := time.Now().UTC()
+		uri, err := url.Parse("spiffe://puppet.test/node/legacy-sans-node")
+		Expect(err).NotTo(HaveOccurred())
+		template := &x509.Certificate{
+			SerialNumber:   serial,
+			Subject:        pkix.Name{CommonName: "legacy-sans-node"},
+			NotBefore:      now.Add(-24 * time.Hour),
+			NotAfter:       now.Add(365 * 24 * time.Hour),
+			DNSNames:       []string{"legacy-sans-node", "legacy-sans-node.puppet.test"},
+			IPAddresses:    []net.IP{net.ParseIP("10.0.0.1"), net.ParseIP("fd00::1")},
+			EmailAddresses: []string{"node@puppet.test"},
+			URIs:           []*url.URL{uri},
+		}
+		der, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
+		Expect(err).NotTo(HaveOccurred())
+		original, err := x509.ParseCertificate(der)
+		Expect(err).NotTo(HaveOccurred())
+
+		renewedPEM, err := myCA.AutoRenew(ctx, original)
+		Expect(err).NotTo(HaveOccurred())
+		renewed := parseCertPEM(renewedPEM)
+
+		Expect(renewed.DNSNames).To(Equal(original.DNSNames))
+		Expect(renewed.IPAddresses).To(Equal(original.IPAddresses))
+		Expect(renewed.EmailAddresses).To(Equal(original.EmailAddresses))
+		Expect(renewed.URIs).To(Equal(original.URIs))
 	})
 
 	It("auto-renews a certificate that has no CSR in storage, e.g. after migration import", func() {

--- a/internal/ca/renew_test.go
+++ b/internal/ca/renew_test.go
@@ -24,7 +24,10 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"fmt"
+	"math/big"
 	"os"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -156,5 +159,147 @@ var _ = Describe("CA Renew", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(parseCertPEM(storedPEM).SerialNumber.Sign()).To(Equal(1),
 			"stored renewed cert must carry a positive serial")
+	})
+})
+
+// CA AutoRenew covers the wire-compatible "no CSR" renewal flow real
+// Puppet/OpenVox agents use by default (hostcert_renewal_interval): the
+// client presents its existing cert over mTLS and gets back a certificate
+// for the SAME public key, with a fresh serial and validity. This matches
+// OpenVox Server's own Clojure CA (renew-certificate!), which does not
+// revoke the certificate being replaced.
+var _ = Describe("CA AutoRenew", func() {
+	var (
+		ctx    = context.Background()
+		tmpDir string
+		myCA   *ca.CA
+		store  *storage.StorageService
+		caKey  *rsa.PrivateKey
+		caCert *x509.Certificate
+	)
+
+	parseCertPEM := func(certPEM []byte) *x509.Certificate {
+		block, _ := pem.Decode(certPEM)
+		Expect(block).NotTo(BeNil(), "renewed cert PEM must decode")
+		cert, err := x509.ParseCertificate(block.Bytes)
+		Expect(err).NotTo(HaveOccurred())
+		return cert
+	}
+
+	issue := func(subject string) *x509.Certificate {
+		csrPEM, _ := buildCSR(subject)
+		_, err := myCA.SaveRequest(ctx, subject, csrPEM)
+		Expect(err).NotTo(HaveOccurred())
+		certPEM, err := myCA.Sign(ctx, subject)
+		Expect(err).NotTo(HaveOccurred())
+		return parseCertPEM(certPEM)
+	}
+
+	// seedCertWithoutCSR mints a leaf certificate directly with the cached
+	// test CA's key and stores it as subject's cert, without ever writing a
+	// CSR to storage — simulating a certificate imported from a migration
+	// (see the storage migrate command) or any other cert whose CSR has
+	// since been cleaned up. AutoRenew must work from the certificate alone.
+	seedCertWithoutCSR := func(subject string) *x509.Certificate {
+		key, err := rsa.GenerateKey(rand.Reader, 2048)
+		Expect(err).NotTo(HaveOccurred())
+		serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+		Expect(err).NotTo(HaveOccurred())
+		now := time.Now().UTC()
+		template := &x509.Certificate{
+			SerialNumber: serial,
+			Subject:      pkix.Name{CommonName: subject},
+			NotBefore:    now.Add(-24 * time.Hour),
+			NotAfter:     now.Add(365 * 24 * time.Hour),
+			DNSNames:     []string{subject},
+		}
+		der, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
+		Expect(err).NotTo(HaveOccurred())
+		certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+		Expect(store.SaveCert(ctx, subject, certPEM)).To(Succeed())
+
+		entry := fmt.Sprintf("%s %s %s /%s",
+			serial.Text(16),
+			template.NotBefore.Format("2006-01-02T15:04:05UTC"),
+			template.NotAfter.Format("2006-01-02T15:04:05UTC"),
+			subject)
+		Expect(store.AppendInventory(ctx, entry)).To(Succeed())
+
+		return parseCertPEM(certPEM)
+	}
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "openvox-ca-autorenew-test")
+		Expect(err).NotTo(HaveOccurred())
+
+		store = storage.New(tmpDir)
+		myCA = ca.New(store, ca.AutosignConfig{Mode: "off"}, "puppet.test")
+
+		Expect(store.EnsureDirs(ctx)).To(Succeed())
+		Expect(store.SaveCAKey(ctx, cachedKeyPEM)).To(Succeed())
+		Expect(store.SaveCACert(ctx, cachedCrtPEM)).To(Succeed())
+		Expect(store.UpdateCRL(ctx, cachedCrlPEM)).To(Succeed())
+		Expect(store.WriteSerial(ctx, "0001")).To(Succeed())
+		Expect(store.TouchInventory(ctx)).To(Succeed())
+		Expect(myCA.Init(ctx)).To(Succeed())
+
+		keyBlock, _ := pem.Decode(cachedKeyPEM)
+		caKey, err = x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+		Expect(err).NotTo(HaveOccurred())
+		certBlock, _ := pem.Decode(cachedCrtPEM)
+		caCert, err = x509.ParseCertificate(certBlock.Bytes)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(tmpDir)
+	})
+
+	It("reissues the same public key with a fresh serial, matching Clojure CA semantics", func() {
+		original := issue("autorenew-node")
+
+		renewedPEM, err := myCA.AutoRenew(ctx, original)
+		Expect(err).NotTo(HaveOccurred())
+		renewed := parseCertPEM(renewedPEM)
+
+		Expect(renewed.Subject.CommonName).To(Equal("autorenew-node"))
+		Expect(renewed.PublicKey).To(Equal(original.PublicKey),
+			"auto-renewal must not rotate the key, only the serial/validity")
+		Expect(renewed.SerialNumber.Cmp(original.SerialNumber)).NotTo(Equal(0),
+			"auto-renewed cert must carry a different serial than the original")
+
+		storedPEM, err := store.GetCert(ctx, "autorenew-node")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(parseCertPEM(storedPEM).SerialNumber.Cmp(renewed.SerialNumber)).To(Equal(0),
+			"stored cert must match the auto-renewed serial")
+	})
+
+	It("carries the original certificate's SANs forward unchanged", func() {
+		csrPEM, _ := buildCSR("autorenew-sans-node")
+		_, err := myCA.SaveRequest(ctx, "autorenew-sans-node", csrPEM)
+		Expect(err).NotTo(HaveOccurred())
+		certPEM, err := myCA.Sign(ctx, "autorenew-sans-node")
+		Expect(err).NotTo(HaveOccurred())
+		original := parseCertPEM(certPEM)
+
+		renewedPEM, err := myCA.AutoRenew(ctx, original)
+		Expect(err).NotTo(HaveOccurred())
+		renewed := parseCertPEM(renewedPEM)
+
+		Expect(renewed.DNSNames).To(Equal(original.DNSNames))
+	})
+
+	It("auto-renews a certificate that has no CSR in storage, e.g. after migration import", func() {
+		original := seedCertWithoutCSR("migrated-node")
+		Expect(store.HasCSR(ctx, "migrated-node")).To(BeFalse(),
+			"this test only proves anything if there really is no CSR to fall back on")
+
+		renewedPEM, err := myCA.AutoRenew(ctx, original)
+		Expect(err).NotTo(HaveOccurred())
+		renewed := parseCertPEM(renewedPEM)
+
+		Expect(renewed.PublicKey).To(Equal(original.PublicKey))
+		Expect(renewed.SerialNumber.Cmp(original.SerialNumber)).NotTo(Equal(0))
 	})
 })

--- a/internal/ca/signing.go
+++ b/internal/ca/signing.go
@@ -769,6 +769,14 @@ func (c *CA) AutoRenew(ctx context.Context, presentedCert *x509.Certificate) ([]
 
 	var extraExtensions []pkix.Extension
 	for _, ext := range presentedCert.Extensions {
+		// Carry EVERY Puppet OID forward, including authorization-arc OIDs
+		// (pp_cli_auth et al.). Unlike signWithDuration's CSR path — which adds
+		// `&& !IsAuthOID(ext.Id)` here to strip auth OIDs as an anti-escalation
+		// control — these were already vetted when presentedCert was issued, so
+		// preserving them is required for wire-compat (e.g. OpenVox Server's own
+		// cert keeps pp_cli_auth across renewal, or the CA CLI stops
+		// authenticating). Do NOT add an IsAuthOID filter here; see this
+		// method's godoc. NIST 800-53: AC-6, CM-7.
 		if IsPuppetOID(ext.Id) {
 			extraExtensions = append(extraExtensions, ext)
 		}

--- a/internal/ca/signing.go
+++ b/internal/ca/signing.go
@@ -210,9 +210,11 @@ func (c *CA) sign(ctx context.Context, subject string) ([]byte, error) {
 // ttl=0 means use the default certValidity.
 // c.mu must be held by the caller.
 func (c *CA) signWithDuration(ctx context.Context, subject string, ttl time.Duration) ([]byte, error) {
-	// Defensive: a nil CACert here means the caller skipped Init() (or it
-	// failed). Without this guard the c.CACert.NotAfter dereference below
-	// would panic the entire frontend.
+	// Fail fast on an uninitialised CA (caller skipped Init(), or it failed)
+	// before we bother reading a CSR from storage, so Sign() returns a clear
+	// ErrNotInitialized rather than a misleading "CSR not found". The actual
+	// c.CACert dereference happens later in issueLeafLocked, which carries the
+	// same guard for callers (e.g. AutoRenew) that reach it by other paths.
 	if c.CACert == nil || c.CAKey == nil {
 		return nil, ErrNotInitialized
 	}

--- a/internal/ca/signing.go
+++ b/internal/ca/signing.go
@@ -30,6 +30,8 @@ import (
 	"fmt"
 	"log/slog"
 	"math/big"
+	"net"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -282,7 +284,7 @@ func (c *CA) signWithDuration(ctx context.Context, subject string, ttl time.Dura
 		}
 	}
 
-	certPEM, err := c.issueLeafLocked(ctx, subject, csr.Subject, csr.PublicKey, dnsNames, extraExtensions, ttl)
+	certPEM, err := c.issueLeafLocked(ctx, subject, csr.Subject, csr.PublicKey, subjectAltNames{DNSNames: dnsNames}, extraExtensions, ttl)
 	if err != nil {
 		return nil, err
 	}
@@ -295,6 +297,17 @@ func (c *CA) signWithDuration(ctx context.Context, subject string, ttl time.Dura
 	return certPEM, nil
 }
 
+// subjectAltNames carries the full set of Subject Alternative Name entries
+// copied onto an issued leaf certificate. Bundling them keeps issueLeafLocked's
+// signature manageable and ensures every SAN type is threaded through together,
+// rather than DNS names alone.
+type subjectAltNames struct {
+	DNSNames       []string
+	IPAddresses    []net.IP
+	EmailAddresses []string
+	URIs           []*url.URL
+}
+
 // issueLeafLocked builds, signs, and persists a leaf certificate for subject
 // from the given public key, SANs, and extra (Puppet OID) extensions, then
 // appends the inventory entry and updates the in-memory serial index.
@@ -303,7 +316,7 @@ func (c *CA) signWithDuration(ctx context.Context, subject string, ttl time.Dura
 // This is the tail shared by signWithDuration (inputs come from a submitted
 // CSR, after CSR-specific validation) and AutoRenew (inputs come from an
 // already-issued certificate's public key, with no CSR involved at all).
-func (c *CA) issueLeafLocked(ctx context.Context, subject string, subjectName pkix.Name, pubKey any, dnsNames []string, extraExtensions []pkix.Extension, ttl time.Duration) ([]byte, error) {
+func (c *CA) issueLeafLocked(ctx context.Context, subject string, subjectName pkix.Name, pubKey any, sans subjectAltNames, extraExtensions []pkix.Extension, ttl time.Duration) ([]byte, error) {
 	// Defensive: a nil CACert here means the caller skipped Init() (or it
 	// failed). Without this guard the c.CACert.NotAfter dereference below
 	// would panic the entire frontend.
@@ -360,7 +373,10 @@ func (c *CA) issueLeafLocked(ctx context.Context, subject string, subjectName pk
 		SubjectKeyId:   subjectKeyID[:],
 		AuthorityKeyId: c.CACert.SubjectKeyId,
 
-		DNSNames: dnsNames,
+		DNSNames:       sans.DNSNames,
+		IPAddresses:    sans.IPAddresses,
+		EmailAddresses: sans.EmailAddresses,
+		URIs:           sans.URIs,
 	}
 
 	// CRL Distribution Points: embed CRL URL(s) when configured so that
@@ -760,7 +776,17 @@ func (c *CA) AutoRenew(ctx context.Context, presentedCert *x509.Certificate) ([]
 	err := c.Storage.WithLock(ctx, subjectLockName(subject), func() error {
 		c.mu.Lock()
 		defer c.mu.Unlock()
-		certPEM, err := c.issueLeafLocked(ctx, subject, presentedCert.Subject, presentedCert.PublicKey, presentedCert.DNSNames, extraExtensions, 0)
+		// Carry forward every SAN type from the certificate being renewed,
+		// not just DNS names: a leaf imported from a legacy CA may carry IP,
+		// email, or URI SANs that services still depend on, and auto-renewal
+		// must not silently drop them.
+		sans := subjectAltNames{
+			DNSNames:       presentedCert.DNSNames,
+			IPAddresses:    presentedCert.IPAddresses,
+			EmailAddresses: presentedCert.EmailAddresses,
+			URIs:           presentedCert.URIs,
+		}
+		certPEM, err := c.issueLeafLocked(ctx, subject, presentedCert.Subject, presentedCert.PublicKey, sans, extraExtensions, 0)
 		if err != nil {
 			return err
 		}

--- a/internal/ca/signing.go
+++ b/internal/ca/signing.go
@@ -262,6 +262,55 @@ func (c *CA) signWithDuration(ctx context.Context, subject string, ttl time.Dura
 		}
 	}
 
+	dnsNames := csr.DNSNames
+	// RFC 2818 §3.1: TLS clients match the server name against SANs, not the
+	// CN. When the CSR carries no SANs and promotion is enabled, add the CN as
+	// a DNS SAN so that the issued certificate works with modern TLS stacks.
+	if c.PromoteCNToSAN && len(dnsNames) == 0 && csr.Subject.CommonName != "" {
+		dnsNames = []string{csr.Subject.CommonName}
+	}
+
+	// SECURITY: Copy Puppet OID extensions from the CSR, excluding
+	// authorization-arc OIDs (1.3.6.1.4.1.34380.1.3.*). Allowing CSRs to
+	// inject auth OIDs like pp_cli_auth would let any agent request admin
+	// privileges, which is a direct privilege escalation.
+	// NIST 800-53: AC-6 (Least Privilege), CM-7 (Least Functionality)
+	var extraExtensions []pkix.Extension
+	for _, ext := range csr.Extensions {
+		if IsPuppetOID(ext.Id) && !IsAuthOID(ext.Id) {
+			extraExtensions = append(extraExtensions, ext)
+		}
+	}
+
+	certPEM, err := c.issueLeafLocked(ctx, subject, csr.Subject, csr.PublicKey, dnsNames, extraExtensions, ttl)
+	if err != nil {
+		return nil, err
+	}
+
+	// Remove the pending CSR now that we have a signed cert.
+	if err := c.Storage.DeleteCSR(ctx, subject); err != nil {
+		slog.Warn("Could not delete CSR after signing", "subject", subject, "error", err)
+	}
+
+	return certPEM, nil
+}
+
+// issueLeafLocked builds, signs, and persists a leaf certificate for subject
+// from the given public key, SANs, and extra (Puppet OID) extensions, then
+// appends the inventory entry and updates the in-memory serial index.
+// ttl=0 means use the default certValidity. c.mu must be held by the caller.
+//
+// This is the tail shared by signWithDuration (inputs come from a submitted
+// CSR, after CSR-specific validation) and AutoRenew (inputs come from an
+// already-issued certificate's public key, with no CSR involved at all).
+func (c *CA) issueLeafLocked(ctx context.Context, subject string, subjectName pkix.Name, pubKey any, dnsNames []string, extraExtensions []pkix.Extension, ttl time.Duration) ([]byte, error) {
+	// Defensive: a nil CACert here means the caller skipped Init() (or it
+	// failed). Without this guard the c.CACert.NotAfter dereference below
+	// would panic the entire frontend.
+	if c.CACert == nil || c.CAKey == nil {
+		return nil, ErrNotInitialized
+	}
+
 	// SECURITY: Generate a random 128-bit serial number (CA/Browser Forum guidance).
 	// NIST 800-53: SC-12 (Cryptographic Key Establishment and Management)
 	serialLimit := new(big.Int).Lsh(big.NewInt(1), 128)
@@ -290,7 +339,7 @@ func (c *CA) signWithDuration(ctx context.Context, subject string, ttl time.Dura
 	validity = min(validity, caRemaining)
 
 	// SubjectKeyIdentifier: SHA1 of the SubjectPublicKeyInfo DER (RFC 5280 §4.2.1.2).
-	pubKeyDER, err := x509.MarshalPKIXPublicKey(csr.PublicKey)
+	pubKeyDER, err := x509.MarshalPKIXPublicKey(pubKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal public key for %s: %w", subject, err)
 	}
@@ -298,7 +347,7 @@ func (c *CA) signWithDuration(ctx context.Context, subject string, ttl time.Dura
 
 	template := &x509.Certificate{
 		SerialNumber: serialInt,
-		Subject:      csr.Subject,
+		Subject:      subjectName,
 		NotBefore:    now.Add(-24 * time.Hour),
 		NotAfter:     now.Add(validity),
 
@@ -311,14 +360,7 @@ func (c *CA) signWithDuration(ctx context.Context, subject string, ttl time.Dura
 		SubjectKeyId:   subjectKeyID[:],
 		AuthorityKeyId: c.CACert.SubjectKeyId,
 
-		DNSNames: csr.DNSNames,
-	}
-
-	// RFC 2818 §3.1: TLS clients match the server name against SANs, not the
-	// CN. When the CSR carries no SANs and promotion is enabled, add the CN as
-	// a DNS SAN so that the issued certificate works with modern TLS stacks.
-	if c.PromoteCNToSAN && len(template.DNSNames) == 0 && csr.Subject.CommonName != "" {
-		template.DNSNames = []string{csr.Subject.CommonName}
+		DNSNames: dnsNames,
 	}
 
 	// CRL Distribution Points: embed CRL URL(s) when configured so that
@@ -339,16 +381,7 @@ func (c *CA) signWithDuration(ctx context.Context, subject string, ttl time.Dura
 		})
 	}
 
-	// SECURITY: Copy Puppet OID extensions from the CSR, excluding
-	// authorization-arc OIDs (1.3.6.1.4.1.34380.1.3.*). Allowing CSRs to
-	// inject auth OIDs like pp_cli_auth would let any agent request admin
-	// privileges, which is a direct privilege escalation.
-	// NIST 800-53: AC-6 (Least Privilege), CM-7 (Least Functionality)
-	for _, ext := range csr.Extensions {
-		if IsPuppetOID(ext.Id) && !IsAuthOID(ext.Id) {
-			template.ExtraExtensions = append(template.ExtraExtensions, ext)
-		}
-	}
+	template.ExtraExtensions = append(template.ExtraExtensions, extraExtensions...)
 
 	// SECURITY: two complementary controls guard against signing under a key
 	// that doesn't match the CA certificate (e.g. an OpenBao Transit key
@@ -370,7 +403,7 @@ func (c *CA) signWithDuration(ctx context.Context, subject string, ttl time.Dura
 	// round trip, and under key isolation no RPC beyond the one Sign this call
 	// already makes.
 	// NIST 800-53: SC-12 (Cryptographic Key Establishment and Management)
-	certBytes, err := x509.CreateCertificate(rand.Reader, template, c.CACert, csr.PublicKey, c.CAKey)
+	certBytes, err := x509.CreateCertificate(rand.Reader, template, c.CACert, pubKey, c.CAKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign certificate for %s: %w", subject, err)
 	}
@@ -394,11 +427,6 @@ func (c *CA) signWithDuration(ctx context.Context, subject string, ttl time.Dura
 
 	// Update in-memory serial index for O(1) OCSP lookups.
 	c.serialIndex[serialStr] = subject
-
-	// Remove the pending CSR now that we have a signed cert.
-	if err := c.Storage.DeleteCSR(ctx, subject); err != nil {
-		slog.Warn("Could not delete CSR after signing", "subject", subject, "error", err)
-	}
 
 	slog.Debug("Certificate signed",
 		"subject", subject,
@@ -675,6 +703,64 @@ func (c *CA) Renew(ctx context.Context, subject string, csrPEM []byte) ([]byte, 
 			return fmt.Errorf("saving renewal CSR: %w", err)
 		}
 		certPEM, err := c.signWithDuration(ctx, subject, 0)
+		if err != nil {
+			return err
+		}
+		out = certPEM
+		return nil
+	})
+	return out, err
+}
+
+// AutoRenew reissues a certificate for the same public key as presentedCert —
+// the certificate that authenticated this request over mTLS — instead of
+// requiring a fresh CSR. This is the wire-compatible counterpart to the "no
+// CSR" renewal flow real Puppet/OpenVox agents use by default (see
+// Puppet's `hostcert_renewal_interval`, default 30 days): the mTLS handshake
+// already proved possession of the private key, so a second
+// proof-of-possession isn't required. presentedCert's SANs and Puppet OID
+// extensions — including any auth OIDs such as pp_cli_auth — are carried
+// forward verbatim, since they were already vetted when presentedCert itself
+// was issued; only the serial, validity window, and key identifiers are
+// refreshed.
+//
+// This matches the behaviour of OpenVox Server's own Clojure CA
+// (renew-certificate! in certificate_authority.clj): the certificate being
+// replaced is not revoked, so both the old and new certificates remain valid
+// (for the same key) until the old one naturally expires.
+//
+// The caller must NOT hold c.mu. Same cross-node guarantees as Sign.
+func (c *CA) AutoRenew(ctx context.Context, presentedCert *x509.Certificate) ([]byte, error) {
+	subject := presentedCert.Subject.CommonName
+	if err := ValidateSubject(subject); err != nil {
+		return nil, err
+	}
+
+	// SECURITY: Re-check the key-strength policy before perpetuating a key
+	// via auto-renewal. A cert imported from a legacy CA (see the migrate
+	// command) may predate this CA's key policy; auto-renewal must not be a
+	// backdoor to indefinitely extend a substandard key — the operator/agent
+	// should re-key via the CSR-based Renew path instead.
+	// NIST 800-53: SC-12, SC-13 (Cryptographic Protection)
+	if err := validatePublicKey(presentedCert.PublicKey); err != nil {
+		return nil, fmt.Errorf("rejecting auto-renewal for %s: %w", subject, err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, lockTimeout)
+	defer cancel()
+
+	var extraExtensions []pkix.Extension
+	for _, ext := range presentedCert.Extensions {
+		if IsPuppetOID(ext.Id) {
+			extraExtensions = append(extraExtensions, ext)
+		}
+	}
+
+	var out []byte
+	err := c.Storage.WithLock(ctx, subjectLockName(subject), func() error {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		certPEM, err := c.issueLeafLocked(ctx, subject, presentedCert.Subject, presentedCert.PublicKey, presentedCert.DNSNames, extraExtensions, 0)
 		if err != nil {
 			return err
 		}

--- a/test/puppet/puppet-stack.sh
+++ b/test/puppet/puppet-stack.sh
@@ -544,15 +544,29 @@ _pubkey_after=$(exec_client openssl x509 -in "$_client_cert_path" -noout -pubkey
 
 [[ -n "$_pubkey_after" && "$_pubkey_after" == "$_pubkey_before" ]] \
     && pass "renewed cert keeps the same public key (no CSR, no re-key)" \
-    || fail "renewed cert keeps the same public key (no CSR, no re-key)" "public key changed across renewal"
+    || fail "renewed cert keeps the same public key (no CSR, no re-key)" \
+        "$([[ -z "$_pubkey_after" ]] && echo "post-renewal public key could not be extracted" || echo "public key changed across renewal")"
 
 # The renewed cert must still work for a normal agent run (still trusted,
-# same private key on disk as before the renewal).
+# same private key on disk as before the renewal). Match Group 3's depth:
+# check the catalog actually applied and no revoked-cert/TLS error surfaced,
+# not just the exit code — a revoked or untrusted cert would exit 1, but the
+# output is the direct evidence the renewed cert is still accepted.
 AGENT_RENEW_EXIT=0
 AGENT_RENEW_OUT=$(run_agent) || AGENT_RENEW_EXIT=$?
 [[ "$AGENT_RENEW_EXIT" =~ ^(0|2)$ ]] \
     && pass "Agent run with auto-renewed cert exits 0 or 2" \
     || fail "Agent run with auto-renewed cert exits 0 or 2" "exit code: $AGENT_RENEW_EXIT; output: $(tail -5 <<< "$AGENT_RENEW_OUT" | tr '\n' '|')"
+
+grep -qi "Applied catalog" <<< "$AGENT_RENEW_OUT" \
+    && pass "auto-renewed agent run applied the catalog" \
+    || fail "auto-renewed agent run applied the catalog" "last 5 lines: $(tail -5 <<< "$AGENT_RENEW_OUT" | tr '\n' '|')"
+
+if grep -qiE "certificate revoked|certificate verify failed|SSL_connect" <<< "$AGENT_RENEW_OUT"; then
+    fail "auto-renewed agent run shows no revoked-cert/TLS error" "output: $(tail -5 <<< "$AGENT_RENEW_OUT" | tr '\n' '|')"
+else
+    pass "auto-renewed agent run shows no revoked-cert/TLS error"
+fi
 
 # ═════════════════════════════════════════════════════════════════════════
 # Group 4 -- Server self-apply

--- a/test/puppet/puppet-stack.sh
+++ b/test/puppet/puppet-stack.sh
@@ -500,6 +500,61 @@ grep -qF "client.puppet.localdomain" <<< "$_client_managed" \
     || fail "/tmp/puppet_managed contains client certname"
 
 # ═════════════════════════════════════════════════════════════════════════
+# Group 3b -- Certificate auto-renewal (real agent, no CSR)
+#
+# Real Puppet/OpenVox agents auto-renew their client cert by default
+# (hostcert_renewal_interval, default 30d): they POST an empty body to
+# /certificate_renewal, relying solely on the mTLS-presented cert to prove
+# identity and key possession, and expect the SAME key reissued with a fresh
+# serial and validity. `puppet ssl renew_cert` drives exactly that code path
+# deterministically (see lib/puppet/application/ssl.rb in the openvox repo),
+# so this exercises the real agent binary against openvox-ca's AutoRenew
+# (internal/ca/signing.go), not just a Go-mocked TLS certificate.
+# ═════════════════════════════════════════════════════════════════════════
+printf '\n# Group 3b -- Certificate auto-renewal (real agent, no CSR)\n'
+
+_client_cert_path=/etc/puppetlabs/puppet/ssl/certs/client.puppet.localdomain.pem
+
+_serial_before=$(exec_client openssl x509 -in "$_client_cert_path" -noout -serial 2>/dev/null) || true
+_pubkey_before=$(exec_client openssl x509 -in "$_client_cert_path" -noout -pubkey 2>/dev/null) || true
+
+RENEW_EXIT=0
+RENEW_OUT=$(exec_client \
+    puppet ssl renew_cert \
+    "${_PUPPET_DIRS[@]}" \
+    --ca_server openvox-ca \
+    --ca_port   8140 \
+    --certname  client.puppet.localdomain \
+    2>&1) || RENEW_EXIT=$?
+
+[ "$RENEW_EXIT" -eq 0 ] \
+    && pass "puppet ssl renew_cert exits 0" \
+    || fail "puppet ssl renew_cert exits 0" "exit code: $RENEW_EXIT; output: $(tail -5 <<< "$RENEW_OUT" | tr '\n' '|')"
+
+grep -qi "Downloaded certificate" <<< "$RENEW_OUT" \
+    && pass "renew_cert output confirms a new certificate was downloaded" \
+    || fail "renew_cert output confirms a new certificate was downloaded" "output: $(tail -5 <<< "$RENEW_OUT" | tr '\n' '|')"
+
+_serial_after=$(exec_client openssl x509 -in "$_client_cert_path" -noout -serial 2>/dev/null) || true
+_pubkey_after=$(exec_client openssl x509 -in "$_client_cert_path" -noout -pubkey 2>/dev/null) || true
+
+[[ -n "$_serial_after" && "$_serial_after" != "$_serial_before" ]] \
+    && pass "renewed cert carries a new serial" \
+    || fail "renewed cert carries a new serial" "before=$_serial_before after=$_serial_after"
+
+[[ -n "$_pubkey_after" && "$_pubkey_after" == "$_pubkey_before" ]] \
+    && pass "renewed cert keeps the same public key (no CSR, no re-key)" \
+    || fail "renewed cert keeps the same public key (no CSR, no re-key)" "public key changed across renewal"
+
+# The renewed cert must still work for a normal agent run (still trusted,
+# same private key on disk as before the renewal).
+AGENT_RENEW_EXIT=0
+AGENT_RENEW_OUT=$(run_agent) || AGENT_RENEW_EXIT=$?
+[[ "$AGENT_RENEW_EXIT" =~ ^(0|2)$ ]] \
+    && pass "Agent run with auto-renewed cert exits 0 or 2" \
+    || fail "Agent run with auto-renewed cert exits 0 or 2" "exit code: $AGENT_RENEW_EXIT; output: $(tail -5 <<< "$AGENT_RENEW_OUT" | tr '\n' '|')"
+
+# ═════════════════════════════════════════════════════════════════════════
 # Group 4 -- Server self-apply
 # ═════════════════════════════════════════════════════════════════════════
 printf '\n# Group 4 -- Server self-apply\n'


### PR DESCRIPTION
Real Puppet/OpenVox agents renew their client certificate by default (`hostcert_renewal_interval`, default 30d) by POSTing an empty body to `/certificate_renewal` and relying solely on the mTLS-presented client certificate to prove identity and key possession — they never send a CSR, and expect the SAME key reissued with a fresh serial and validity. Our existing CSR-only handler rejected every such request with a 400, so a stock agent's automatic renewal silently never worked against openvox-ca (the agent logs a warning and keeps using its current cert).

This adds `CA.AutoRenew`, matching OpenVox Server's own Clojure CA (`renew-certificate!` in `certificate_authority.clj`): it builds the new certificate directly from the already-issued certificate presented over mTLS — no CSR lookup at all, so it also covers certificates whose CSR was deleted after signing (the normal case) or that arrived via migration import with no CSR ever recorded. It carries forward the original certificate's SANs and Puppet OID extensions, and reissues under the same key.

`POST /certificate_renewal` now branches on an empty body to this path; a non-empty body keeps using the existing CSR re-key path unchanged.

The internals of `signWithDuration` were split so the "build template, sign, persist" tail (`issueLeafLocked`) is shared between the CSR path and `AutoRenew`.

**Real-agent regression test:** added Group 3b to `test/puppet/puppet-stack.sh`, which drives the actual `puppet ssl renew_cert` CLI action (the same code path a stock agent's automatic renewal takes) against a live openvox-ca instance in the compose-puppet stack, and asserts: exit 0, a new serial, the same public key, and that the renewed cert still works for a normal agent run. This is deliberately end-to-end with the real `openvox-agent` package rather than a Go-mocked TLS cert, since the bug this PR fixes is specifically a wire-format mismatch that unit tests alone would not catch.

**Scope note:** OpenVox Server's Clojure CA does not revoke the certificate being replaced during this kind of renewal — both the old and new certs (same key) stay valid until the old one naturally expires. This PR preserves that behaviour to match. A follow-up PR (voxpupuli/openvox-ca#114, based on this branch) adds revocation of the superseded certificate as a configurable, secure-by-default option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)