### PR TITLE
Revoke the certificate replaced by renewal, configurable for auto-renew

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,8 +393,10 @@ All endpoints are served under both the bare path and `/puppet-ca/v1/<path>`, so
 
 Requires a valid CA-signed client certificate. The new certificate is issued immediately without entering the pending-CSR queue or autosign evaluation.
 
-- **CSR body (re-key):** the CSR Common Name must match the authenticated client CN — an agent can only renew its own certificate, not another's. Issues a certificate for the new key in the CSR.
-- **Empty body (wire-compatible auto-renewal):** matches the request real Puppet/OpenVox agents send by default (`hostcert_renewal_interval`, and the `puppet ssl renew_cert` CLI action). Identity and key possession come solely from the mTLS-presented client certificate; the same public key is reissued with a fresh serial and validity, carrying forward the original certificate's SANs and Puppet OID extensions unchanged. This mirrors the behaviour of OpenVox Server's own (Clojure) CA: the certificate being replaced is not revoked, so it remains valid for the same key until it naturally expires.
+- **CSR body (re-key):** the CSR Common Name must match the authenticated client CN — an agent can only renew its own certificate, not another's. Issues a certificate for the new key in the CSR. Puppet OID extensions are copied from the CSR **except** authorization-arc OIDs (`1.3.6.1.4.1.34380.1.3.*`, such as `pp_cli_auth`), which are stripped so a submitted CSR cannot request elevated privileges.
+- **Empty body (wire-compatible auto-renewal):** matches the request real Puppet/OpenVox agents send by default (`hostcert_renewal_interval`, and the `puppet ssl renew_cert` CLI action). Identity and key possession come solely from the mTLS-presented client certificate; the same public key is reissued with a fresh serial and validity, carrying forward the original certificate's SANs and Puppet OID extensions unchanged. Unlike the CSR path, this **preserves authorization-arc OIDs** (e.g. `pp_cli_auth`): they were already vetted when the presented certificate was issued, so a cert that legitimately holds them keeps them across renewal. This mirrors the behaviour of OpenVox Server's own (Clojure) CA: the certificate being replaced is not revoked, so it remains valid for the same key until it naturally expires.
+
+If the presented certificate's (or CSR's) key falls below the CA key-strength policy — for example an RSA-1024 key imported from a legacy CA — the request is rejected with `422 Unprocessable Entity` rather than renewed; the agent must re-key via the CSR path with a compliant key.
 
 ### Bulk signing
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ encrypt_ca_key: false           # encrypt the CA private key (AES-256-GCM + Argo
 ca_key_passphrase_file: ""      # path to passphrase file; auto-generated if omitted
 # Date/time format in JSON responses.
 puppet_datetime_format: false   # use Puppet CA style "2006-01-02T15:04:05MST" instead of RFC 3339
+# Certificate auto-renewal (empty-body POST /certificate_renewal).
+revoke_on_auto_renew: true      # false matches OpenVox Server's Clojure CA (no revocation on auto-renewal)
 ```
 
 **Environment variables (mirrors CLI flags):**
@@ -237,6 +239,7 @@ The CA key passphrase can also be provided via `PUPPET_CA_KEY_PASSPHRASE` (env v
 | `etcd_tls_cert_file` | `PUPPET_CA_ETCD_TLS_CERT_FILE` |
 | `etcd_tls_key_file` | `PUPPET_CA_ETCD_TLS_KEY_FILE` |
 | `puppet_datetime_format` | `PUPPET_CA_PUPPET_DATETIME_FORMAT` |
+| `revoke_on_auto_renew` | `PUPPET_CA_REVOKE_ON_AUTO_RENEW` |
 
 > **Note:** `--daemon` is intentionally excluded from config file and environment
 > variable support because `PUPPET_CA_DAEMON` is used internally as the daemon fork
@@ -391,12 +394,14 @@ All endpoints are served under both the bare path and `/puppet-ca/v1/<path>`, so
 |--------|------|-------------|
 | `POST` | `/certificate_renewal` | Renew an existing certificate; body: raw CSR PEM, or empty; returns new certificate PEM |
 
-Requires a valid CA-signed client certificate. The new certificate is issued immediately without entering the pending-CSR queue or autosign evaluation.
+Requires a valid CA-signed client certificate. The new certificate is issued immediately without entering the pending-CSR queue or autosign evaluation, and the certificate it replaces is revoked once the new one is safely stored (see `revoke_on_auto_renew` below for the auto-renewal case).
 
 - **CSR body (re-key):** the CSR Common Name must match the authenticated client CN — an agent can only renew its own certificate, not another's. Issues a certificate for the new key in the CSR. Puppet OID extensions are copied from the CSR **except** authorization-arc OIDs (`1.3.6.1.4.1.34380.1.3.*`, such as `pp_cli_auth`), which are stripped so a submitted CSR cannot request elevated privileges.
-- **Empty body (wire-compatible auto-renewal):** matches the request real Puppet/OpenVox agents send by default (`hostcert_renewal_interval`, and the `puppet ssl renew_cert` CLI action). Identity and key possession come solely from the mTLS-presented client certificate; the same public key is reissued with a fresh serial and validity, carrying forward the original certificate's SANs and Puppet OID extensions unchanged. Unlike the CSR path, this **preserves authorization-arc OIDs** (e.g. `pp_cli_auth`): they were already vetted when the presented certificate was issued, so a cert that legitimately holds them keeps them across renewal. This mirrors the behaviour of OpenVox Server's own (Clojure) CA: the certificate being replaced is not revoked, so it remains valid for the same key until it naturally expires.
+- **Empty body (wire-compatible auto-renewal):** matches the request real Puppet/OpenVox agents send by default (`hostcert_renewal_interval`, and the `puppet ssl renew_cert` CLI action). Identity and key possession come solely from the mTLS-presented client certificate; the same public key is reissued with a fresh serial and validity, carrying forward the original certificate's SANs and Puppet OID extensions unchanged. Unlike the CSR path, this **preserves authorization-arc OIDs** (e.g. `pp_cli_auth`): they were already vetted when the presented certificate was issued, so a cert that legitimately holds them keeps them across renewal.
 
 If the presented certificate's (or CSR's) key falls below the CA key-strength policy — for example an RSA-1024 key imported from a legacy CA — the request is rejected with `422 Unprocessable Entity` rather than renewed; the agent must re-key via the CSR path with a compliant key.
+
+`revoke_on_auto_renew` (env `PUPPET_CA_REVOKE_ON_AUTO_RENEW`, default `true`) controls whether the certificate replaced by an auto-renewal (empty body) is revoked. The default keeps only the newest serial per subject valid. Set to `false` to match OpenVox Server's own (Clojure) CA exactly, which leaves the replaced certificate valid — for the same key — until it naturally expires. This setting has no effect on the CSR-body (re-key) path, which always revokes the certificate it replaces.
 
 ### Bulk signing
 

--- a/README.md
+++ b/README.md
@@ -403,6 +403,8 @@ If the presented certificate's (or CSR's) key falls below the CA key-strength po
 
 `revoke_on_auto_renew` (env `PUPPET_CA_REVOKE_ON_AUTO_RENEW`, default `true`) controls whether the certificate replaced by an auto-renewal (empty body) is revoked. The default keeps only the newest serial per subject valid. Set to `false` to match OpenVox Server's own (Clojure) CA exactly, which leaves the replaced certificate valid — for the same key — until it naturally expires. This setting has no effect on the CSR-body (re-key) path, which always revokes the certificate it replaces.
 
+> **CRL growth:** with the default `true`, every auto-renewal appends the retired serial to the CRL, and the entry stays there until the certificate expires. Entries are only pruned by the expired-certificate cleanup job, which is off by default — enable `enable_expired_cert_cleanup` to bound CRL size on busy CAs, and watch `puppetca_crl_revoked_certificates` to keep an eye on it. Revocation is best-effort (a failure never fails the renewal); the `puppetca_crl_update_failures_total` metric counts any failure to amend the CRL, including a superseded certificate that could not be revoked.
+
 ### Bulk signing
 
 | Method | Path | Description |

--- a/README.md
+++ b/README.md
@@ -389,9 +389,12 @@ All endpoints are served under both the bare path and `/puppet-ca/v1/<path>`, so
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `POST` | `/certificate_renewal` | Renew an existing certificate; body: raw CSR PEM; returns new certificate PEM |
+| `POST` | `/certificate_renewal` | Renew an existing certificate; body: raw CSR PEM, or empty; returns new certificate PEM |
 
-Requires a valid CA-signed client certificate. The CSR Common Name must match the authenticated client CN — an agent can only renew its own certificate, not another's. The new certificate is issued immediately without entering the pending-CSR queue or autosign evaluation.
+Requires a valid CA-signed client certificate. The new certificate is issued immediately without entering the pending-CSR queue or autosign evaluation.
+
+- **CSR body (re-key):** the CSR Common Name must match the authenticated client CN — an agent can only renew its own certificate, not another's. Issues a certificate for the new key in the CSR.
+- **Empty body (wire-compatible auto-renewal):** matches the request real Puppet/OpenVox agents send by default (`hostcert_renewal_interval`, and the `puppet ssl renew_cert` CLI action). Identity and key possession come solely from the mTLS-presented client certificate; the same public key is reissued with a fresh serial and validity, carrying forward the original certificate's SANs and Puppet OID extensions unchanged. This mirrors the behaviour of OpenVox Server's own (Clojure) CA: the certificate being replaced is not revoked, so it remains valid for the same key until it naturally expires.
 
 ### Bulk signing
 

--- a/cmd/openvox-ca/config.go
+++ b/cmd/openvox-ca/config.go
@@ -116,6 +116,12 @@ type serverConfig struct {
 	// PuppetDateTimeFormat formats JSON date/time fields using the original Puppet CA
 	// style ("2006-01-02T15:04:05MST") instead of RFC 3339 (default: false).
 	PuppetDateTimeFormat bool `yaml:"puppet_datetime_format"`
+	// RevokeOnAutoRenew revokes the certificate replaced by the empty-body
+	// (no-CSR) /certificate_renewal auto-renewal path once its successor is
+	// signed and stored, so only the newest serial per subject stays valid
+	// (default: true). Set to false to match OpenVox Server's own Clojure CA,
+	// which leaves the replaced certificate valid until it naturally expires.
+	RevokeOnAutoRenew bool `yaml:"revoke_on_auto_renew"`
 
 	// Storage backend selection and parameters. Embedded inline so the YAML
 	// keys (storage_backend, etcd_*, redis_*, sql_*, ca_cert_file, ca_key_file)
@@ -139,11 +145,12 @@ type serverConfig struct {
 // loading.
 func loadServerConfig(configFile string) (*serverConfig, error) {
 	cfg := &serverConfig{
-		Host:           "0.0.0.0",
-		Port:           8140,
-		CAPathLength:   -1,   // unconstrained; 0 = leaf-only, N = N levels of intermediates
-		CSRRateLimit:   -1,   // unset sentinel; 0 disables, -1 falls back to defaultCSRRateLimit
-		PromoteCNToSAN: true, // RFC 2818: add CN as SAN when CSR has no SANs
+		Host:              "0.0.0.0",
+		Port:              8140,
+		CAPathLength:      -1,   // unconstrained; 0 = leaf-only, N = N levels of intermediates
+		CSRRateLimit:      -1,   // unset sentinel; 0 disables, -1 falls back to defaultCSRRateLimit
+		PromoteCNToSAN:    true, // RFC 2818: add CN as SAN when CSR has no SANs
+		RevokeOnAutoRenew: true, // only the newest serial per subject should be valid
 	}
 
 	if configFile != "" {
@@ -386,6 +393,11 @@ func applyServerEnv(cfg *serverConfig) {
 	if v := os.Getenv("PUPPET_CA_PUPPET_DATETIME_FORMAT"); v != "" {
 		if b, err := strconv.ParseBool(v); err == nil {
 			cfg.PuppetDateTimeFormat = b
+		}
+	}
+	if v := os.Getenv("PUPPET_CA_REVOKE_ON_AUTO_RENEW"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.RevokeOnAutoRenew = b
 		}
 	}
 	if v := os.Getenv("PUPPET_CA_KEY_PASSPHRASE_FILE"); v != "" {

--- a/cmd/openvox-ca/config_test.go
+++ b/cmd/openvox-ca/config_test.go
@@ -182,6 +182,10 @@ var _ = Describe("loadServerConfig built-in defaults", func() {
 		Expect(cfg.NoTLSRequired).To(BeFalse(), "NoTLSRequired = true; want false")
 		Expect(cfg.Verbosity).To(Equal(0), "Verbosity = %d; want 0", cfg.Verbosity)
 		Expect(cfg.CAPathLength).To(Equal(-1), "CAPathLength = %d; want -1 (unconstrained)", cfg.CAPathLength)
+		// Security-relevant default: superseded certificates are revoked on
+		// auto-renewal unless explicitly disabled. Guard the literal so a
+		// regression flipping it to false cannot pass silently.
+		Expect(cfg.RevokeOnAutoRenew).To(BeTrue(), "RevokeOnAutoRenew = false; want true (secure default)")
 	})
 })
 

--- a/cmd/openvox-ca/config_test.go
+++ b/cmd/openvox-ca/config_test.go
@@ -58,6 +58,7 @@ var serverEnvVars = []string{
 	"PUPPET_CA_DISABLE_CRL_REFRESH",
 	"PUPPET_CA_CRL_REFRESH_INTERVAL_SEC",
 	"PUPPET_CA_CRL_REFRESH_BEFORE_SEC",
+	"PUPPET_CA_REVOKE_ON_AUTO_RENEW",
 	"PUPPET_CA_ENABLE_EXPIRED_CERT_CLEANUP",
 	"PUPPET_CA_EXPIRED_CERT_RETENTION_SEC",
 	"PUPPET_CA_EXPIRED_CERT_CLEANUP_INTERVAL_SEC",
@@ -571,6 +572,12 @@ var _ = Describe("applyServerEnv each variable", func() {
 			func(c *serverConfig) bool { return c.CRLRefreshIntervalSec == 900 }, "CRLRefreshIntervalSec"),
 		Entry("CRL_REFRESH_BEFORE_SEC", "PUPPET_CA_CRL_REFRESH_BEFORE_SEC", "86400",
 			func(c *serverConfig) bool { return c.CRLRefreshBeforeSec == 86400 }, "CRLRefreshBeforeSec"),
+		// The zero value of RevokeOnAutoRenew is already false, so assert the
+		// env var flips it to true — a value distinct from the zero value —
+		// which proves the env key is parsed and wired to the right field. A
+		// typo in the env key would then leave it false and fail this entry.
+		Entry("REVOKE_ON_AUTO_RENEW", "PUPPET_CA_REVOKE_ON_AUTO_RENEW", "true",
+			func(c *serverConfig) bool { return c.RevokeOnAutoRenew }, "RevokeOnAutoRenew"),
 		// CA key provider selection and OpenBao settings. Each entry uses a
 		// distinct value and asserts the specific destination field, so a
 		// wrong target (e.g. role-id <-> secret-id, or tls_cert <-> tls_key —

--- a/cmd/openvox-ca/main.go
+++ b/cmd/openvox-ca/main.go
@@ -126,6 +126,7 @@ func applyCAConfig(myCA *ca.CA, cfg *serverConfig) error {
 	myCA.LeafValidityDays = cfg.LeafValidityDays
 	myCA.EncryptCAKey = cfg.EncryptCAKey
 	myCA.PromoteCNToSAN = cfg.PromoteCNToSAN
+	myCA.RevokeOnAutoRenew = cfg.RevokeOnAutoRenew
 	myCA.KeyPassphrase = ca.KeyPassphraseConfig{
 		PassphraseFile: cfg.CAKeyPassphraseFile,
 	}

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -88,6 +88,7 @@ the Unix epoch, the Prometheus convention for `*_timestamp_seconds` gauges.
 | `puppetca_crl_this_update_timestamp_seconds` | CRL `ThisUpdate` time. |
 | `puppetca_crl_next_update_timestamp_seconds` | CRL `NextUpdate` (expiry) time. |
 | `puppetca_crl_revoked_certificates` | Number of certificates currently listed in the CRL. |
+| `puppetca_crl_update_failures_total` | Counter of failures to amend the CRL — a revocation that could not be recorded, or a CRL that could not be re-signed or written (across the revoke, cleanup, reissue and refresh paths). A rising value means the CRL is not being maintained; for revocations it means a superseded certificate may still be a valid credential. Resets to `0` on process restart. |
 
 ### Leaf certificates
 
@@ -128,4 +129,5 @@ sum(rate(puppetca_http_requests_total{code=~"5.."}[5m]))
 
 See the [`mixin/`](../mixin/) directory for the Jsonnet monitoring mixin and
 instructions for rendering or importing it. It alerts on exporter availability,
-CA/CRL/leaf expiry, and pending requests, with all thresholds configurable.
+CA/CRL/leaf expiry, pending requests, and CRL update failures
+(`puppetca_crl_update_failures_total`), with all thresholds configurable.

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1309,6 +1309,26 @@ var _ = Describe("API Workflow", func() {
 			Expect(renewed.SerialNumber.Cmp(clientCert.SerialNumber)).NotTo(Equal(0))
 		})
 
+		// The routing decision uses strings.TrimSpace, so a whitespace-only body
+		// (some clients send a trailing newline) must take the same auto-renewal
+		// path as a truly-empty one — not be treated as a malformed CSR. Guards
+		// against the check regressing to a bare len(body)==0.
+		It("should auto-renew when the body is whitespace only", func() {
+			req := httptest.NewRequest("POST", "/certificate_renewal", bytes.NewReader([]byte("  \n\t")))
+			req.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{clientCert}}
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+			Expect(rr.Code).To(Equal(http.StatusOK))
+
+			block, _ := pem.Decode(rr.Body.Bytes())
+			Expect(block).NotTo(BeNil())
+			renewed, err := x509.ParseCertificate(block.Bytes)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(renewed.PublicKey).To(Equal(clientCert.PublicKey),
+				"whitespace-only body must route to auto-renewal and reissue the same key")
+			Expect(renewed.SerialNumber.Cmp(clientCert.SerialNumber)).NotTo(Equal(0))
+		})
+
 		// A legacy-imported node may present a cert whose key predates this CA's
 		// key-strength policy. The empty-body auto-renewal path must surface that
 		// as a client-actionable 422 (re-key via CSR), not mask it behind a 500.

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -28,6 +28,7 @@ import (
 	"encoding/asn1"
 	"encoding/json"
 	"encoding/pem"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1306,6 +1307,51 @@ var _ = Describe("API Workflow", func() {
 			Expect(renewed.PublicKey).To(Equal(clientCert.PublicKey),
 				"auto-renewal via empty body must not rotate the key")
 			Expect(renewed.SerialNumber.Cmp(clientCert.SerialNumber)).NotTo(Equal(0))
+		})
+
+		// A legacy-imported node may present a cert whose key predates this CA's
+		// key-strength policy. The empty-body auto-renewal path must surface that
+		// as a client-actionable 422 (re-key via CSR), not mask it behind a 500.
+		// This guards the errors.Is(err, ca.ErrKeyPolicy) mapping at the HTTP
+		// layer, which the CA-layer AutoRenew test cannot exercise.
+		It("should return 422 when the presented certificate's key is below policy (empty body)", func() {
+			weakKey, err := rsa.GenerateKey(rand.Reader, 1024)
+			Expect(err).NotTo(HaveOccurred())
+			template := &x509.Certificate{
+				SerialNumber: big.NewInt(1),
+				Subject:      pkix.Name{CommonName: subject},
+				NotBefore:    time.Now().Add(-time.Hour),
+				NotAfter:     time.Now().Add(time.Hour),
+				DNSNames:     []string{subject},
+			}
+			der, err := x509.CreateCertificate(rand.Reader, template, template, &weakKey.PublicKey, weakKey)
+			Expect(err).NotTo(HaveOccurred())
+			weakCert, err := x509.ParseCertificate(der)
+			Expect(err).NotTo(HaveOccurred())
+
+			req := httptest.NewRequest("POST", "/certificate_renewal", bytes.NewReader(nil))
+			req.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{weakCert}}
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+			Expect(rr.Code).To(Equal(http.StatusUnprocessableEntity))
+		})
+
+		// The same key-strength policy applies to a re-key CSR: a CSR carrying a
+		// sub-policy key must yield 422, not the generic 400 (invalid CSR) or a
+		// 500. Guards the second errors.Is(err, ca.ErrKeyPolicy) branch.
+		It("should return 422 when the renewal CSR key is below policy", func() {
+			weakKey, err := rsa.GenerateKey(rand.Reader, 1024)
+			Expect(err).NotTo(HaveOccurred())
+			csrDER, err := x509.CreateCertificateRequest(rand.Reader,
+				&x509.CertificateRequest{Subject: pkix.Name{CommonName: subject}}, weakKey)
+			Expect(err).NotTo(HaveOccurred())
+			weakCSR := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER})
+
+			req := httptest.NewRequest("POST", "/certificate_renewal", bytes.NewReader(weakCSR))
+			req.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{clientCert}}
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+			Expect(rr.Code).To(Equal(http.StatusUnprocessableEntity))
 		})
 	})
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1307,6 +1307,13 @@ var _ = Describe("API Workflow", func() {
 			Expect(renewed.PublicKey).To(Equal(clientCert.PublicKey),
 				"auto-renewal via empty body must not rotate the key")
 			Expect(renewed.SerialNumber.Cmp(clientCert.SerialNumber)).NotTo(Equal(0))
+
+			// Default RevokeOnAutoRenew=true: the pre-renewal serial must no
+			// longer be usable once the renewed cert is safely stored.
+			revoked, err := myCA.IsRevokedSerial(context.Background(), clientCert.SerialNumber)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(revoked).To(BeTrue(),
+				"the pre-renewal serial must be revoked by default after auto-renewal")
 		})
 
 		// The routing decision uses strings.TrimSpace, so a whitespace-only body

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1288,6 +1288,25 @@ var _ = Describe("API Workflow", func() {
 			mux.ServeHTTP(rr, req)
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
 		})
+
+		// Real Puppet/OpenVox agents POST an empty body by default
+		// (hostcert_renewal_interval), relying solely on the mTLS-presented
+		// client cert. This must reissue the SAME key, not require a CSR.
+		It("should auto-renew the presented certificate's own key when the body is empty", func() {
+			req := httptest.NewRequest("POST", "/certificate_renewal", bytes.NewReader(nil))
+			req.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{clientCert}}
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+			Expect(rr.Code).To(Equal(http.StatusOK))
+
+			block, _ := pem.Decode(rr.Body.Bytes())
+			Expect(block).NotTo(BeNil())
+			renewed, err := x509.ParseCertificate(block.Bytes)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(renewed.PublicKey).To(Equal(clientCert.PublicKey),
+				"auto-renewal via empty body must not rotate the key")
+			Expect(renewed.SerialNumber.Cmp(clientCert.SerialNumber)).NotTo(Equal(0))
+		})
 	})
 
 	Context("PuppetDateTimeFormat", func() {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -920,8 +920,10 @@ func (s *Server) handlePostCertificateRenewal(w http.ResponseWriter, r *http.Req
 		// (hostcert_renewal_interval) they POST an empty body here, relying
 		// solely on the mTLS-presented client cert to prove identity and key
 		// possession, and expect the SAME key reissued with a fresh serial
-		// and validity. clientCN(r) already established that r.TLS carries a
-		// verified, non-revoked peer certificate.
+		// and validity. Reissuing without a fresh proof-of-possession is safe
+		// because newAuthMiddleware (the tierAnyClient path guarding this
+		// route) has already verified r.TLS.PeerCertificates[0] chains to our
+		// CA and is not revoked; clientCN(r) only reads its CN.
 		certPEM, err = s.CA.AutoRenew(r.Context(), r.TLS.PeerCertificates[0])
 		if err != nil {
 			// A key-strength rejection is client-actionable: the presented

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -907,34 +907,50 @@ func (s *Server) handlePostCertificateRenewal(w http.ResponseWriter, r *http.Req
 
 	// SECURITY: Limit body to 1 MiB to prevent memory exhaustion.
 	// NIST 800-53: SC-5 (Denial-of-Service Protection)
-	csrPEM, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 	if err != nil {
-		slog.Error("read renewal CSR body failed", "client", cn, "error", err)
+		slog.Error("read renewal body failed", "client", cn, "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
 
-	csr, err := parseCSR(csrPEM)
-	if err != nil {
-		http.Error(w, "invalid CSR: "+err.Error(), http.StatusBadRequest)
-		return
-	}
+	var certPEM []byte
+	if strings.TrimSpace(string(body)) == "" {
+		// Wire-compatible with real Puppet/OpenVox agents: by default
+		// (hostcert_renewal_interval) they POST an empty body here, relying
+		// solely on the mTLS-presented client cert to prove identity and key
+		// possession, and expect the SAME key reissued with a fresh serial
+		// and validity. clientCN(r) already established that r.TLS carries a
+		// verified, non-revoked peer certificate.
+		certPEM, err = s.CA.AutoRenew(r.Context(), r.TLS.PeerCertificates[0])
+		if err != nil {
+			slog.Warn("Auto-renewal failed", "subject", cn, "error", err)
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+			return
+		}
+	} else {
+		csr, err := parseCSR(body)
+		if err != nil {
+			http.Error(w, "invalid CSR: "+err.Error(), http.StatusBadRequest)
+			return
+		}
 
-	// SECURITY: CSR CN must match the authenticated client CN. Without this
-	// check an agent could renew another agent's certificate by sending a CSR
-	// with a different CN while authenticating as itself.
-	// NIST 800-53: IA-5(2) (PKI-Based Authentication)
-	if csr.Subject.CommonName != cn {
-		slog.Warn("Renewal rejected: CN mismatch", "client_cn", cn, "csr_cn", csr.Subject.CommonName)
-		http.Error(w, "CSR CN does not match authenticated client CN", http.StatusForbidden)
-		return
-	}
+		// SECURITY: CSR CN must match the authenticated client CN. Without this
+		// check an agent could renew another agent's certificate by sending a CSR
+		// with a different CN while authenticating as itself.
+		// NIST 800-53: IA-5(2) (PKI-Based Authentication)
+		if csr.Subject.CommonName != cn {
+			slog.Warn("Renewal rejected: CN mismatch", "client_cn", cn, "csr_cn", csr.Subject.CommonName)
+			http.Error(w, "CSR CN does not match authenticated client CN", http.StatusForbidden)
+			return
+		}
 
-	certPEM, err := s.CA.Renew(r.Context(), cn, csrPEM)
-	if err != nil {
-		slog.Warn("Renewal failed", "subject", cn, "error", err)
-		http.Error(w, "internal server error", http.StatusInternalServerError)
-		return
+		certPEM, err = s.CA.Renew(r.Context(), cn, body)
+		if err != nil {
+			slog.Warn("Renewal failed", "subject", cn, "error", err)
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+			return
+		}
 	}
 
 	w.Header().Set("Content-Type", "text/plain")

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -924,6 +924,15 @@ func (s *Server) handlePostCertificateRenewal(w http.ResponseWriter, r *http.Req
 		// verified, non-revoked peer certificate.
 		certPEM, err = s.CA.AutoRenew(r.Context(), r.TLS.PeerCertificates[0])
 		if err != nil {
+			// A key-strength rejection is client-actionable: the presented
+			// cert (e.g. imported from a legacy CA) carries a key below policy
+			// and the agent must re-key via the CSR-based renewal path. Report
+			// it as such rather than masking it behind a 500.
+			if errors.Is(err, ca.ErrKeyPolicy) {
+				slog.Warn("Auto-renewal rejected: key policy", "subject", cn, "error", err)
+				http.Error(w, "certificate key does not meet policy; renew with a new CSR", http.StatusUnprocessableEntity)
+				return
+			}
 			slog.Warn("Auto-renewal failed", "subject", cn, "error", err)
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 			return
@@ -947,6 +956,13 @@ func (s *Server) handlePostCertificateRenewal(w http.ResponseWriter, r *http.Req
 
 		certPEM, err = s.CA.Renew(r.Context(), cn, body)
 		if err != nil {
+			// Same key-strength policy applies to the re-key CSR: surface it as
+			// a client error instead of a 500.
+			if errors.Is(err, ca.ErrKeyPolicy) {
+				slog.Warn("Renewal rejected: key policy", "subject", cn, "error", err)
+				http.Error(w, "CSR key does not meet policy", http.StatusUnprocessableEntity)
+				return
+			}
 			slog.Warn("Renewal failed", "subject", cn, "error", err)
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 			return

--- a/internal/ca/ca.go
+++ b/internal/ca/ca.go
@@ -106,6 +106,16 @@ type CA struct {
 	// handle the SAN extension.
 	PromoteCNToSAN bool
 
+	// RevokeOnAutoRenew, when true (the default), revokes the certificate
+	// being replaced by AutoRenew (the empty-body /certificate_renewal path)
+	// once its successor is safely signed and stored, so only the newest
+	// serial for a subject is ever valid. OpenVox Server's own Clojure CA
+	// does not do this — both the old and new certs (same key) stay valid
+	// until the old one naturally expires. Set to false to match that
+	// behaviour exactly. This does not affect the CSR-based Renew path
+	// (a genuine re-key), which always revokes the certificate it replaces.
+	RevokeOnAutoRenew bool
+
 	// ExternalSigner, when non-nil, is used instead of loading the CA private
 	// key from disk. This enables key isolation: the private key lives in a
 	// separate process and signing requests are proxied over IPC.
@@ -130,13 +140,14 @@ type CA struct {
 
 func New(s *storage.StorageService, autosignCfg AutosignConfig, hostname string) *CA {
 	return &CA{
-		Storage:        s,
-		AutosignConfig: autosignCfg,
-		Hostname:       hostname,
-		CAPathLength:   -1,   // unconstrained by default
-		PromoteCNToSAN: true, // on by default; RFC 2818 deprecates CN-only certs
-		serialIndex:    make(map[string]string),
-		ocspCache:      make(map[string]ocspCacheEntry),
+		Storage:           s,
+		AutosignConfig:    autosignCfg,
+		Hostname:          hostname,
+		CAPathLength:      -1,   // unconstrained by default
+		PromoteCNToSAN:    true, // on by default; RFC 2818 deprecates CN-only certs
+		RevokeOnAutoRenew: true, // on by default; only the newest serial should be valid
+		serialIndex:       make(map[string]string),
+		ocspCache:         make(map[string]ocspCacheEntry),
 	}
 }
 

--- a/internal/ca/ca.go
+++ b/internal/ca/ca.go
@@ -22,6 +22,7 @@ import (
 	"crypto"
 	"crypto/x509"
 	"sync"
+	"sync/atomic"
 
 	"github.com/voxpupuli/openvox-ca/internal/storage"
 )
@@ -136,6 +137,17 @@ type CA struct {
 	ocspCache   map[string]ocspCacheEntry // same key; protected by mu
 	cachedCRL   *x509.RevocationList      // in-memory CRL for auth checks; protected by mu
 	mu          sync.RWMutex
+
+	// crlUpdateFailures counts failures to amend the CRL: a revocation that
+	// could not be recorded (bad serial, unreadable CRL) or a CRL that could
+	// not be re-signed or written (during revoke, cleanup, reissue or refresh).
+	// Some callers treat these as fatal and return the error; others — notably
+	// the best-effort revoke of a superseded certificate on renewal — swallow
+	// it so the primary operation still succeeds. Either way a rising count
+	// means the CRL is not being maintained and, for revocations, that a
+	// superseded certificate may still be a valid credential. Exposed via the
+	// metrics exporter (puppetca_crl_update_failures_total) for alerting.
+	crlUpdateFailures atomic.Uint64
 }
 
 func New(s *storage.StorageService, autosignCfg AutosignConfig, hostname string) *CA {
@@ -149,6 +161,15 @@ func New(s *storage.StorageService, autosignCfg AutosignConfig, hostname string)
 		serialIndex:       make(map[string]string),
 		ocspCache:         make(map[string]ocspCacheEntry),
 	}
+}
+
+// CRLUpdateFailures returns the number of times the CA failed to amend the
+// CRL — a revocation it could not record, or a CRL it could not re-sign or
+// write (across the revoke, cleanup, reissue and refresh paths). A rising
+// value means the CRL is not being maintained; the metrics exporter surfaces
+// it as puppetca_crl_update_failures_total.
+func (c *CA) CRLUpdateFailures() uint64 {
+	return c.crlUpdateFailures.Load()
 }
 
 // IsReady reports whether the CA has been fully initialized and can serve requests.

--- a/internal/ca/ca_test.go
+++ b/internal/ca/ca_test.go
@@ -570,6 +570,26 @@ var _ = Describe("CA Revocation", func() {
 		Expect(myCA.Revoke(context.Background(), "never-signed")).To(HaveOccurred())
 	})
 
+	It("counts a CRL-update failure when a revocation cannot amend the CRL", func() {
+		// The crlUpdateFailures counter is general, not renewal-specific: it must
+		// move for any failed CRL amendment. Sign a cert, corrupt the stored CRL,
+		// then revoke — revocation cannot parse the CRL, so it fails and the
+		// failure is counted for alerting even though it is surfaced to the caller.
+		csrPEM, err := testutil.GenerateCSR("revoke-count-node")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = myCA.SaveRequest(context.Background(), "revoke-count-node", csrPEM)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = myCA.Sign(context.Background(), "revoke-count-node")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(myCA.CRLUpdateFailures()).To(BeNumerically("==", 0))
+		Expect(store.UpdateCRL(context.Background(), []byte("not a valid CRL"))).To(Succeed())
+
+		Expect(myCA.Revoke(context.Background(), "revoke-count-node")).To(HaveOccurred())
+		Expect(myCA.CRLUpdateFailures()).To(BeNumerically("==", 1),
+			"a failed CRL amendment must be counted regardless of the caller")
+	})
+
 	It("IsRevokedSerial returns true for a revoked certificate's serial", func() {
 		csrPEM, err := testutil.GenerateCSR("serial-revoke-node")
 		Expect(err).NotTo(HaveOccurred())

--- a/internal/ca/crl.go
+++ b/internal/ca/crl.go
@@ -47,11 +47,13 @@ func (c *CA) signCRLLocked(ctx context.Context, prevNumber *big.Int, revoked []x
 
 	crlBytes, err := x509.CreateRevocationList(rand.Reader, template, c.CACert, c.CAKey)
 	if err != nil {
+		c.crlUpdateFailures.Add(1)
 		return fmt.Errorf("failed to sign CRL: %w", err)
 	}
 
 	newCRLPEM := pem.EncodeToMemory(&pem.Block{Type: "X509 CRL", Bytes: crlBytes})
 	if err := c.Storage.UpdateCRL(ctx, newCRLPEM); err != nil {
+		c.crlUpdateFailures.Add(1)
 		return fmt.Errorf("failed to write CRL: %w", err)
 	}
 

--- a/internal/ca/keys.go
+++ b/internal/ca/keys.go
@@ -26,8 +26,15 @@ import (
 	"crypto/sha1"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 )
+
+// ErrKeyPolicy is wrapped by validatePublicKey when a presented or submitted
+// public key fails the CA's key-strength policy. It lets callers distinguish a
+// client-actionable rejection (re-key with a stronger key) from an internal
+// fault, so the HTTP layer can answer 4xx rather than 5xx.
+var ErrKeyPolicy = errors.New("public key does not meet the CA key-strength policy")
 
 // KeyAlgo identifies the asymmetric key algorithm to use when generating a key.
 type KeyAlgo string
@@ -96,7 +103,7 @@ func validatePublicKey(pub crypto.PublicKey) error {
 	switch k := pub.(type) {
 	case *rsa.PublicKey:
 		if bits := k.N.BitLen(); bits < 2048 {
-			return fmt.Errorf("RSA public key size %d is below the minimum of 2048 bits", bits)
+			return fmt.Errorf("%w: RSA public key size %d is below the minimum of 2048 bits", ErrKeyPolicy, bits)
 		}
 		return nil
 	case *ecdsa.PublicKey:
@@ -108,10 +115,10 @@ func validatePublicKey(pub crypto.PublicKey) error {
 			if k.Curve != nil {
 				name = k.Curve.Params().Name
 			}
-			return fmt.Errorf("unsupported ECDSA curve %q (must be P-256, P-384, or P-521)", name)
+			return fmt.Errorf("%w: unsupported ECDSA curve %q (must be P-256, P-384, or P-521)", ErrKeyPolicy, name)
 		}
 	default:
-		return fmt.Errorf("unsupported public key type %T (must be RSA >= 2048 bits or ECDSA P-256/P-384/P-521)", pub)
+		return fmt.Errorf("%w: unsupported public key type %T (must be RSA >= 2048 bits or ECDSA P-256/P-384/P-521)", ErrKeyPolicy, pub)
 	}
 }
 

--- a/internal/ca/renew_test.go
+++ b/internal/ca/renew_test.go
@@ -340,4 +340,29 @@ var _ = Describe("CA AutoRenew", func() {
 		Expect(renewed.PublicKey).To(Equal(original.PublicKey))
 		Expect(renewed.SerialNumber.Cmp(original.SerialNumber)).NotTo(Equal(0))
 	})
+
+	It("rejects a sub-policy key with ErrKeyPolicy rather than a generic failure", func() {
+		// A legacy-CA cert may carry an RSA-1024 key that predates this CA's
+		// policy. Auto-renewal must refuse to perpetuate it, and the error
+		// must be classifiable so the HTTP layer answers 4xx, not 5xx.
+		key, err := rsa.GenerateKey(rand.Reader, 1024)
+		Expect(err).NotTo(HaveOccurred())
+		serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+		Expect(err).NotTo(HaveOccurred())
+		now := time.Now().UTC()
+		template := &x509.Certificate{
+			SerialNumber: serial,
+			Subject:      pkix.Name{CommonName: "weak-key-node"},
+			NotBefore:    now.Add(-24 * time.Hour),
+			NotAfter:     now.Add(365 * 24 * time.Hour),
+			DNSNames:     []string{"weak-key-node"},
+		}
+		der, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
+		Expect(err).NotTo(HaveOccurred())
+		original, err := x509.ParseCertificate(der)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = myCA.AutoRenew(ctx, original)
+		Expect(err).To(MatchError(ca.ErrKeyPolicy))
+	})
 })

--- a/internal/ca/renew_test.go
+++ b/internal/ca/renew_test.go
@@ -198,37 +198,50 @@ var _ = Describe("CA AutoRenew", func() {
 		return parseCertPEM(certPEM)
 	}
 
-	// seedCertWithoutCSR mints a leaf certificate directly with the cached
-	// test CA's key and stores it as subject's cert, without ever writing a
-	// CSR to storage — simulating a certificate imported from a migration
-	// (see the storage migrate command) or any other cert whose CSR has
-	// since been cleaned up. AutoRenew must work from the certificate alone.
-	seedCertWithoutCSR := func(subject string) *x509.Certificate {
-		key, err := rsa.GenerateKey(rand.Reader, 2048)
+	// mintLeaf signs a leaf certificate directly with the cached test CA key
+	// from template — generating an RSA key of keyBits and a random 128-bit
+	// serial when the template has none — and returns the parsed certificate.
+	// It does not touch storage; callers that need the cert on disk store it
+	// themselves. This collapses the key-gen / serial / CreateCertificate
+	// scaffolding shared by the direct-mint specs below (which simulate certs
+	// imported from a legacy CA, where AutoRenew works from the cert alone).
+	mintLeaf := func(keyBits int, template *x509.Certificate) *x509.Certificate {
+		key, err := rsa.GenerateKey(rand.Reader, keyBits)
 		Expect(err).NotTo(HaveOccurred())
-		serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
-		Expect(err).NotTo(HaveOccurred())
-		now := time.Now().UTC()
-		template := &x509.Certificate{
-			SerialNumber: serial,
-			Subject:      pkix.Name{CommonName: subject},
-			NotBefore:    now.Add(-24 * time.Hour),
-			NotAfter:     now.Add(365 * 24 * time.Hour),
-			DNSNames:     []string{subject},
+		if template.SerialNumber == nil {
+			serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+			Expect(err).NotTo(HaveOccurred())
+			template.SerialNumber = serial
 		}
 		der, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
 		Expect(err).NotTo(HaveOccurred())
-		certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+		return parseCertPEM(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+	}
+
+	// seedCertWithoutCSR mints a leaf certificate (via mintLeaf) and stores it
+	// as subject's cert, without ever writing a CSR to storage — simulating a
+	// certificate imported from a migration (see the storage migrate command)
+	// or any other cert whose CSR has since been cleaned up. AutoRenew must
+	// work from the certificate alone.
+	seedCertWithoutCSR := func(subject string) *x509.Certificate {
+		now := time.Now().UTC()
+		cert := mintLeaf(2048, &x509.Certificate{
+			Subject:   pkix.Name{CommonName: subject},
+			NotBefore: now.Add(-24 * time.Hour),
+			NotAfter:  now.Add(365 * 24 * time.Hour),
+			DNSNames:  []string{subject},
+		})
+		certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
 		Expect(store.SaveCert(ctx, subject, certPEM)).To(Succeed())
 
 		entry := fmt.Sprintf("%s %s %s /%s",
-			serial.Text(16),
-			template.NotBefore.Format("2006-01-02T15:04:05UTC"),
-			template.NotAfter.Format("2006-01-02T15:04:05UTC"),
+			cert.SerialNumber.Text(16),
+			cert.NotBefore.Format("2006-01-02T15:04:05UTC"),
+			cert.NotAfter.Format("2006-01-02T15:04:05UTC"),
 			subject)
 		Expect(store.AppendInventory(ctx, entry)).To(Succeed())
 
-		return parseCertPEM(certPEM)
+		return cert
 	}
 
 	BeforeEach(func() {
@@ -278,7 +291,34 @@ var _ = Describe("CA AutoRenew", func() {
 			"stored cert must match the auto-renewed serial")
 	})
 
-	It("carries the original certificate's SANs forward unchanged", func() {
+	It("extends the validity window, not just the serial", func() {
+		// The whole point of a renewal is a later expiry. Seed a nearly-expired
+		// cert (a few minutes of life left) so the reissue's fresh window — even
+		// after being capped to the test CA cert's own remaining lifetime — is
+		// unambiguously later. This can't rely on the happy-path spec, where the
+		// original and renewed windows differ only by the sub-second gap between
+		// two signings and both round to the same second. Guards a regression
+		// that reissued with the same or a shorter validity, leaving the agent's
+		// cert to expire on its original schedule despite a "successful" renewal.
+		now := time.Now().UTC()
+		original := mintLeaf(2048, &x509.Certificate{
+			Subject:   pkix.Name{CommonName: "autorenew-expiry-node"},
+			NotBefore: now.Add(-1 * time.Hour),
+			NotAfter:  now.Add(5 * time.Minute),
+			DNSNames:  []string{"autorenew-expiry-node"},
+		})
+
+		renewedPEM, err := myCA.AutoRenew(ctx, original)
+		Expect(err).NotTo(HaveOccurred())
+		renewed := parseCertPEM(renewedPEM)
+
+		Expect(renewed.NotAfter).To(BeTemporally(">", original.NotAfter),
+			"auto-renewal must extend validity, not just mint a new serial")
+	})
+
+	It("carries the original certificate's DNS SANs forward unchanged", func() {
+		// A CSR-issued openvox-ca cert carries only DNS SANs, so this asserts
+		// DNSNames; the IP/email/URI SAN types are covered by the next spec.
 		csrPEM, _ := buildCSR("autorenew-sans-node")
 		_, err := myCA.SaveRequest(ctx, "autorenew-sans-node", csrPEM)
 		Expect(err).NotTo(HaveOccurred())
@@ -297,15 +337,10 @@ var _ = Describe("CA AutoRenew", func() {
 		// openvox-ca only ever issues DNS SANs itself, but a leaf imported
 		// from a legacy CA can carry IP/email/URI SANs that services depend
 		// on. Mint such a cert directly and prove auto-renewal preserves them.
-		key, err := rsa.GenerateKey(rand.Reader, 2048)
-		Expect(err).NotTo(HaveOccurred())
-		serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
-		Expect(err).NotTo(HaveOccurred())
 		now := time.Now().UTC()
 		uri, err := url.Parse("spiffe://puppet.test/node/legacy-sans-node")
 		Expect(err).NotTo(HaveOccurred())
-		template := &x509.Certificate{
-			SerialNumber:   serial,
+		original := mintLeaf(2048, &x509.Certificate{
 			Subject:        pkix.Name{CommonName: "legacy-sans-node"},
 			NotBefore:      now.Add(-24 * time.Hour),
 			NotAfter:       now.Add(365 * 24 * time.Hour),
@@ -313,11 +348,7 @@ var _ = Describe("CA AutoRenew", func() {
 			IPAddresses:    []net.IP{net.ParseIP("10.0.0.1"), net.ParseIP("fd00::1")},
 			EmailAddresses: []string{"node@puppet.test"},
 			URIs:           []*url.URL{uri},
-		}
-		der, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
-		Expect(err).NotTo(HaveOccurred())
-		original, err := x509.ParseCertificate(der)
-		Expect(err).NotTo(HaveOccurred())
+		})
 
 		renewedPEM, err := myCA.AutoRenew(ctx, original)
 		Expect(err).NotTo(HaveOccurred())
@@ -346,24 +377,15 @@ var _ = Describe("CA AutoRenew", func() {
 		// A legacy-CA cert may carry an RSA-1024 key that predates this CA's
 		// policy. Auto-renewal must refuse to perpetuate it, and the error
 		// must be classifiable so the HTTP layer answers 4xx, not 5xx.
-		key, err := rsa.GenerateKey(rand.Reader, 1024)
-		Expect(err).NotTo(HaveOccurred())
-		serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
-		Expect(err).NotTo(HaveOccurred())
 		now := time.Now().UTC()
-		template := &x509.Certificate{
-			SerialNumber: serial,
-			Subject:      pkix.Name{CommonName: "weak-key-node"},
-			NotBefore:    now.Add(-24 * time.Hour),
-			NotAfter:     now.Add(365 * 24 * time.Hour),
-			DNSNames:     []string{"weak-key-node"},
-		}
-		der, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
-		Expect(err).NotTo(HaveOccurred())
-		original, err := x509.ParseCertificate(der)
-		Expect(err).NotTo(HaveOccurred())
+		original := mintLeaf(1024, &x509.Certificate{
+			Subject:   pkix.Name{CommonName: "weak-key-node"},
+			NotBefore: now.Add(-24 * time.Hour),
+			NotAfter:  now.Add(365 * 24 * time.Hour),
+			DNSNames:  []string{"weak-key-node"},
+		})
 
-		_, err = myCA.AutoRenew(ctx, original)
+		_, err := myCA.AutoRenew(ctx, original)
 		Expect(err).To(MatchError(ca.ErrKeyPolicy))
 	})
 
@@ -375,11 +397,6 @@ var _ = Describe("CA AutoRenew", func() {
 		// (e.g. OpenVox Server's own cert) must keep it across auto-renewal, or
 		// the puppetserver CA CLI stops authenticating. This locks in that
 		// deliberate asymmetry with the CSR path.
-		key, err := rsa.GenerateKey(rand.Reader, 2048)
-		Expect(err).NotTo(HaveOccurred())
-		serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
-		Expect(err).NotTo(HaveOccurred())
-
 		authVal, err := asn1.Marshal("true")
 		Expect(err).NotTo(HaveOccurred())
 		roleVal, err := asn1.Marshal("web")
@@ -390,21 +407,16 @@ var _ = Describe("CA AutoRenew", func() {
 		ppRole := asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 34380, 1, 1, 13}
 
 		now := time.Now().UTC()
-		template := &x509.Certificate{
-			SerialNumber: serial,
-			Subject:      pkix.Name{CommonName: "autorenew-oid-node"},
-			NotBefore:    now.Add(-24 * time.Hour),
-			NotAfter:     now.Add(365 * 24 * time.Hour),
-			DNSNames:     []string{"autorenew-oid-node"},
+		original := mintLeaf(2048, &x509.Certificate{
+			Subject:   pkix.Name{CommonName: "autorenew-oid-node"},
+			NotBefore: now.Add(-24 * time.Hour),
+			NotAfter:  now.Add(365 * 24 * time.Hour),
+			DNSNames:  []string{"autorenew-oid-node"},
 			ExtraExtensions: []pkix.Extension{
 				{Id: ca.OIDPpCliAuth, Value: authVal}, // auth-arc: CSR path would strip this
 				{Id: ppRole, Value: roleVal},          // node-attr arc: always carried
 			},
-		}
-		der, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
-		Expect(err).NotTo(HaveOccurred())
-		original, err := x509.ParseCertificate(der)
-		Expect(err).NotTo(HaveOccurred())
+		})
 
 		renewedPEM, err := myCA.AutoRenew(ctx, original)
 		Expect(err).NotTo(HaveOccurred())

--- a/internal/ca/renew_test.go
+++ b/internal/ca/renew_test.go
@@ -23,6 +23,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/asn1"
 	"encoding/pem"
 	"fmt"
 	"math/big"
@@ -364,5 +365,67 @@ var _ = Describe("CA AutoRenew", func() {
 
 		_, err = myCA.AutoRenew(ctx, original)
 		Expect(err).To(MatchError(ca.ErrKeyPolicy))
+	})
+
+	It("carries Puppet OID extensions forward, including auth OIDs the CSR path would strip", func() {
+		// Unlike the CSR signing path (which strips authorization-arc OIDs such
+		// as pp_cli_auth as an anti-escalation control), AutoRenew preserves
+		// every Puppet-arc OID because they were already vetted when the
+		// presented cert was issued. A cert legitimately carrying pp_cli_auth
+		// (e.g. OpenVox Server's own cert) must keep it across auto-renewal, or
+		// the puppetserver CA CLI stops authenticating. This locks in that
+		// deliberate asymmetry with the CSR path.
+		key, err := rsa.GenerateKey(rand.Reader, 2048)
+		Expect(err).NotTo(HaveOccurred())
+		serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+		Expect(err).NotTo(HaveOccurred())
+
+		authVal, err := asn1.Marshal("true")
+		Expect(err).NotTo(HaveOccurred())
+		roleVal, err := asn1.Marshal("web")
+		Expect(err).NotTo(HaveOccurred())
+		// pp_role lives in the node-attribute arc (…34380.1.1.*), not the auth
+		// arc, so both the CSR path and AutoRenew carry it; pp_cli_auth lives in
+		// the auth arc (…34380.1.3.*) that only AutoRenew preserves.
+		ppRole := asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 34380, 1, 1, 13}
+
+		now := time.Now().UTC()
+		template := &x509.Certificate{
+			SerialNumber: serial,
+			Subject:      pkix.Name{CommonName: "autorenew-oid-node"},
+			NotBefore:    now.Add(-24 * time.Hour),
+			NotAfter:     now.Add(365 * 24 * time.Hour),
+			DNSNames:     []string{"autorenew-oid-node"},
+			ExtraExtensions: []pkix.Extension{
+				{Id: ca.OIDPpCliAuth, Value: authVal}, // auth-arc: CSR path would strip this
+				{Id: ppRole, Value: roleVal},          // node-attr arc: always carried
+			},
+		}
+		der, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
+		Expect(err).NotTo(HaveOccurred())
+		original, err := x509.ParseCertificate(der)
+		Expect(err).NotTo(HaveOccurred())
+
+		renewedPEM, err := myCA.AutoRenew(ctx, original)
+		Expect(err).NotTo(HaveOccurred())
+		renewed := parseCertPEM(renewedPEM)
+
+		findExt := func(cert *x509.Certificate, oid asn1.ObjectIdentifier) (pkix.Extension, bool) {
+			for _, ext := range cert.Extensions {
+				if ext.Id.Equal(oid) {
+					return ext, true
+				}
+			}
+			return pkix.Extension{}, false
+		}
+
+		authExt, ok := findExt(renewed, ca.OIDPpCliAuth)
+		Expect(ok).To(BeTrue(),
+			"auto-renewal must carry the pp_cli_auth auth OID forward, unlike the CSR path")
+		Expect(authExt.Value).To(Equal(authVal))
+
+		roleExt, ok := findExt(renewed, ppRole)
+		Expect(ok).To(BeTrue(), "auto-renewal must carry the pp_role OID forward")
+		Expect(roleExt.Value).To(Equal(roleVal))
 	})
 })

--- a/internal/ca/renew_test.go
+++ b/internal/ca/renew_test.go
@@ -26,6 +26,8 @@ import (
 	"encoding/pem"
 	"fmt"
 	"math/big"
+	"net"
+	"net/url"
 	"os"
 	"time"
 
@@ -288,6 +290,42 @@ var _ = Describe("CA AutoRenew", func() {
 		renewed := parseCertPEM(renewedPEM)
 
 		Expect(renewed.DNSNames).To(Equal(original.DNSNames))
+	})
+
+	It("carries non-DNS SANs (IP, email, URI) forward, e.g. from a legacy-CA cert", func() {
+		// openvox-ca only ever issues DNS SANs itself, but a leaf imported
+		// from a legacy CA can carry IP/email/URI SANs that services depend
+		// on. Mint such a cert directly and prove auto-renewal preserves them.
+		key, err := rsa.GenerateKey(rand.Reader, 2048)
+		Expect(err).NotTo(HaveOccurred())
+		serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+		Expect(err).NotTo(HaveOccurred())
+		now := time.Now().UTC()
+		uri, err := url.Parse("spiffe://puppet.test/node/legacy-sans-node")
+		Expect(err).NotTo(HaveOccurred())
+		template := &x509.Certificate{
+			SerialNumber:   serial,
+			Subject:        pkix.Name{CommonName: "legacy-sans-node"},
+			NotBefore:      now.Add(-24 * time.Hour),
+			NotAfter:       now.Add(365 * 24 * time.Hour),
+			DNSNames:       []string{"legacy-sans-node", "legacy-sans-node.puppet.test"},
+			IPAddresses:    []net.IP{net.ParseIP("10.0.0.1"), net.ParseIP("fd00::1")},
+			EmailAddresses: []string{"node@puppet.test"},
+			URIs:           []*url.URL{uri},
+		}
+		der, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
+		Expect(err).NotTo(HaveOccurred())
+		original, err := x509.ParseCertificate(der)
+		Expect(err).NotTo(HaveOccurred())
+
+		renewedPEM, err := myCA.AutoRenew(ctx, original)
+		Expect(err).NotTo(HaveOccurred())
+		renewed := parseCertPEM(renewedPEM)
+
+		Expect(renewed.DNSNames).To(Equal(original.DNSNames))
+		Expect(renewed.IPAddresses).To(Equal(original.IPAddresses))
+		Expect(renewed.EmailAddresses).To(Equal(original.EmailAddresses))
+		Expect(renewed.URIs).To(Equal(original.URIs))
 	})
 
 	It("auto-renews a certificate that has no CSR in storage, e.g. after migration import", func() {

--- a/internal/ca/renew_test.go
+++ b/internal/ca/renew_test.go
@@ -149,6 +149,19 @@ var _ = Describe("CA Renew", func() {
 			"renewal must fail when the CSR signature is invalid")
 	})
 
+	It("revokes the replaced certificate's serial so only the renewed one is active", func() {
+		original := issue("renew-node")
+
+		csrPEM, _ := buildCSR("renew-node")
+		_, err := myCA.Renew(ctx, "renew-node", csrPEM)
+		Expect(err).NotTo(HaveOccurred())
+
+		revoked, err := myCA.IsRevokedSerial(ctx, original.SerialNumber)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(revoked).To(BeTrue(),
+			"the pre-renewal serial must be revoked so it can no longer authenticate or pass OCSP/CRL checks")
+	})
+
 	It("renews a subject that has no prior certificate", func() {
 		// Renew bypasses the pending-CSR queue, so it can issue even when no
 		// certificate exists yet. Guards that the happy path does not depend on
@@ -439,5 +452,34 @@ var _ = Describe("CA AutoRenew", func() {
 		roleExt, ok := findExt(renewed, ppRole)
 		Expect(ok).To(BeTrue(), "auto-renewal must carry the pp_role OID forward")
 		Expect(roleExt.Value).To(Equal(roleVal))
+	})
+
+	It("revokes the replaced certificate by default, so only the newest serial is active", func() {
+		Expect(myCA.RevokeOnAutoRenew).To(BeTrue(),
+			"revoke-on-auto-renew must default to true (secure by default)")
+
+		original := issue("autorenew-revoke-node")
+
+		_, err := myCA.AutoRenew(ctx, original)
+		Expect(err).NotTo(HaveOccurred())
+
+		revoked, err := myCA.IsRevokedSerial(ctx, original.SerialNumber)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(revoked).To(BeTrue(),
+			"the pre-renewal serial must be revoked so it can no longer authenticate or pass OCSP/CRL checks")
+	})
+
+	It("leaves the replaced certificate valid when RevokeOnAutoRenew is disabled, matching Clojure CA", func() {
+		myCA.RevokeOnAutoRenew = false
+
+		original := issue("autorenew-no-revoke-node")
+
+		_, err := myCA.AutoRenew(ctx, original)
+		Expect(err).NotTo(HaveOccurred())
+
+		revoked, err := myCA.IsRevokedSerial(ctx, original.SerialNumber)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(revoked).To(BeFalse(),
+			"with RevokeOnAutoRenew disabled, the pre-renewal certificate must remain valid for its key, as OpenVox Server's Clojure CA does")
 	})
 })

--- a/internal/ca/renew_test.go
+++ b/internal/ca/renew_test.go
@@ -162,6 +162,28 @@ var _ = Describe("CA Renew", func() {
 			"the pre-renewal serial must be revoked so it can no longer authenticate or pass OCSP/CRL checks")
 	})
 
+	It("still returns the renewed certificate when revoking the replaced one fails", func() {
+		// Revoking the superseded serial is deliberately best-effort: a failure
+		// there must NOT undo the renewal the caller is waiting on. Corrupt the
+		// stored CRL so revocation fails, then assert Renew still succeeds with a
+		// fresh serial and records the failure via the metrics counter. Without
+		// this, a refactor turning the best-effort log into `return err` would
+		// pass every other spec while breaking renewal whenever the CRL is
+		// unreadable.
+		original := issue("renew-revoke-fail-node")
+		Expect(store.UpdateCRL(ctx, []byte("not a valid CRL"))).To(Succeed())
+
+		csrPEM, _ := buildCSR("renew-revoke-fail-node")
+		renewedPEM, err := myCA.Renew(ctx, "renew-revoke-fail-node", csrPEM)
+		Expect(err).NotTo(HaveOccurred(),
+			"a failed revocation of the replaced cert must not fail the renewal")
+		renewed := parseCertPEM(renewedPEM)
+		Expect(renewed.SerialNumber.Cmp(original.SerialNumber)).NotTo(Equal(0),
+			"the renewal must still issue a fresh serial")
+		Expect(myCA.CRLUpdateFailures()).To(BeNumerically("==", 1),
+			"the best-effort revoke failure must be counted for alerting")
+	})
+
 	It("renews a subject that has no prior certificate", func() {
 		// Renew bypasses the pending-CSR queue, so it can issue even when no
 		// certificate exists yet. Guards that the happy path does not depend on
@@ -474,12 +496,37 @@ var _ = Describe("CA AutoRenew", func() {
 
 		original := issue("autorenew-no-revoke-node")
 
-		_, err := myCA.AutoRenew(ctx, original)
+		renewedPEM, err := myCA.AutoRenew(ctx, original)
 		Expect(err).NotTo(HaveOccurred())
+
+		// Assert an actual reissue happened, not an early no-op: a fresh serial
+		// for the same subject proves the disabled flag skipped only the
+		// revocation, not the renewal itself.
+		renewed := parseCertPEM(renewedPEM)
+		Expect(renewed.SerialNumber.Cmp(original.SerialNumber)).NotTo(Equal(0),
+			"AutoRenew must still reissue with a fresh serial even when revocation is disabled")
 
 		revoked, err := myCA.IsRevokedSerial(ctx, original.SerialNumber)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(revoked).To(BeFalse(),
 			"with RevokeOnAutoRenew disabled, the pre-renewal certificate must remain valid for its key, as OpenVox Server's Clojure CA does")
+	})
+
+	It("still returns the renewed certificate when revoking the replaced one fails", func() {
+		// The auto-renewal revoke is best-effort, exactly like Renew's rekey
+		// path: a failed revocation must not undo the renewal the agent is
+		// waiting on. Corrupt the CRL so revocation fails, then assert AutoRenew
+		// still reissues and the failure is counted for alerting.
+		original := issue("autorenew-revoke-fail-node")
+		Expect(store.UpdateCRL(ctx, []byte("not a valid CRL"))).To(Succeed())
+
+		renewedPEM, err := myCA.AutoRenew(ctx, original)
+		Expect(err).NotTo(HaveOccurred(),
+			"a failed revocation of the replaced cert must not fail the auto-renewal")
+		renewed := parseCertPEM(renewedPEM)
+		Expect(renewed.SerialNumber.Cmp(original.SerialNumber)).NotTo(Equal(0),
+			"the auto-renewal must still issue a fresh serial")
+		Expect(myCA.CRLUpdateFailures()).To(BeNumerically("==", 1),
+			"the best-effort revoke failure must be counted for alerting")
 	})
 })

--- a/internal/ca/renew_test.go
+++ b/internal/ca/renew_test.go
@@ -24,7 +24,10 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"fmt"
+	"math/big"
 	"os"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -156,5 +159,147 @@ var _ = Describe("CA Renew", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(parseCertPEM(storedPEM).SerialNumber.Sign()).To(Equal(1),
 			"stored renewed cert must carry a positive serial")
+	})
+})
+
+// CA AutoRenew covers the wire-compatible "no CSR" renewal flow real
+// Puppet/OpenVox agents use by default (hostcert_renewal_interval): the
+// client presents its existing cert over mTLS and gets back a certificate
+// for the SAME public key, with a fresh serial and validity. This matches
+// OpenVox Server's own Clojure CA (renew-certificate!), which does not
+// revoke the certificate being replaced.
+var _ = Describe("CA AutoRenew", func() {
+	var (
+		ctx    = context.Background()
+		tmpDir string
+		myCA   *ca.CA
+		store  *storage.StorageService
+		caKey  *rsa.PrivateKey
+		caCert *x509.Certificate
+	)
+
+	parseCertPEM := func(certPEM []byte) *x509.Certificate {
+		block, _ := pem.Decode(certPEM)
+		Expect(block).NotTo(BeNil(), "renewed cert PEM must decode")
+		cert, err := x509.ParseCertificate(block.Bytes)
+		Expect(err).NotTo(HaveOccurred())
+		return cert
+	}
+
+	issue := func(subject string) *x509.Certificate {
+		csrPEM, _ := buildCSR(subject)
+		_, err := myCA.SaveRequest(ctx, subject, csrPEM)
+		Expect(err).NotTo(HaveOccurred())
+		certPEM, err := myCA.Sign(ctx, subject)
+		Expect(err).NotTo(HaveOccurred())
+		return parseCertPEM(certPEM)
+	}
+
+	// seedCertWithoutCSR mints a leaf certificate directly with the cached
+	// test CA's key and stores it as subject's cert, without ever writing a
+	// CSR to storage — simulating a certificate imported from a migration
+	// (see the storage migrate command) or any other cert whose CSR has
+	// since been cleaned up. AutoRenew must work from the certificate alone.
+	seedCertWithoutCSR := func(subject string) *x509.Certificate {
+		key, err := rsa.GenerateKey(rand.Reader, 2048)
+		Expect(err).NotTo(HaveOccurred())
+		serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+		Expect(err).NotTo(HaveOccurred())
+		now := time.Now().UTC()
+		template := &x509.Certificate{
+			SerialNumber: serial,
+			Subject:      pkix.Name{CommonName: subject},
+			NotBefore:    now.Add(-24 * time.Hour),
+			NotAfter:     now.Add(365 * 24 * time.Hour),
+			DNSNames:     []string{subject},
+		}
+		der, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
+		Expect(err).NotTo(HaveOccurred())
+		certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+		Expect(store.SaveCert(ctx, subject, certPEM)).To(Succeed())
+
+		entry := fmt.Sprintf("%s %s %s /%s",
+			serial.Text(16),
+			template.NotBefore.Format("2006-01-02T15:04:05UTC"),
+			template.NotAfter.Format("2006-01-02T15:04:05UTC"),
+			subject)
+		Expect(store.AppendInventory(ctx, entry)).To(Succeed())
+
+		return parseCertPEM(certPEM)
+	}
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "openvox-ca-autorenew-test")
+		Expect(err).NotTo(HaveOccurred())
+
+		store = storage.New(tmpDir)
+		myCA = ca.New(store, ca.AutosignConfig{Mode: "off"}, "puppet.test")
+
+		Expect(store.EnsureDirs(ctx)).To(Succeed())
+		Expect(store.SaveCAKey(ctx, cachedKeyPEM)).To(Succeed())
+		Expect(store.SaveCACert(ctx, cachedCrtPEM)).To(Succeed())
+		Expect(store.UpdateCRL(ctx, cachedCrlPEM)).To(Succeed())
+		Expect(store.WriteSerial(ctx, "0001")).To(Succeed())
+		Expect(store.TouchInventory(ctx)).To(Succeed())
+		Expect(myCA.Init(ctx)).To(Succeed())
+
+		keyBlock, _ := pem.Decode(cachedKeyPEM)
+		caKey, err = x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+		Expect(err).NotTo(HaveOccurred())
+		certBlock, _ := pem.Decode(cachedCrtPEM)
+		caCert, err = x509.ParseCertificate(certBlock.Bytes)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(tmpDir)
+	})
+
+	It("reissues the same public key with a fresh serial, matching Clojure CA semantics", func() {
+		original := issue("autorenew-node")
+
+		renewedPEM, err := myCA.AutoRenew(ctx, original)
+		Expect(err).NotTo(HaveOccurred())
+		renewed := parseCertPEM(renewedPEM)
+
+		Expect(renewed.Subject.CommonName).To(Equal("autorenew-node"))
+		Expect(renewed.PublicKey).To(Equal(original.PublicKey),
+			"auto-renewal must not rotate the key, only the serial/validity")
+		Expect(renewed.SerialNumber.Cmp(original.SerialNumber)).NotTo(Equal(0),
+			"auto-renewed cert must carry a different serial than the original")
+
+		storedPEM, err := store.GetCert(ctx, "autorenew-node")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(parseCertPEM(storedPEM).SerialNumber.Cmp(renewed.SerialNumber)).To(Equal(0),
+			"stored cert must match the auto-renewed serial")
+	})
+
+	It("carries the original certificate's SANs forward unchanged", func() {
+		csrPEM, _ := buildCSR("autorenew-sans-node")
+		_, err := myCA.SaveRequest(ctx, "autorenew-sans-node", csrPEM)
+		Expect(err).NotTo(HaveOccurred())
+		certPEM, err := myCA.Sign(ctx, "autorenew-sans-node")
+		Expect(err).NotTo(HaveOccurred())
+		original := parseCertPEM(certPEM)
+
+		renewedPEM, err := myCA.AutoRenew(ctx, original)
+		Expect(err).NotTo(HaveOccurred())
+		renewed := parseCertPEM(renewedPEM)
+
+		Expect(renewed.DNSNames).To(Equal(original.DNSNames))
+	})
+
+	It("auto-renews a certificate that has no CSR in storage, e.g. after migration import", func() {
+		original := seedCertWithoutCSR("migrated-node")
+		Expect(store.HasCSR(ctx, "migrated-node")).To(BeFalse(),
+			"this test only proves anything if there really is no CSR to fall back on")
+
+		renewedPEM, err := myCA.AutoRenew(ctx, original)
+		Expect(err).NotTo(HaveOccurred())
+		renewed := parseCertPEM(renewedPEM)
+
+		Expect(renewed.PublicKey).To(Equal(original.PublicKey))
+		Expect(renewed.SerialNumber.Cmp(original.SerialNumber)).NotTo(Equal(0))
 	})
 })

--- a/internal/ca/revoke.go
+++ b/internal/ca/revoke.go
@@ -51,18 +51,34 @@ func (c *CA) Revoke(ctx context.Context, subject string) error {
 func (c *CA) revokeLocked(ctx context.Context, subject string) error {
 	slog.Debug("Revoking certificate", "subject", subject)
 
-	// 1. Find Serial
 	serialStr, err := c.findSerialForSubject(ctx, subject)
 	if err != nil {
 		return fmt.Errorf("could not find certificate for subject %s: %w", subject, err)
 	}
 
-	serialInt := new(big.Int)
-	if _, ok := serialInt.SetString(serialStr, 16); !ok {
-		return fmt.Errorf("malformed serial %q for subject %s in inventory", serialStr, subject)
+	if err := c.revokeSerialLocked(ctx, serialStr); err != nil {
+		return err
 	}
 
-	// 2. Load CRL
+	slog.Debug("Certificate revoked", "subject", subject, "serial", serialStr)
+	return nil
+}
+
+// revokeSerialLocked adds serialStr to the CRL, unless it is already present.
+// The cluster CRL lock and c.mu must both be held by the caller.
+//
+// This is split out from revokeLocked so Renew and AutoRenew can revoke the
+// exact serial of the certificate they are replacing. By the time either
+// wants to revoke, issueLeafLocked has already appended the new cert's row
+// to the inventory, so findSerialForSubject (latest-issued-for-subject) would
+// resolve to the new serial rather than the one being retired.
+func (c *CA) revokeSerialLocked(ctx context.Context, serialStr string) error {
+	serialInt := new(big.Int)
+	if _, ok := serialInt.SetString(serialStr, 16); !ok {
+		return fmt.Errorf("malformed serial %q", serialStr)
+	}
+
+	// 1. Load CRL
 	crlPEM, err := c.Storage.GetCRL(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to load CRL: %w", err)
@@ -76,16 +92,16 @@ func (c *CA) revokeLocked(ctx context.Context, subject string) error {
 		return fmt.Errorf("failed to parse CRL: %w", err)
 	}
 
-	// 3. Check for duplicate revocation: a serial that's already in the CRL
+	// 2. Check for duplicate revocation: a serial that's already in the CRL
 	// should not be appended again (prevents unbounded CRL growth on retries).
 	for _, entry := range crl.RevokedCertificateEntries {
 		if entry.SerialNumber.Cmp(serialInt) == 0 {
-			slog.Debug("Certificate already revoked", "subject", subject, "serial", serialStr)
+			slog.Debug("Certificate already revoked", "serial", serialStr)
 			return nil
 		}
 	}
 
-	// 4. Prepare New CRL
+	// 3. Prepare New CRL
 	newRevoked := x509.RevocationListEntry{
 		SerialNumber:   serialInt,
 		RevocationTime: time.Now(),
@@ -103,7 +119,6 @@ func (c *CA) revokeLocked(ctx context.Context, subject string) error {
 	// Use the same normalised key as the OCSP index (uppercase hex, no padding).
 	delete(c.ocspCache, serialHexStr(serialInt))
 
-	slog.Debug("Certificate revoked", "subject", subject, "serial", serialStr)
 	return nil
 }
 

--- a/internal/ca/revoke.go
+++ b/internal/ca/revoke.go
@@ -75,21 +75,15 @@ func (c *CA) revokeLocked(ctx context.Context, subject string) error {
 func (c *CA) revokeSerialLocked(ctx context.Context, serialStr string) error {
 	serialInt := new(big.Int)
 	if _, ok := serialInt.SetString(serialStr, 16); !ok {
+		c.crlUpdateFailures.Add(1)
 		return fmt.Errorf("malformed serial %q", serialStr)
 	}
 
 	// 1. Load CRL
-	crlPEM, err := c.Storage.GetCRL(ctx)
+	crl, err := c.readStoredCRL(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to load CRL: %w", err)
-	}
-	block, _ := pem.Decode(crlPEM)
-	if block == nil {
-		return fmt.Errorf("failed to decode CRL PEM")
-	}
-	crl, err := x509.ParseRevocationList(block.Bytes)
-	if err != nil {
-		return fmt.Errorf("failed to parse CRL: %w", err)
+		c.crlUpdateFailures.Add(1)
+		return err
 	}
 
 	// 2. Check for duplicate revocation: a serial that's already in the CRL
@@ -101,7 +95,9 @@ func (c *CA) revokeSerialLocked(ctx context.Context, serialStr string) error {
 		}
 	}
 
-	// 3. Prepare New CRL
+	// 3. Append the new entry and re-sign. signCRLLocked counts its own
+	// sign/write failures into crlUpdateFailures, so this path does not
+	// double-count them.
 	newRevoked := x509.RevocationListEntry{
 		SerialNumber:   serialInt,
 		RevocationTime: time.Now(),

--- a/internal/ca/signing.go
+++ b/internal/ca/signing.go
@@ -769,6 +769,14 @@ func (c *CA) AutoRenew(ctx context.Context, presentedCert *x509.Certificate) ([]
 
 	var extraExtensions []pkix.Extension
 	for _, ext := range presentedCert.Extensions {
+		// Carry EVERY Puppet OID forward, including authorization-arc OIDs
+		// (pp_cli_auth et al.). Unlike signWithDuration's CSR path — which adds
+		// `&& !IsAuthOID(ext.Id)` here to strip auth OIDs as an anti-escalation
+		// control — these were already vetted when presentedCert was issued, so
+		// preserving them is required for wire-compat (e.g. OpenVox Server's own
+		// cert keeps pp_cli_auth across renewal, or the CA CLI stops
+		// authenticating). Do NOT add an IsAuthOID filter here; see this
+		// method's godoc. NIST 800-53: AC-6, CM-7.
 		if IsPuppetOID(ext.Id) {
 			extraExtensions = append(extraExtensions, ext)
 		}

--- a/internal/ca/signing.go
+++ b/internal/ca/signing.go
@@ -731,13 +731,18 @@ func (c *CA) Renew(ctx context.Context, subject string, csrPEM []byte) ([]byte, 
 			return fmt.Errorf("looking up existing certificate for %s: %w", subject, err)
 		}
 
-		c.mu.Lock()
-		if err := c.Storage.SaveCSR(ctx, subject, csrPEM); err != nil {
-			c.mu.Unlock()
-			return fmt.Errorf("saving renewal CSR: %w", err)
-		}
-		certPEM, err := c.signWithDuration(ctx, subject, 0)
-		c.mu.Unlock()
+		// Save the renewal CSR and sign the replacement while holding c.mu,
+		// releasing it via defer before the revoke step below re-acquires it
+		// (c.mu is non-reentrant). The closure keeps the unlock panic-safe: a
+		// panic mid-sign still frees the lock rather than wedging the CA.
+		certPEM, err := func() ([]byte, error) {
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			if err := c.Storage.SaveCSR(ctx, subject, csrPEM); err != nil {
+				return nil, fmt.Errorf("saving renewal CSR: %w", err)
+			}
+			return c.signWithDuration(ctx, subject, 0)
+		}()
 		if err != nil {
 			return err
 		}
@@ -756,6 +761,8 @@ func (c *CA) Renew(ctx context.Context, subject string, csrPEM []byte) ([]byte, 
 			defer c.mu.Unlock()
 			return c.revokeSerialLocked(ctx, oldSerial)
 		}); err != nil {
+			// revokeSerialLocked/signCRLLocked already count this into
+			// crlUpdateFailures; here we only note it and let the renewal stand.
 			slog.Warn("Renew: failed to revoke replaced certificate", "subject", subject, "serial", oldSerial, "error", err)
 		}
 		return nil
@@ -820,19 +827,25 @@ func (c *CA) AutoRenew(ctx context.Context, presentedCert *x509.Certificate) ([]
 
 	var out []byte
 	err := c.Storage.WithLock(ctx, subjectLockName(subject), func() error {
-		c.mu.Lock()
-		// Carry forward every SAN type from the certificate being renewed,
-		// not just DNS names: a leaf imported from a legacy CA may carry IP,
-		// email, or URI SANs that services still depend on, and auto-renewal
-		// must not silently drop them.
-		sans := subjectAltNames{
-			DNSNames:       presentedCert.DNSNames,
-			IPAddresses:    presentedCert.IPAddresses,
-			EmailAddresses: presentedCert.EmailAddresses,
-			URIs:           presentedCert.URIs,
-		}
-		certPEM, err := c.issueLeafLocked(ctx, subject, presentedCert.Subject, presentedCert.PublicKey, sans, extraExtensions, 0)
-		c.mu.Unlock()
+		// Issue the replacement while holding c.mu, releasing it via defer
+		// before the revoke step below re-acquires it (c.mu is non-reentrant).
+		// The closure keeps the unlock panic-safe: a panic mid-issue still
+		// frees the lock rather than wedging the CA.
+		certPEM, err := func() ([]byte, error) {
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			// Carry forward every SAN type from the certificate being renewed,
+			// not just DNS names: a leaf imported from a legacy CA may carry IP,
+			// email, or URI SANs that services still depend on, and auto-renewal
+			// must not silently drop them.
+			sans := subjectAltNames{
+				DNSNames:       presentedCert.DNSNames,
+				IPAddresses:    presentedCert.IPAddresses,
+				EmailAddresses: presentedCert.EmailAddresses,
+				URIs:           presentedCert.URIs,
+			}
+			return c.issueLeafLocked(ctx, subject, presentedCert.Subject, presentedCert.PublicKey, sans, extraExtensions, 0)
+		}()
 		if err != nil {
 			return err
 		}
@@ -851,6 +864,8 @@ func (c *CA) AutoRenew(ctx context.Context, presentedCert *x509.Certificate) ([]
 			defer c.mu.Unlock()
 			return c.revokeSerialLocked(ctx, oldSerial)
 		}); err != nil {
+			// revokeSerialLocked/signCRLLocked already count this into
+			// crlUpdateFailures; here we only note it and let the renewal stand.
 			slog.Warn("AutoRenew: failed to revoke replaced certificate", "subject", subject, "serial", oldSerial, "error", err)
 		}
 		return nil

--- a/internal/ca/signing.go
+++ b/internal/ca/signing.go
@@ -210,9 +210,11 @@ func (c *CA) sign(ctx context.Context, subject string) ([]byte, error) {
 // ttl=0 means use the default certValidity.
 // c.mu must be held by the caller.
 func (c *CA) signWithDuration(ctx context.Context, subject string, ttl time.Duration) ([]byte, error) {
-	// Defensive: a nil CACert here means the caller skipped Init() (or it
-	// failed). Without this guard the c.CACert.NotAfter dereference below
-	// would panic the entire frontend.
+	// Fail fast on an uninitialised CA (caller skipped Init(), or it failed)
+	// before we bother reading a CSR from storage, so Sign() returns a clear
+	// ErrNotInitialized rather than a misleading "CSR not found". The actual
+	// c.CACert dereference happens later in issueLeafLocked, which carries the
+	// same guard for callers (e.g. AutoRenew) that reach it by other paths.
 	if c.CACert == nil || c.CAKey == nil {
 		return nil, ErrNotInitialized
 	}

--- a/internal/ca/signing.go
+++ b/internal/ca/signing.go
@@ -30,6 +30,8 @@ import (
 	"fmt"
 	"log/slog"
 	"math/big"
+	"net"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -282,7 +284,7 @@ func (c *CA) signWithDuration(ctx context.Context, subject string, ttl time.Dura
 		}
 	}
 
-	certPEM, err := c.issueLeafLocked(ctx, subject, csr.Subject, csr.PublicKey, dnsNames, extraExtensions, ttl)
+	certPEM, err := c.issueLeafLocked(ctx, subject, csr.Subject, csr.PublicKey, subjectAltNames{DNSNames: dnsNames}, extraExtensions, ttl)
 	if err != nil {
 		return nil, err
 	}
@@ -295,6 +297,17 @@ func (c *CA) signWithDuration(ctx context.Context, subject string, ttl time.Dura
 	return certPEM, nil
 }
 
+// subjectAltNames carries the full set of Subject Alternative Name entries
+// copied onto an issued leaf certificate. Bundling them keeps issueLeafLocked's
+// signature manageable and ensures every SAN type is threaded through together,
+// rather than DNS names alone.
+type subjectAltNames struct {
+	DNSNames       []string
+	IPAddresses    []net.IP
+	EmailAddresses []string
+	URIs           []*url.URL
+}
+
 // issueLeafLocked builds, signs, and persists a leaf certificate for subject
 // from the given public key, SANs, and extra (Puppet OID) extensions, then
 // appends the inventory entry and updates the in-memory serial index.
@@ -303,7 +316,7 @@ func (c *CA) signWithDuration(ctx context.Context, subject string, ttl time.Dura
 // This is the tail shared by signWithDuration (inputs come from a submitted
 // CSR, after CSR-specific validation) and AutoRenew (inputs come from an
 // already-issued certificate's public key, with no CSR involved at all).
-func (c *CA) issueLeafLocked(ctx context.Context, subject string, subjectName pkix.Name, pubKey any, dnsNames []string, extraExtensions []pkix.Extension, ttl time.Duration) ([]byte, error) {
+func (c *CA) issueLeafLocked(ctx context.Context, subject string, subjectName pkix.Name, pubKey any, sans subjectAltNames, extraExtensions []pkix.Extension, ttl time.Duration) ([]byte, error) {
 	// Defensive: a nil CACert here means the caller skipped Init() (or it
 	// failed). Without this guard the c.CACert.NotAfter dereference below
 	// would panic the entire frontend.
@@ -360,7 +373,10 @@ func (c *CA) issueLeafLocked(ctx context.Context, subject string, subjectName pk
 		SubjectKeyId:   subjectKeyID[:],
 		AuthorityKeyId: c.CACert.SubjectKeyId,
 
-		DNSNames: dnsNames,
+		DNSNames:       sans.DNSNames,
+		IPAddresses:    sans.IPAddresses,
+		EmailAddresses: sans.EmailAddresses,
+		URIs:           sans.URIs,
 	}
 
 	// CRL Distribution Points: embed CRL URL(s) when configured so that
@@ -760,7 +776,17 @@ func (c *CA) AutoRenew(ctx context.Context, presentedCert *x509.Certificate) ([]
 	err := c.Storage.WithLock(ctx, subjectLockName(subject), func() error {
 		c.mu.Lock()
 		defer c.mu.Unlock()
-		certPEM, err := c.issueLeafLocked(ctx, subject, presentedCert.Subject, presentedCert.PublicKey, presentedCert.DNSNames, extraExtensions, 0)
+		// Carry forward every SAN type from the certificate being renewed,
+		// not just DNS names: a leaf imported from a legacy CA may carry IP,
+		// email, or URI SANs that services still depend on, and auto-renewal
+		// must not silently drop them.
+		sans := subjectAltNames{
+			DNSNames:       presentedCert.DNSNames,
+			IPAddresses:    presentedCert.IPAddresses,
+			EmailAddresses: presentedCert.EmailAddresses,
+			URIs:           presentedCert.URIs,
+		}
+		certPEM, err := c.issueLeafLocked(ctx, subject, presentedCert.Subject, presentedCert.PublicKey, sans, extraExtensions, 0)
 		if err != nil {
 			return err
 		}

--- a/internal/ca/signing.go
+++ b/internal/ca/signing.go
@@ -28,6 +28,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"math/big"
 	"net"
@@ -681,7 +682,10 @@ func (c *CA) SaveRequest(ctx context.Context, subject string, csrPEM []byte) (bo
 
 // Renew issues a replacement certificate for subject from the provided CSR,
 // bypassing the pending-CSR queue and autosign check. The existing certificate
-// (if any) is replaced atomically under the per-subject distributed lock.
+// (if any) is replaced atomically under the per-subject distributed lock, and
+// revoked once its successor is safely signed and stored: a CSR-based renewal
+// is a genuine re-key, so the old key/cert must not remain a valid credential
+// once the new one takes over.
 //
 // The caller is responsible for verifying that the CSR CN matches the
 // authenticated client's CN before calling Renew; this method enforces that
@@ -715,16 +719,45 @@ func (c *CA) Renew(ctx context.Context, subject string, csrPEM []byte) ([]byte, 
 	defer cancel()
 	var out []byte
 	err = c.Storage.WithLock(ctx, subjectLockName(subject), func() error {
+		// Capture the serial of the certificate being replaced, if any, before
+		// signing overwrites the cert blob and appends a new inventory row —
+		// afterwards LatestSerialForSubject would resolve to the *new* serial,
+		// not the one being retired.
+		oldSerial, hadOldCert := "", false
+		switch s, err := c.Storage.LatestSerialForSubject(ctx, subject); {
+		case err == nil:
+			oldSerial, hadOldCert = s, true
+		case !errors.Is(err, fs.ErrNotExist):
+			return fmt.Errorf("looking up existing certificate for %s: %w", subject, err)
+		}
+
 		c.mu.Lock()
-		defer c.mu.Unlock()
 		if err := c.Storage.SaveCSR(ctx, subject, csrPEM); err != nil {
+			c.mu.Unlock()
 			return fmt.Errorf("saving renewal CSR: %w", err)
 		}
 		certPEM, err := c.signWithDuration(ctx, subject, 0)
+		c.mu.Unlock()
 		if err != nil {
 			return err
 		}
 		out = certPEM
+
+		if !hadOldCert {
+			return nil
+		}
+		// Revoke the certificate just replaced so its serial can no longer
+		// pass CRL/OCSP checks now that it is no longer the cert served for
+		// this subject. Best-effort like Clean's revoke-then-delete: a
+		// failure here shouldn't undo the renewal the caller is waiting on.
+		// Lock ordering: subject-lock (held) -> CRL-lock -> c.mu, matching Clean.
+		if err := c.Storage.WithLock(ctx, lockNameCRL, func() error {
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			return c.revokeSerialLocked(ctx, oldSerial)
+		}); err != nil {
+			slog.Warn("Renew: failed to revoke replaced certificate", "subject", subject, "serial", oldSerial, "error", err)
+		}
 		return nil
 	})
 	return out, err
@@ -742,10 +775,12 @@ func (c *CA) Renew(ctx context.Context, subject string, csrPEM []byte) ([]byte, 
 // was issued; only the serial, validity window, and key identifiers are
 // refreshed.
 //
-// This matches the behaviour of OpenVox Server's own Clojure CA
-// (renew-certificate! in certificate_authority.clj): the certificate being
-// replaced is not revoked, so both the old and new certificates remain valid
-// (for the same key) until the old one naturally expires.
+// By default the certificate being replaced is revoked once its successor is
+// safely signed and stored, so only the newest serial for a subject is ever
+// valid (see c.RevokeOnAutoRenew). OpenVox Server's own Clojure CA
+// (renew-certificate! in certificate_authority.clj) does not do this — both
+// the old and new certificates (same key) remain valid until the old one
+// naturally expires; set RevokeOnAutoRenew to false to match that exactly.
 //
 // The caller must NOT hold c.mu. Same cross-node guarantees as Sign.
 func (c *CA) AutoRenew(ctx context.Context, presentedCert *x509.Certificate) ([]byte, error) {
@@ -781,11 +816,11 @@ func (c *CA) AutoRenew(ctx context.Context, presentedCert *x509.Certificate) ([]
 			extraExtensions = append(extraExtensions, ext)
 		}
 	}
+	oldSerial := serialHexStr(presentedCert.SerialNumber)
 
 	var out []byte
 	err := c.Storage.WithLock(ctx, subjectLockName(subject), func() error {
 		c.mu.Lock()
-		defer c.mu.Unlock()
 		// Carry forward every SAN type from the certificate being renewed,
 		// not just DNS names: a leaf imported from a legacy CA may carry IP,
 		// email, or URI SANs that services still depend on, and auto-renewal
@@ -797,10 +832,27 @@ func (c *CA) AutoRenew(ctx context.Context, presentedCert *x509.Certificate) ([]
 			URIs:           presentedCert.URIs,
 		}
 		certPEM, err := c.issueLeafLocked(ctx, subject, presentedCert.Subject, presentedCert.PublicKey, sans, extraExtensions, 0)
+		c.mu.Unlock()
 		if err != nil {
 			return err
 		}
 		out = certPEM
+
+		if !c.RevokeOnAutoRenew {
+			return nil
+		}
+		// Revoke the certificate just replaced, same as Renew's rekey path:
+		// only the newest serial should ever be valid for a subject. Best
+		// effort: a failure here shouldn't undo the renewal the agent is
+		// waiting on.
+		// Lock ordering: subject-lock (held) -> CRL-lock -> c.mu, matching Clean.
+		if err := c.Storage.WithLock(ctx, lockNameCRL, func() error {
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			return c.revokeSerialLocked(ctx, oldSerial)
+		}); err != nil {
+			slog.Warn("AutoRenew: failed to revoke replaced certificate", "subject", subject, "serial", oldSerial, "error", err)
+		}
 		return nil
 	})
 	return out, err

--- a/internal/ca/signing.go
+++ b/internal/ca/signing.go
@@ -262,6 +262,55 @@ func (c *CA) signWithDuration(ctx context.Context, subject string, ttl time.Dura
 		}
 	}
 
+	dnsNames := csr.DNSNames
+	// RFC 2818 §3.1: TLS clients match the server name against SANs, not the
+	// CN. When the CSR carries no SANs and promotion is enabled, add the CN as
+	// a DNS SAN so that the issued certificate works with modern TLS stacks.
+	if c.PromoteCNToSAN && len(dnsNames) == 0 && csr.Subject.CommonName != "" {
+		dnsNames = []string{csr.Subject.CommonName}
+	}
+
+	// SECURITY: Copy Puppet OID extensions from the CSR, excluding
+	// authorization-arc OIDs (1.3.6.1.4.1.34380.1.3.*). Allowing CSRs to
+	// inject auth OIDs like pp_cli_auth would let any agent request admin
+	// privileges, which is a direct privilege escalation.
+	// NIST 800-53: AC-6 (Least Privilege), CM-7 (Least Functionality)
+	var extraExtensions []pkix.Extension
+	for _, ext := range csr.Extensions {
+		if IsPuppetOID(ext.Id) && !IsAuthOID(ext.Id) {
+			extraExtensions = append(extraExtensions, ext)
+		}
+	}
+
+	certPEM, err := c.issueLeafLocked(ctx, subject, csr.Subject, csr.PublicKey, dnsNames, extraExtensions, ttl)
+	if err != nil {
+		return nil, err
+	}
+
+	// Remove the pending CSR now that we have a signed cert.
+	if err := c.Storage.DeleteCSR(ctx, subject); err != nil {
+		slog.Warn("Could not delete CSR after signing", "subject", subject, "error", err)
+	}
+
+	return certPEM, nil
+}
+
+// issueLeafLocked builds, signs, and persists a leaf certificate for subject
+// from the given public key, SANs, and extra (Puppet OID) extensions, then
+// appends the inventory entry and updates the in-memory serial index.
+// ttl=0 means use the default certValidity. c.mu must be held by the caller.
+//
+// This is the tail shared by signWithDuration (inputs come from a submitted
+// CSR, after CSR-specific validation) and AutoRenew (inputs come from an
+// already-issued certificate's public key, with no CSR involved at all).
+func (c *CA) issueLeafLocked(ctx context.Context, subject string, subjectName pkix.Name, pubKey any, dnsNames []string, extraExtensions []pkix.Extension, ttl time.Duration) ([]byte, error) {
+	// Defensive: a nil CACert here means the caller skipped Init() (or it
+	// failed). Without this guard the c.CACert.NotAfter dereference below
+	// would panic the entire frontend.
+	if c.CACert == nil || c.CAKey == nil {
+		return nil, ErrNotInitialized
+	}
+
 	// SECURITY: Generate a random 128-bit serial number (CA/Browser Forum guidance).
 	// NIST 800-53: SC-12 (Cryptographic Key Establishment and Management)
 	serialLimit := new(big.Int).Lsh(big.NewInt(1), 128)
@@ -290,7 +339,7 @@ func (c *CA) signWithDuration(ctx context.Context, subject string, ttl time.Dura
 	validity = min(validity, caRemaining)
 
 	// SubjectKeyIdentifier: SHA1 of the SubjectPublicKeyInfo DER (RFC 5280 §4.2.1.2).
-	pubKeyDER, err := x509.MarshalPKIXPublicKey(csr.PublicKey)
+	pubKeyDER, err := x509.MarshalPKIXPublicKey(pubKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal public key for %s: %w", subject, err)
 	}
@@ -298,7 +347,7 @@ func (c *CA) signWithDuration(ctx context.Context, subject string, ttl time.Dura
 
 	template := &x509.Certificate{
 		SerialNumber: serialInt,
-		Subject:      csr.Subject,
+		Subject:      subjectName,
 		NotBefore:    now.Add(-24 * time.Hour),
 		NotAfter:     now.Add(validity),
 
@@ -311,14 +360,7 @@ func (c *CA) signWithDuration(ctx context.Context, subject string, ttl time.Dura
 		SubjectKeyId:   subjectKeyID[:],
 		AuthorityKeyId: c.CACert.SubjectKeyId,
 
-		DNSNames: csr.DNSNames,
-	}
-
-	// RFC 2818 §3.1: TLS clients match the server name against SANs, not the
-	// CN. When the CSR carries no SANs and promotion is enabled, add the CN as
-	// a DNS SAN so that the issued certificate works with modern TLS stacks.
-	if c.PromoteCNToSAN && len(template.DNSNames) == 0 && csr.Subject.CommonName != "" {
-		template.DNSNames = []string{csr.Subject.CommonName}
+		DNSNames: dnsNames,
 	}
 
 	// CRL Distribution Points: embed CRL URL(s) when configured so that
@@ -339,16 +381,7 @@ func (c *CA) signWithDuration(ctx context.Context, subject string, ttl time.Dura
 		})
 	}
 
-	// SECURITY: Copy Puppet OID extensions from the CSR, excluding
-	// authorization-arc OIDs (1.3.6.1.4.1.34380.1.3.*). Allowing CSRs to
-	// inject auth OIDs like pp_cli_auth would let any agent request admin
-	// privileges, which is a direct privilege escalation.
-	// NIST 800-53: AC-6 (Least Privilege), CM-7 (Least Functionality)
-	for _, ext := range csr.Extensions {
-		if IsPuppetOID(ext.Id) && !IsAuthOID(ext.Id) {
-			template.ExtraExtensions = append(template.ExtraExtensions, ext)
-		}
-	}
+	template.ExtraExtensions = append(template.ExtraExtensions, extraExtensions...)
 
 	// SECURITY: two complementary controls guard against signing under a key
 	// that doesn't match the CA certificate (e.g. an OpenBao Transit key
@@ -370,7 +403,7 @@ func (c *CA) signWithDuration(ctx context.Context, subject string, ttl time.Dura
 	// round trip, and under key isolation no RPC beyond the one Sign this call
 	// already makes.
 	// NIST 800-53: SC-12 (Cryptographic Key Establishment and Management)
-	certBytes, err := x509.CreateCertificate(rand.Reader, template, c.CACert, csr.PublicKey, c.CAKey)
+	certBytes, err := x509.CreateCertificate(rand.Reader, template, c.CACert, pubKey, c.CAKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign certificate for %s: %w", subject, err)
 	}
@@ -394,11 +427,6 @@ func (c *CA) signWithDuration(ctx context.Context, subject string, ttl time.Dura
 
 	// Update in-memory serial index for O(1) OCSP lookups.
 	c.serialIndex[serialStr] = subject
-
-	// Remove the pending CSR now that we have a signed cert.
-	if err := c.Storage.DeleteCSR(ctx, subject); err != nil {
-		slog.Warn("Could not delete CSR after signing", "subject", subject, "error", err)
-	}
 
 	slog.Debug("Certificate signed",
 		"subject", subject,
@@ -675,6 +703,64 @@ func (c *CA) Renew(ctx context.Context, subject string, csrPEM []byte) ([]byte, 
 			return fmt.Errorf("saving renewal CSR: %w", err)
 		}
 		certPEM, err := c.signWithDuration(ctx, subject, 0)
+		if err != nil {
+			return err
+		}
+		out = certPEM
+		return nil
+	})
+	return out, err
+}
+
+// AutoRenew reissues a certificate for the same public key as presentedCert —
+// the certificate that authenticated this request over mTLS — instead of
+// requiring a fresh CSR. This is the wire-compatible counterpart to the "no
+// CSR" renewal flow real Puppet/OpenVox agents use by default (see
+// Puppet's `hostcert_renewal_interval`, default 30 days): the mTLS handshake
+// already proved possession of the private key, so a second
+// proof-of-possession isn't required. presentedCert's SANs and Puppet OID
+// extensions — including any auth OIDs such as pp_cli_auth — are carried
+// forward verbatim, since they were already vetted when presentedCert itself
+// was issued; only the serial, validity window, and key identifiers are
+// refreshed.
+//
+// This matches the behaviour of OpenVox Server's own Clojure CA
+// (renew-certificate! in certificate_authority.clj): the certificate being
+// replaced is not revoked, so both the old and new certificates remain valid
+// (for the same key) until the old one naturally expires.
+//
+// The caller must NOT hold c.mu. Same cross-node guarantees as Sign.
+func (c *CA) AutoRenew(ctx context.Context, presentedCert *x509.Certificate) ([]byte, error) {
+	subject := presentedCert.Subject.CommonName
+	if err := ValidateSubject(subject); err != nil {
+		return nil, err
+	}
+
+	// SECURITY: Re-check the key-strength policy before perpetuating a key
+	// via auto-renewal. A cert imported from a legacy CA (see the migrate
+	// command) may predate this CA's key policy; auto-renewal must not be a
+	// backdoor to indefinitely extend a substandard key — the operator/agent
+	// should re-key via the CSR-based Renew path instead.
+	// NIST 800-53: SC-12, SC-13 (Cryptographic Protection)
+	if err := validatePublicKey(presentedCert.PublicKey); err != nil {
+		return nil, fmt.Errorf("rejecting auto-renewal for %s: %w", subject, err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, lockTimeout)
+	defer cancel()
+
+	var extraExtensions []pkix.Extension
+	for _, ext := range presentedCert.Extensions {
+		if IsPuppetOID(ext.Id) {
+			extraExtensions = append(extraExtensions, ext)
+		}
+	}
+
+	var out []byte
+	err := c.Storage.WithLock(ctx, subjectLockName(subject), func() error {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		certPEM, err := c.issueLeafLocked(ctx, subject, presentedCert.Subject, presentedCert.PublicKey, presentedCert.DNSNames, extraExtensions, 0)
 		if err != nil {
 			return err
 		}

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -69,6 +69,8 @@ type Collector struct {
 	scrapeDuration *prometheus.Desc
 	caReady        *prometheus.Desc
 
+	crlUpdateFailures *prometheus.Desc
+
 	caInfo      *prometheus.Desc
 	caNotBefore *prometheus.Desc
 	caNotAfter  *prometheus.Desc
@@ -102,6 +104,13 @@ func NewCollector(c *ca.CA) *Collector {
 		caReady: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "ca_ready"),
 			"1 when the CA has finished initialising and can serve requests, 0 otherwise.",
+			nil, nil),
+		crlUpdateFailures: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "crl", "update_failures_total"),
+			"Total failures to amend the CRL — a revocation that could not be recorded, or a CRL "+
+				"that could not be re-signed or written (across revoke, cleanup, reissue and refresh). "+
+				"A rising value means the CRL is not being maintained; for revocations it means a "+
+				"superseded certificate may still be a valid credential.",
 			nil, nil),
 		caInfo: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "ca_certificate", "info"),
@@ -161,6 +170,7 @@ func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.scrapeSuccess
 	ch <- c.scrapeDuration
 	ch <- c.caReady
+	ch <- c.crlUpdateFailures
 	ch <- c.caInfo
 	ch <- c.caNotBefore
 	ch <- c.caNotAfter
@@ -188,6 +198,13 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	duration := time.Since(start)
 
 	ch <- prometheus.MustNewConstMetric(c.scrapeDuration, prometheus.GaugeValue, duration.Seconds())
+
+	// This counter is an in-process event tally, independent of the storage
+	// gather, so emit it even when the gather below fails — an unreadable
+	// backend must not blind operators to CRL-maintenance failures.
+	ch <- prometheus.MustNewConstMetric(c.crlUpdateFailures, prometheus.CounterValue,
+		float64(c.ca.CRLUpdateFailures()))
+
 	if err != nil {
 		slog.Warn("Prometheus CA metrics scrape failed", "error", err)
 		ch <- prometheus.MustNewConstMetric(c.scrapeSuccess, prometheus.GaugeValue, 0)

--- a/internal/metrics/collector_test.go
+++ b/internal/metrics/collector_test.go
@@ -81,6 +81,8 @@ func (g gathered) findByLabels(name string, want map[string]string) *dto.Metric 
 
 func gaugeValue(m *dto.Metric) float64 { return m.GetGauge().GetValue() }
 
+func counterValue(m *dto.Metric) float64 { return m.GetCounter().GetValue() }
+
 var _ = Describe("Collector", func() {
 	var (
 		ctx   context.Context
@@ -130,6 +132,12 @@ var _ = Describe("Collector", func() {
 		// A freshly bootstrapped CA has published an (empty) CRL.
 		Expect(g.findByLabels("puppetca_crl_next_update_timestamp_seconds", nil)).NotTo(BeNil())
 		Expect(gaugeValue(g.findByLabels("puppetca_crl_revoked_certificates", nil))).To(Equal(0.0))
+
+		// The CRL-update failure counter is always exported, starting at zero
+		// on a CA that has performed no failed CRL amendments.
+		crlUpdateFailures := g.findByLabels("puppetca_crl_update_failures_total", nil)
+		Expect(crlUpdateFailures).NotTo(BeNil())
+		Expect(counterValue(crlUpdateFailures)).To(Equal(0.0))
 	})
 
 	It("reports per-leaf metrics with issuance state", func() {

--- a/mixin/README.md
+++ b/mixin/README.md
@@ -7,7 +7,10 @@ alerting rules for the Puppet CA exporter. It alerts on:
 - the **CA certificate** nearing expiry (warning) or expiring imminently (critical);
 - the **CRL** approaching its `NextUpdate` (warning) or having lapsed (critical);
 - **leaf certificates** nearing/at expiry — excluding revoked ones — and
-  certificate **requests that stay pending** too long.
+  certificate **requests that stay pending** too long;
+- **CRL update failures** — the CA failing to amend its CRL (a revocation it
+  could not record, or a CRL it could not re-sign or write), which can leave
+  revoked or superseded certificates still valid.
 
 All thresholds and the target selector live in [`config.libsonnet`](config.libsonnet)
 and can be overridden without editing the rules.
@@ -86,4 +89,6 @@ jsonnet -J vendor -m . mixin.jsonnet
 | `leafExpiryWarningSeconds` | 7 days | Leaf certificate expiry warning threshold. |
 | `leafExpiryCriticalSeconds` | 1 day | Leaf certificate expiry critical threshold. |
 | `pendingFor` | `1h` | How long a request may stay pending before alerting. |
+| `crlUpdateWindow` | `1h` | Window over which CRL-update failures are counted (the metric is a restart-resetting counter). |
+| `crlUpdateFor` | `15m` | `for:` debounce for the CRL-update-failure alert. |
 | `expiryFor` / `scrapeFor` / `readyFor` / `downFor` | `1h` / `15m` / `10m` / `5m` | `for:` debounce durations. |

--- a/mixin/alerts.libsonnet
+++ b/mixin/alerts.libsonnet
@@ -174,6 +174,30 @@
           },
         ],
       },
+      {
+        name: 'openvox-ca-crl-maintenance',
+        rules: [
+          {
+            alert: 'PuppetCACRLUpdateFailing',
+            // The CA failed to amend the CRL — a revocation it could not record,
+            // or a CRL it could not re-sign or write (revoke, cleanup, reissue or
+            // refresh). Some callers swallow this (e.g. the best-effort revoke of
+            // a superseded cert on renewal), so a revoked/superseded certificate
+            // may remain valid. The counter resets on restart, so alert on
+            // increase() over a window rather than a raw value.
+            expr: 'increase(puppetca_crl_update_failures_total{%(selector)s}[%(window)s]) > 0' % {
+              selector: $._config.puppetCASelector,
+              window: $._config.crlUpdateWindow,
+            },
+            'for': $._config.crlUpdateFor,
+            labels: { severity: 'warning' } + $._config.alertLabels,
+            annotations: {
+              summary: 'Puppet CA is failing to update its CRL.',
+              description: 'The Puppet CA on {{ $labels.instance }} could not amend its CRL (puppetca_crl_update_failures_total is rising). Revocations may not have taken effect and superseded certificates may still be valid; check CRL storage and the CA logs.',
+            },
+          },
+        ],
+      },
     ],
   },
 }

--- a/mixin/config.libsonnet
+++ b/mixin/config.libsonnet
@@ -31,6 +31,16 @@
     // larger value (or silence the alert) on CAs that sign manually by policy.
     pendingFor: '1h',
 
+    // --- CRL update failures ---
+    // The CA may fail to amend its CRL (a revocation it cannot record, or a CRL
+    // it cannot re-sign or write). Some of these are best-effort and swallowed
+    // — e.g. revoking the certificate a renewal supersedes — leaving the old
+    // certificate valid for its key. The counter resets on restart, so the
+    // alert looks at increase() over crlUpdateWindow and debounces with
+    // crlUpdateFor.
+    crlUpdateWindow: '1h',
+    crlUpdateFor: '15m',
+
     // 'for' durations applied to the expiry alerts to debounce flapping at the
     // threshold boundary.
     expiryFor: '1h',

--- a/test/integration-compose.sh
+++ b/test/integration-compose.sh
@@ -1978,6 +1978,7 @@ _REN_PID=""
 _REN_CA_URL="http://127.0.0.1:${_REN_PORT}"
 _REN_NODE="ren-node-${RUN_ID}"
 _REN_OTHER="ren-other-${RUN_ID}"
+_REN_BARE="ren-bare-${RUN_ID}"
 
 _wait_ren_ca() {
     local url="$1" n=60
@@ -2017,6 +2018,13 @@ if _wait_ren_ca "$_REN_CA_URL"; then
     openvox-ca-ctl --server-url "$_REN_CA_URL" \
         generate --certname "$_REN_OTHER" --out-dir "$WORK_DIR" \
         > "$WORK_DIR/ren-other.crt" 2>/dev/null
+
+    # Dedicated node cert for the bare-path renewal test. A successful CSR
+    # renewal now revokes the cert it replaces, so the bare-path test can't
+    # reuse ren-node (already renewed and thus revoked by the happy-path test).
+    openvox-ca-ctl --server-url "$_REN_CA_URL" \
+        generate --certname "$_REN_BARE" --out-dir "$WORK_DIR" \
+        > "$WORK_DIR/ren-bare.crt" 2>/dev/null
 else
     fail "renewal: Phase 1 CA started (loopback HTTP, autosign=true)" \
         "timed out waiting for health"
@@ -2069,21 +2077,25 @@ if _wait_ren_ca "https://127.0.0.1:${_REN_PORT}"; then
         --data-binary @"$WORK_DIR/ren-renewal.csr" \
         "https://127.0.0.1:${_REN_PORT}/puppet-ca/v1/certificate_renewal"
 
-    # Invalid CSR body → 400
+    # Invalid CSR body → 400. Authenticate with ren-other: the request is
+    # rejected during CSR parsing, before any CN check, so any still-valid
+    # client cert works — and ren-node has been revoked by its renewal above.
     assert_http 400 "renewal: invalid CSR body returns 400" \
         -sk \
-        --cert "$WORK_DIR/ren-node.crt" \
-        --key  "$WORK_DIR/${_REN_NODE}_key.pem" \
+        --cert "$WORK_DIR/ren-other.crt" \
+        --key  "$WORK_DIR/${_REN_OTHER}_key.pem" \
         -X POST -H "Content-Type: text/plain" \
         -d "this is not a csr" \
         "https://127.0.0.1:${_REN_PORT}/puppet-ca/v1/certificate_renewal"
 
-    # Bare-path alias /certificate_renewal (without /puppet-ca/v1) also works
-    make_csr "$_REN_NODE" "$WORK_DIR/ren-renewal2.csr"
+    # Bare-path alias /certificate_renewal (without /puppet-ca/v1) also works.
+    # Uses the dedicated ren-bare cert: this is a successful renewal that
+    # revokes its own presented cert, so it must not reuse ren-node.
+    make_csr "$_REN_BARE" "$WORK_DIR/ren-renewal2.csr"
     assert_http 200 "renewal: bare-path /certificate_renewal returns 200" \
         -sk \
-        --cert "$WORK_DIR/ren-node.crt" \
-        --key  "$WORK_DIR/${_REN_NODE}_key.pem" \
+        --cert "$WORK_DIR/ren-bare.crt" \
+        --key  "$WORK_DIR/${_REN_BARE}_key.pem" \
         -X POST -H "Content-Type: text/plain" \
         --data-binary @"$WORK_DIR/ren-renewal2.csr" \
         "https://127.0.0.1:${_REN_PORT}/certificate_renewal"

--- a/test/puppet/puppet-stack.sh
+++ b/test/puppet/puppet-stack.sh
@@ -553,9 +553,13 @@ _old_serial_hex=${_serial_before#serial=}
 _crl_after_renew=$(curl -sfk "${_CA[@]}" \
     "${CA_HOST_URL}/puppet-ca/v1/certificate_revocation_list/ca" 2>/dev/null \
     | openssl crl -text -noout 2>/dev/null) || true
-grep -qF "$_old_serial_hex" <<< "$_crl_after_renew" \
+# Guard on a non-empty serial first: _serial_before is captured with `|| true`,
+# so if the pre-renewal serial could not be extracted, _old_serial_hex is empty
+# and `grep -qF ""` would match any CRL unconditionally — passing the assertion
+# without ever testing revocation. Refuse to pass on an empty serial.
+[[ -n "$_old_serial_hex" ]] && grep -qF "$_old_serial_hex" <<< "$_crl_after_renew" \
     && pass "pre-renewal serial is revoked by default after auto-renewal" \
-    || fail "pre-renewal serial is revoked by default after auto-renewal" "serial $_old_serial_hex not found in CRL"
+    || fail "pre-renewal serial is revoked by default after auto-renewal" "serial '$_old_serial_hex' not found in CRL"
 
 # The renewed cert must still work for a normal agent run (still trusted,
 # same private key on disk as before the renewal). Match Group 3's depth:

--- a/test/puppet/puppet-stack.sh
+++ b/test/puppet/puppet-stack.sh
@@ -547,6 +547,16 @@ _pubkey_after=$(exec_client openssl x509 -in "$_client_cert_path" -noout -pubkey
     || fail "renewed cert keeps the same public key (no CSR, no re-key)" \
         "$([[ -z "$_pubkey_after" ]] && echo "post-renewal public key could not be extracted" || echo "public key changed across renewal")"
 
+# revoke_on_auto_renew defaults to true: the pre-renewal serial must now be
+# in the CRL, so only the newest serial for this subject stays valid.
+_old_serial_hex=${_serial_before#serial=}
+_crl_after_renew=$(curl -sfk "${_CA[@]}" \
+    "${CA_HOST_URL}/puppet-ca/v1/certificate_revocation_list/ca" 2>/dev/null \
+    | openssl crl -text -noout 2>/dev/null) || true
+grep -qF "$_old_serial_hex" <<< "$_crl_after_renew" \
+    && pass "pre-renewal serial is revoked by default after auto-renewal" \
+    || fail "pre-renewal serial is revoked by default after auto-renewal" "serial $_old_serial_hex not found in CRL"
+
 # The renewed cert must still work for a normal agent run (still trusted,
 # same private key on disk as before the renewal). Match Group 3's depth:
 # check the catalog actually applied and no revoked-cert/TLS error surfaced,

--- a/test/puppet/puppet-stack.sh
+++ b/test/puppet/puppet-stack.sh
@@ -544,15 +544,29 @@ _pubkey_after=$(exec_client openssl x509 -in "$_client_cert_path" -noout -pubkey
 
 [[ -n "$_pubkey_after" && "$_pubkey_after" == "$_pubkey_before" ]] \
     && pass "renewed cert keeps the same public key (no CSR, no re-key)" \
-    || fail "renewed cert keeps the same public key (no CSR, no re-key)" "public key changed across renewal"
+    || fail "renewed cert keeps the same public key (no CSR, no re-key)" \
+        "$([[ -z "$_pubkey_after" ]] && echo "post-renewal public key could not be extracted" || echo "public key changed across renewal")"
 
 # The renewed cert must still work for a normal agent run (still trusted,
-# same private key on disk as before the renewal).
+# same private key on disk as before the renewal). Match Group 3's depth:
+# check the catalog actually applied and no revoked-cert/TLS error surfaced,
+# not just the exit code — a revoked or untrusted cert would exit 1, but the
+# output is the direct evidence the renewed cert is still accepted.
 AGENT_RENEW_EXIT=0
 AGENT_RENEW_OUT=$(run_agent) || AGENT_RENEW_EXIT=$?
 [[ "$AGENT_RENEW_EXIT" =~ ^(0|2)$ ]] \
     && pass "Agent run with auto-renewed cert exits 0 or 2" \
     || fail "Agent run with auto-renewed cert exits 0 or 2" "exit code: $AGENT_RENEW_EXIT; output: $(tail -5 <<< "$AGENT_RENEW_OUT" | tr '\n' '|')"
+
+grep -qi "Applied catalog" <<< "$AGENT_RENEW_OUT" \
+    && pass "auto-renewed agent run applied the catalog" \
+    || fail "auto-renewed agent run applied the catalog" "last 5 lines: $(tail -5 <<< "$AGENT_RENEW_OUT" | tr '\n' '|')"
+
+if grep -qiE "certificate revoked|certificate verify failed|SSL_connect" <<< "$AGENT_RENEW_OUT"; then
+    fail "auto-renewed agent run shows no revoked-cert/TLS error" "output: $(tail -5 <<< "$AGENT_RENEW_OUT" | tr '\n' '|')"
+else
+    pass "auto-renewed agent run shows no revoked-cert/TLS error"
+fi
 
 # ═════════════════════════════════════════════════════════════════════════
 # Group 4 -- Server self-apply

--- a/test/puppet/puppet-stack.sh
+++ b/test/puppet/puppet-stack.sh
@@ -500,6 +500,61 @@ grep -qF "client.puppet.localdomain" <<< "$_client_managed" \
     || fail "/tmp/puppet_managed contains client certname"
 
 # ═════════════════════════════════════════════════════════════════════════
+# Group 3b -- Certificate auto-renewal (real agent, no CSR)
+#
+# Real Puppet/OpenVox agents auto-renew their client cert by default
+# (hostcert_renewal_interval, default 30d): they POST an empty body to
+# /certificate_renewal, relying solely on the mTLS-presented cert to prove
+# identity and key possession, and expect the SAME key reissued with a fresh
+# serial and validity. `puppet ssl renew_cert` drives exactly that code path
+# deterministically (see lib/puppet/application/ssl.rb in the openvox repo),
+# so this exercises the real agent binary against openvox-ca's AutoRenew
+# (internal/ca/signing.go), not just a Go-mocked TLS certificate.
+# ═════════════════════════════════════════════════════════════════════════
+printf '\n# Group 3b -- Certificate auto-renewal (real agent, no CSR)\n'
+
+_client_cert_path=/etc/puppetlabs/puppet/ssl/certs/client.puppet.localdomain.pem
+
+_serial_before=$(exec_client openssl x509 -in "$_client_cert_path" -noout -serial 2>/dev/null) || true
+_pubkey_before=$(exec_client openssl x509 -in "$_client_cert_path" -noout -pubkey 2>/dev/null) || true
+
+RENEW_EXIT=0
+RENEW_OUT=$(exec_client \
+    puppet ssl renew_cert \
+    "${_PUPPET_DIRS[@]}" \
+    --ca_server openvox-ca \
+    --ca_port   8140 \
+    --certname  client.puppet.localdomain \
+    2>&1) || RENEW_EXIT=$?
+
+[ "$RENEW_EXIT" -eq 0 ] \
+    && pass "puppet ssl renew_cert exits 0" \
+    || fail "puppet ssl renew_cert exits 0" "exit code: $RENEW_EXIT; output: $(tail -5 <<< "$RENEW_OUT" | tr '\n' '|')"
+
+grep -qi "Downloaded certificate" <<< "$RENEW_OUT" \
+    && pass "renew_cert output confirms a new certificate was downloaded" \
+    || fail "renew_cert output confirms a new certificate was downloaded" "output: $(tail -5 <<< "$RENEW_OUT" | tr '\n' '|')"
+
+_serial_after=$(exec_client openssl x509 -in "$_client_cert_path" -noout -serial 2>/dev/null) || true
+_pubkey_after=$(exec_client openssl x509 -in "$_client_cert_path" -noout -pubkey 2>/dev/null) || true
+
+[[ -n "$_serial_after" && "$_serial_after" != "$_serial_before" ]] \
+    && pass "renewed cert carries a new serial" \
+    || fail "renewed cert carries a new serial" "before=$_serial_before after=$_serial_after"
+
+[[ -n "$_pubkey_after" && "$_pubkey_after" == "$_pubkey_before" ]] \
+    && pass "renewed cert keeps the same public key (no CSR, no re-key)" \
+    || fail "renewed cert keeps the same public key (no CSR, no re-key)" "public key changed across renewal"
+
+# The renewed cert must still work for a normal agent run (still trusted,
+# same private key on disk as before the renewal).
+AGENT_RENEW_EXIT=0
+AGENT_RENEW_OUT=$(run_agent) || AGENT_RENEW_EXIT=$?
+[[ "$AGENT_RENEW_EXIT" =~ ^(0|2)$ ]] \
+    && pass "Agent run with auto-renewed cert exits 0 or 2" \
+    || fail "Agent run with auto-renewed cert exits 0 or 2" "exit code: $AGENT_RENEW_EXIT; output: $(tail -5 <<< "$AGENT_RENEW_OUT" | tr '\n' '|')"
+
+# ═════════════════════════════════════════════════════════════════════════
 # Group 4 -- Server self-apply
 # ═════════════════════════════════════════════════════════════════════════
 printf '\n# Group 4 -- Server self-apply\n'


### PR DESCRIPTION
**Depends on / stacked on #113** (base branch of this PR is `feature/auto-renew-wire-compat`, not `main`). Merge that one first; this one's diff will shrink to just the commit below once it lands.

Ensures only one certificate per subject is ever valid: once a renewal's replacement certificate is safely signed and stored, the certificate it replaces is revoked.

- **CSR-based `Renew`** (a genuine re-key) always revokes the replaced certificate — it's a different key, so the old one must not remain a usable credential.
- **`AutoRenew`** (the empty-body, same-key path from #113) does this too, but gated behind a new `RevokeOnAutoRenew` option, **default `true`**. OpenVox Server's own Clojure CA (`renew-certificate!`) does not revoke on this path — both the old and new certs (same key) stay valid until the old one naturally expires — so operators who need to match that exactly can set `revoke_on_auto_renew: false` / `PUPPET_CA_REVOKE_ON_AUTO_RENEW=false`.

`revokeLocked` is split into itself (subject → latest-inventory-serial lookup) plus `revokeSerialLocked` (revoke an exact serial), since both `Renew` and `AutoRenew` need to capture the old serial *before* signing — once the new cert's inventory row is appended, a subject-based lookup would resolve to the new serial rather than the one being retired.

**Best-effort revocation + observability:** revoking the superseded certificate is best-effort — a failure to amend the CRL never fails the renewal the agent is waiting on (the renewed certificate is still returned). So that this can't silently hide a broken CRL, a new counter `puppetca_crl_update_failures_total` increments on *any* failure to amend the CRL: a revocation that can't be recorded, or a CRL that can't be re-signed or written. It's incremented at the two shared choke points (`revokeSerialLocked` and `signCRLLocked`), so it covers every path — renewal, admin and clean revocation, cleanup pruning, reissue and refresh — not just this feature. The monitoring mixin gains a `PuppetCACRLUpdateFailing` warning alert; see `docs/metrics.md`.

**CRL growth:** because the default now revokes on every auto-renewal, the CRL gains one entry per renewal until those certificates expire. The `revoke_on_auto_renew` docs now point operators at `enable_expired_cert_cleanup` (which prunes expired entries and is off by default) and `puppetca_crl_revoked_certificates` to keep CRL size bounded on busy CAs.

**Why the default stays `true`:** I validated this end-to-end against a real agent in `test/puppet/puppet-stack.sh` (Group 3b, extended): with `revoke_on_auto_renew: true` (the default), a real agent's `puppet ssl renew_cert` still succeeds, the pre-renewal serial lands in the CRL, and a subsequent normal agent run using the renewed cert still passes. Since the real-agent test passes cleanly with revocation enabled, the more secure default (revoke immediately) is kept, per the plan of only flipping the default if that test had failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
