### PR TITLE
Add import-cert: register externally-issued certificates in the inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,8 @@ Conflict handling, in priority order:
 2. Otherwise, if the certificate's serial number is already tracked anywhere in the inventory (under this subject or another), the request is rejected with `409 Conflict`.
 3. Otherwise, if the subject already has an active (non-revoked) certificate, the request is rejected with `409 Conflict`. If the subject's existing certificate is revoked, it is evicted and the import proceeds.
 
+Invalid certificates — malformed or multi-block PEM, a signature that does not chain to this CA, a CA certificate (`IsCA: true`), a subject that matches neither the CN nor any DNS SAN, a non-positive serial, or a bad validity window — are rejected with `400 Bad Request`. If the CA has not finished initialising, the request returns `503 Service Unavailable` (retry once it is ready).
+
 Response:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -427,6 +427,32 @@ Response:
 { "private_key": "-----BEGIN RSA PRIVATE KEY-----\n...", "certificate": "-----BEGIN CERTIFICATE-----\n..." }
 ```
 
+### Certificate import
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `PUT` | `/certificate/{subject}` | Import a certificate issued outside this CA's normal signing flow into the inventory; admin-only |
+
+Shares its path with `GET /certificate/{subject}` (certificate retrieval, above) but is a distinct, admin-only operation. Request body: raw certificate PEM. `{subject}` must match the certificate's CN or one of its DNS Subject Alternative Names — this lets an operator import under a specific identity even when the certificate's SANs list several names.
+
+This is for certificates that were signed by this CA's key but never went through `Sign`/`Generate` — most commonly certificates migrated from a legacy CA installation that shared this CA's key material. The certificate's signature must verify against this CA's certificate (a pure cryptographic check, so an already-expired certificate is still accepted for record-keeping); CA certificates (`IsCA: true`) are rejected — use `openvox-ca-ctl import` for CA bundle import instead.
+
+Once imported, the certificate is tracked exactly like a normally-issued one: it appears in listings and status lookups, is cleaned up by the normal expiry sweep, and can be revoked via the usual `PUT /certificate_status/{subject}` (`desired_state: "revoked"`) mechanism.
+
+Conflict handling, in priority order:
+
+1. If the exact same certificate (same serial, byte-identical) is already the tracked certificate for the subject, the request succeeds as a no-op (`"imported": false` in the response).
+2. Otherwise, if the certificate's serial number is already tracked anywhere in the inventory (under this subject or another), the request is rejected with `409 Conflict`.
+3. Otherwise, if the subject already has an active (non-revoked) certificate, the request is rejected with `409 Conflict`. If the subject's existing certificate is revoked, it is evicted and the import proceeds.
+
+Response:
+
+```json
+{ "subject": "legacy-node.example.com", "serial": "1A2B3C4D5E6F", "not_before": "2020-01-01T00:00:00Z", "not_after": "2025-01-01T00:00:00Z", "imported": true }
+```
+
+`serial` is uppercase hex (matching the inventory/CRL/OCSP convention), unlike the decimal `serial_number` field in certificate status responses (which is decimal only to preserve the full 128-bit value without int64 truncation — a constraint that doesn't apply to this string field).
+
 ### OCSP
 
 | Method | Path | Description |
@@ -457,7 +483,7 @@ When mTLS is enabled (both `--tls-cert` and `--tls-key` set), each endpoint requ
 | **Public** | None | `GET /healthz/*`, `GET /certificate/{subject}`, `GET /certificate_revocation_list/ca`, `PUT /certificate_request/{subject}`, `GET /expirations`, `POST /ocsp`, `GET /ocsp/{request}` |
 | **Any client** | Any CA-signed cert | `GET /certificate_status/{subject}` (public with `--allow-public-status`), `POST /certificate_renewal` |
 | **Self or admin** | Cert CN matches path subject, OR cert is admin | `GET /certificate_request/{subject}` |
-| **Admin** | Cert is admin (see below) | `PUT /certificate_status/{subject}`, `DELETE /certificate_status/{subject}`, `DELETE /certificate_request/{subject}`, `GET /certificate_statuses/*`, `POST /sign`, `POST /sign/all`, `POST /generate/{subject}`, `PUT /clean`, `PUT /certificate_revocation_list/ca` |
+| **Admin** | Cert is admin (see below) | `PUT /certificate_status/{subject}`, `DELETE /certificate_status/{subject}`, `DELETE /certificate_request/{subject}`, `GET /certificate_statuses/*`, `POST /sign`, `POST /sign/all`, `POST /generate/{subject}`, `PUT /clean`, `PUT /certificate_revocation_list/ca`, `PUT /certificate/{subject}` |
 
 In plain HTTP mode (no TLS), all endpoints are accessible without authentication.
 
@@ -649,6 +675,10 @@ openvox-ca-ctl reissue-crl
 # Generate a server-side key+cert pair (key saved to ./agent.example.com_key.pem)
 openvox-ca-ctl generate --certname agent.example.com
 openvox-ca-ctl generate --certname agent.example.com --dns alt.example.com --out-dir /etc/ssl
+
+# Import a certificate issued outside this CA's normal flow (e.g. migrated
+# from a legacy CA sharing this CA's key)
+openvox-ca-ctl import-cert --certname legacy-node.example.com --cert-file legacy-node_cert.pem
 
 # Bootstrap a new CA offline (no server required)
 openvox-ca-ctl setup --cadir /etc/puppetlabs/puppet/ssl --hostname puppet.example.com

--- a/cmd/openvox-ca-ctl/main.go
+++ b/cmd/openvox-ca-ctl/main.go
@@ -421,6 +421,65 @@ func newGenerateCmd() *cobra.Command {
 	return cmd
 }
 
+// newImportCertCmd registers openvox-ca-ctl's "import-cert" subcommand,
+// which imports a certificate issued OUTSIDE this CA's normal signing flow
+// (e.g. migrated from a legacy CA sharing this CA's key) into the running
+// server's inventory via PUT /certificate/{subject}. This is distinct from
+// the "import" subcommand below, which imports a whole CA cert/key/CRL
+// bundle offline, directly into storage.
+func newImportCertCmd() *cobra.Command {
+	var certname, certFile string
+	cmd := &cobra.Command{
+		Use:          "import-cert",
+		Short:        "Import an externally-issued certificate into the inventory",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			certPEM, err := os.ReadFile(certFile)
+			if err != nil {
+				return fmt.Errorf("reading --cert-file: %w", err)
+			}
+
+			c, err := newClient()
+			if err != nil {
+				return err
+			}
+
+			path := "/puppet-ca/v1/certificate/" + certname
+			code, body, err := c.put(path, certPEM)
+			if err != nil {
+				return err
+			}
+			if err := checkHTTP(code, body, "PUT", path); err != nil {
+				return err
+			}
+
+			var result struct {
+				Subject   string `json:"subject"`
+				Serial    string `json:"serial"`
+				NotBefore string `json:"not_before"`
+				NotAfter  string `json:"not_after"`
+				Imported  bool   `json:"imported"`
+			}
+			if err := json.Unmarshal(body, &result); err != nil {
+				return fmt.Errorf("could not parse response: %w", err)
+			}
+			if result.Imported {
+				fmt.Printf("Imported %s (serial %s, valid %s to %s)\n",
+					result.Subject, result.Serial, result.NotBefore, result.NotAfter)
+			} else {
+				fmt.Printf("%s already tracked (serial %s), no changes made\n",
+					result.Subject, result.Serial)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&certname, "certname", "", "Subject name for the imported certificate")
+	cmd.Flags().StringVar(&certFile, "cert-file", "", "Path to the certificate PEM to import")
+	_ = cmd.MarkFlagRequired("certname")
+	_ = cmd.MarkFlagRequired("cert-file")
+	return cmd
+}
+
 func newSetupCmd() *cobra.Command {
 	var caDir, hostname string
 	var encryptKey bool
@@ -571,6 +630,7 @@ Global flags must be specified before the subcommand.`,
 		newReissueCRLCmd(),
 		newCleanCmd(),
 		newGenerateCmd(),
+		newImportCertCmd(),
 		newSetupCmd(),
 		newImportCmd(),
 		newMigrateCmd(),

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	go.etcd.io/etcd/server/v3 v3.7.0
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/crypto v0.54.0
+	modernc.org/sqlite v1.52.0
 )
 
 require (
@@ -130,7 +131,6 @@ require (
 	modernc.org/libc v1.73.4 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
-	modernc.org/sqlite v1.52.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -462,6 +462,15 @@ var _ = Describe("Auth Middleware", func() {
 			mux.ServeHTTP(rr, req)
 			Expect(rr.Code).To(Equal(http.StatusForbidden))
 		})
+
+		It("returns 403 for PUT /certificate/{subject} (admin-only tier, import)", func() {
+			clientCert := issueClientCert("regular-node", caCert, caKey)
+			req := httptest.NewRequest("PUT", "/certificate/some-node", bytes.NewReader([]byte("not a real cert")))
+			req = withClientCert(req, clientCert)
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+			Expect(rr.Code).To(Equal(http.StatusForbidden))
+		})
 	})
 
 	// --- Non-self client on self-or-admin endpoints ---
@@ -1056,6 +1065,10 @@ var _ = Describe("lookupTier classification", func() {
 		Entry("status delete is admin-only", "DELETE", "/certificate_status/node1", "node1", "adminOnly"),
 		Entry("unknown path falls through to admin-only", "GET", "/totally/unknown/path", "", "adminOnly"),
 		Entry("unknown method on public path is admin-only", "POST", "/certificate/node1", "node1", "adminOnly"),
+		// PUT certificate/{subject} (certificate import) shares its path with the
+		// public GET above, but is admin-only — proving the two methods on this
+		// path really do have different tiers.
+		Entry("PUT certificate is admin-only (import)", "PUT", "/certificate/node1", "node1", "adminOnly"),
 	)
 
 	DescribeTable("with AllowPublicStatus=true",

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -284,9 +284,9 @@ func (s *Server) handleGetCert(w http.ResponseWriter, r *http.Request) {
 type ImportResponse struct {
 	Subject   string `json:"subject"`
 	Serial    string `json:"serial"`
-	NotBefore string `json:"not_before"`
-	NotAfter  string `json:"not_after"`
-	Imported  bool   `json:"imported"` // false if this was a no-op (already tracked)
+	NotBefore string `json:"not_before"` // UTC timestamp, rendered with the server's configured time format (timeFormat())
+	NotAfter  string `json:"not_after"`  // UTC timestamp, rendered with the server's configured time format (timeFormat())
+	Imported  bool   `json:"imported"`   // false if this was a no-op (already tracked)
 }
 
 // handlePutCert imports a certificate that was issued OUTSIDE this CA's

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -104,6 +104,7 @@ func (s *Server) Routes() http.Handler {
 		{"PUT", "/certificate_request/{subject}", s.handlePutRequest},
 		{"DELETE", "/certificate_request/{subject}", s.handleDeleteRequest},
 		{"GET", "/certificate/{subject}", s.handleGetCert},
+		{"PUT", "/certificate/{subject}", s.handlePutCert},
 		{"GET", "/certificate_revocation_list/ca", s.handleGetCRL},
 		{"PUT", "/certificate_revocation_list/ca", s.handleReissueCRL},
 		{"POST", "/ocsp", s.handleOCSP},
@@ -277,6 +278,69 @@ func (s *Server) handleGetCert(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "text/plain")
 	w.Write(certPEM)
+}
+
+// ImportResponse is returned by PUT /certificate/{subject} on success.
+type ImportResponse struct {
+	Subject   string `json:"subject"`
+	Serial    string `json:"serial"`
+	NotBefore string `json:"not_before"`
+	NotAfter  string `json:"not_after"`
+	Imported  bool   `json:"imported"` // false if this was a no-op (already tracked)
+}
+
+// handlePutCert imports a certificate that was issued OUTSIDE this CA's
+// normal signing flow (e.g. migrated from a legacy CA sharing this CA's
+// key) into the inventory under subject, so it appears in listings, has its
+// lifetime tracked, and can be revoked via the normal PUT
+// certificate_status desired_state=revoked mechanism. This is the only way
+// to directly set a subject's certificate outside the CSR-based signing
+// flow, hence sharing this path with GET certificate/{subject}. Admin-only
+// (enforced by the auth middleware, which defaults non-GET methods on this
+// path to tierAdminOnly).
+func (s *Server) handlePutCert(w http.ResponseWriter, r *http.Request) {
+	subject := r.PathValue("subject")
+	if err := ca.ValidateSubject(subject); err != nil {
+		http.Error(w, "invalid subject", http.StatusBadRequest)
+		return
+	}
+	slog.Debug("PUT certificate (import)", "subject", subject, "client", clientCN(r))
+
+	certPEM, err := io.ReadAll(io.LimitReader(r.Body, maxJSONBody))
+	if err != nil {
+		slog.Error("read import cert body failed", "subject", subject, "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	result, err := s.CA.ImportCertificate(r.Context(), subject, certPEM)
+	if err != nil {
+		switch {
+		case errors.Is(err, ca.ErrNotInitialized):
+			http.Error(w, "CA not ready", http.StatusServiceUnavailable)
+		case errors.Is(err, ca.ErrImportInvalid):
+			slog.Warn("Import rejected", "subject", subject, "error", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		case errors.Is(err, ca.ErrSerialExists), errors.Is(err, ca.ErrCertExists):
+			slog.Warn("Import conflict", "subject", subject, "error", err)
+			http.Error(w, err.Error(), http.StatusConflict)
+		default:
+			slog.Error("Import failed", "subject", subject, "error", err)
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+		}
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(ImportResponse{
+		Subject:   result.Subject,
+		Serial:    result.Serial,
+		NotBefore: result.NotBefore.UTC().Format(s.timeFormat()),
+		NotAfter:  result.NotAfter.UTC().Format(s.timeFormat()),
+		Imported:  result.Imported,
+	}); err != nil {
+		slog.Warn("encode response failed", "error", err)
+	}
 }
 
 // --- CRL ---

--- a/internal/api/import_test.go
+++ b/internal/api/import_test.go
@@ -129,6 +129,12 @@ var _ = Describe("PUT /certificate/{subject} (import)", func() {
 		Expect(result.Subject).To(Equal("import-node"))
 		Expect(result.Imported).To(BeTrue())
 		Expect(result.Serial).NotTo(BeEmpty())
+		Expect(result.NotBefore).NotTo(BeEmpty())
+		Expect(result.NotAfter).NotTo(BeEmpty())
+		_, err := time.Parse(time.RFC3339, result.NotBefore)
+		Expect(err).NotTo(HaveOccurred(), "not_before must parse as RFC3339")
+		_, err = time.Parse(time.RFC3339, result.NotAfter)
+		Expect(err).NotTo(HaveOccurred(), "not_after must parse as RFC3339")
 
 		// Resubmitting the identical certificate must be a no-op, not an error.
 		req2 := httptest.NewRequest("PUT", "/certificate/import-node", bytes.NewReader(certPEM))
@@ -233,5 +239,23 @@ var _ = Describe("PUT /certificate/{subject} (import)", func() {
 		var status2 api.CertStatusResponse
 		Expect(json.Unmarshal(statusRR2.Body.Bytes(), &status2)).To(Succeed())
 		Expect(status2.State).To(Equal("revoked"))
+	})
+
+	It("returns 503 when the CA has not been initialised", func() {
+		rawDir, err := os.MkdirTemp("", "openvox-ca-import-uninit-api-test")
+		Expect(err).NotTo(HaveOccurred())
+		defer os.RemoveAll(rawDir)
+		rawStore := storage.New(rawDir)
+		Expect(rawStore.EnsureDirs(context.Background())).To(Succeed())
+		// Deliberately no myCA.Init(): CACert/CAKey stay nil, so ImportCertificate
+		// returns ca.ErrNotInitialized, which the handler maps to 503.
+		rawCA := ca.New(rawStore, ca.AutosignConfig{Mode: "off"}, "puppet.test")
+		rawMux := api.New(rawCA).Routes()
+
+		certPEM := signLeaf(caKey, caCert, "uninit-node", []string{"uninit-node"}, nil, false)
+		req := httptest.NewRequest("PUT", "/certificate/uninit-node", bytes.NewReader(certPEM))
+		rr := httptest.NewRecorder()
+		rawMux.ServeHTTP(rr, req)
+		Expect(rr.Code).To(Equal(http.StatusServiceUnavailable))
 	})
 })

--- a/internal/api/import_test.go
+++ b/internal/api/import_test.go
@@ -1,0 +1,237 @@
+// Copyright (C) 2026 Chris Boot
+// Copyright (C) 2026 Vox Pupuli and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package api_test
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/voxpupuli/openvox-ca/internal/api"
+	"github.com/voxpupuli/openvox-ca/internal/ca"
+	"github.com/voxpupuli/openvox-ca/internal/storage"
+	"github.com/voxpupuli/openvox-ca/internal/testutil"
+)
+
+// buildImportTestCSR returns a minimal, validly-signed CSR PEM for cn.
+func buildImportTestCSR(cn string) []byte {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	Expect(err).NotTo(HaveOccurred())
+	csrDER, err := x509.CreateCertificateRequest(rand.Reader, &x509.CertificateRequest{
+		Subject: pkix.Name{CommonName: cn},
+	}, key)
+	Expect(err).NotTo(HaveOccurred())
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER})
+}
+
+var _ = Describe("PUT /certificate/{subject} (import)", func() {
+	var (
+		tmpDir string
+		myCA   *ca.CA
+		mux    http.Handler
+		caKey  crypto.Signer
+		caCert *x509.Certificate
+	)
+
+	signLeaf := func(signerKey crypto.Signer, signerCert *x509.Certificate, cn string, dnsNames []string, serial *big.Int, isCA bool) []byte {
+		key, err := rsa.GenerateKey(rand.Reader, 2048)
+		Expect(err).NotTo(HaveOccurred())
+		if serial == nil {
+			serial, err = rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+			Expect(err).NotTo(HaveOccurred())
+		}
+		template := &x509.Certificate{
+			SerialNumber:          serial,
+			Subject:               pkix.Name{CommonName: cn},
+			NotBefore:             time.Now().Add(-24 * time.Hour),
+			NotAfter:              time.Now().Add(365 * 24 * time.Hour),
+			DNSNames:              dnsNames,
+			BasicConstraintsValid: true,
+			IsCA:                  isCA,
+		}
+		if isCA {
+			template.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageCRLSign
+		}
+		der, err := x509.CreateCertificate(rand.Reader, template, signerCert, &key.PublicKey, signerKey)
+		Expect(err).NotTo(HaveOccurred())
+		return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	}
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "openvox-ca-import-api-test")
+		Expect(err).NotTo(HaveOccurred())
+
+		store := storage.New(tmpDir)
+		myCA = ca.New(store, ca.AutosignConfig{Mode: "off"}, "puppet.test")
+
+		Expect(store.EnsureDirs(context.Background())).To(Succeed())
+		Expect(store.SaveCAKey(context.Background(), cachedKeyPEM)).To(Succeed())
+		Expect(store.SaveCACert(context.Background(), cachedCrtPEM)).To(Succeed())
+		Expect(store.UpdateCRL(context.Background(), cachedCrlPEM)).To(Succeed())
+		Expect(store.WriteSerial(context.Background(), "0001")).To(Succeed())
+		Expect(store.TouchInventory(context.Background())).To(Succeed())
+		Expect(myCA.Init(context.Background())).To(Succeed())
+
+		server := api.New(myCA)
+		mux = server.Routes()
+
+		keyBlock, _ := pem.Decode(cachedKeyPEM)
+		caKey, err = x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+		Expect(err).NotTo(HaveOccurred())
+		certBlock, _ := pem.Decode(cachedCrtPEM)
+		caCert, err = x509.ParseCertificate(certBlock.Bytes)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(tmpDir)
+	})
+
+	It("returns 200 with the import result on a valid certificate, and is idempotent on resubmission", func() {
+		certPEM := signLeaf(caKey, caCert, "import-node", []string{"import-node"}, nil, false)
+
+		req := httptest.NewRequest("PUT", "/certificate/import-node", bytes.NewReader(certPEM))
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, req)
+		Expect(rr.Code).To(Equal(http.StatusOK))
+
+		var result api.ImportResponse
+		Expect(json.Unmarshal(rr.Body.Bytes(), &result)).To(Succeed())
+		Expect(result.Subject).To(Equal("import-node"))
+		Expect(result.Imported).To(BeTrue())
+		Expect(result.Serial).NotTo(BeEmpty())
+
+		// Resubmitting the identical certificate must be a no-op, not an error.
+		req2 := httptest.NewRequest("PUT", "/certificate/import-node", bytes.NewReader(certPEM))
+		rr2 := httptest.NewRecorder()
+		mux.ServeHTTP(rr2, req2)
+		Expect(rr2.Code).To(Equal(http.StatusOK))
+
+		var result2 api.ImportResponse
+		Expect(json.Unmarshal(rr2.Body.Bytes(), &result2)).To(Succeed())
+		Expect(result2.Imported).To(BeFalse())
+		Expect(result2.Serial).To(Equal(result.Serial))
+	})
+
+	It("returns 400 when the certificate CN/SANs do not match the URL subject", func() {
+		certPEM := signLeaf(caKey, caCert, "actual-cn", []string{"actual-cn"}, nil, false)
+
+		req := httptest.NewRequest("PUT", "/certificate/unrelated-subject", bytes.NewReader(certPEM))
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, req)
+		Expect(rr.Code).To(Equal(http.StatusBadRequest))
+	})
+
+	It("returns 400 for a malformed PEM body", func() {
+		req := httptest.NewRequest("PUT", "/certificate/malformed-node", bytes.NewReader([]byte("not a pem file")))
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, req)
+		Expect(rr.Code).To(Equal(http.StatusBadRequest))
+	})
+
+	It("returns 400 for a certificate that does not chain to this CA", func() {
+		altKeyPEM, altCertPEM, _, err := testutil.GenerateTestCA()
+		Expect(err).NotTo(HaveOccurred())
+		altKeyBlock, _ := pem.Decode(altKeyPEM)
+		altKey, err := x509.ParsePKCS1PrivateKey(altKeyBlock.Bytes)
+		Expect(err).NotTo(HaveOccurred())
+		altCertBlock, _ := pem.Decode(altCertPEM)
+		altCert, err := x509.ParseCertificate(altCertBlock.Bytes)
+		Expect(err).NotTo(HaveOccurred())
+
+		foreignCert := signLeaf(altKey, altCert, "foreign-node", []string{"foreign-node"}, nil, false)
+
+		req := httptest.NewRequest("PUT", "/certificate/foreign-node", bytes.NewReader(foreignCert))
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, req)
+		Expect(rr.Code).To(Equal(http.StatusBadRequest))
+	})
+
+	It("returns 409 when the serial is already tracked under a different subject", func() {
+		serial := big.NewInt(0xABCDEF)
+		certA := signLeaf(caKey, caCert, "serial-a", []string{"serial-a"}, serial, false)
+		reqA := httptest.NewRequest("PUT", "/certificate/serial-a", bytes.NewReader(certA))
+		rrA := httptest.NewRecorder()
+		mux.ServeHTTP(rrA, reqA)
+		Expect(rrA.Code).To(Equal(http.StatusOK))
+
+		certB := signLeaf(caKey, caCert, "serial-b", []string{"serial-b"}, serial, false)
+		reqB := httptest.NewRequest("PUT", "/certificate/serial-b", bytes.NewReader(certB))
+		rrB := httptest.NewRecorder()
+		mux.ServeHTTP(rrB, reqB)
+		Expect(rrB.Code).To(Equal(http.StatusConflict))
+	})
+
+	It("returns 409 when the subject already has an active certificate", func() {
+		csrPEM := buildImportTestCSR("active-node")
+		_, err := myCA.SaveRequest(context.Background(), "active-node", csrPEM)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = myCA.Sign(context.Background(), "active-node")
+		Expect(err).NotTo(HaveOccurred())
+
+		importCert := signLeaf(caKey, caCert, "active-node", []string{"active-node"}, nil, false)
+		req := httptest.NewRequest("PUT", "/certificate/active-node", bytes.NewReader(importCert))
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, req)
+		Expect(rr.Code).To(Equal(http.StatusConflict))
+	})
+
+	It("makes the imported certificate visible via status and revocable via the normal mechanism", func() {
+		certPEM := signLeaf(caKey, caCert, "e2e-node", []string{"e2e-node"}, nil, false)
+
+		req := httptest.NewRequest("PUT", "/certificate/e2e-node", bytes.NewReader(certPEM))
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, req)
+		Expect(rr.Code).To(Equal(http.StatusOK))
+
+		statusReq := httptest.NewRequest("GET", "/certificate_status/e2e-node", nil)
+		statusRR := httptest.NewRecorder()
+		mux.ServeHTTP(statusRR, statusReq)
+		Expect(statusRR.Code).To(Equal(http.StatusOK))
+		var status api.CertStatusResponse
+		Expect(json.Unmarshal(statusRR.Body.Bytes(), &status)).To(Succeed())
+		Expect(status.State).To(Equal("signed"))
+
+		revokeBody, _ := json.Marshal(api.PutStatusBody{DesiredState: "revoked"})
+		revokeReq := httptest.NewRequest("PUT", "/certificate_status/e2e-node", bytes.NewReader(revokeBody))
+		revokeRR := httptest.NewRecorder()
+		mux.ServeHTTP(revokeRR, revokeReq)
+		Expect(revokeRR.Code).To(Equal(http.StatusNoContent))
+
+		statusReq2 := httptest.NewRequest("GET", "/certificate_status/e2e-node", nil)
+		statusRR2 := httptest.NewRecorder()
+		mux.ServeHTTP(statusRR2, statusReq2)
+		var status2 api.CertStatusResponse
+		Expect(json.Unmarshal(statusRR2.Body.Bytes(), &status2)).To(Succeed())
+		Expect(status2.State).To(Equal("revoked"))
+	})
+})

--- a/internal/ca/cleanup.go
+++ b/internal/ca/cleanup.go
@@ -28,12 +28,6 @@ import (
 	"github.com/voxpupuli/openvox-ca/internal/storage"
 )
 
-// inventoryTimeFormat is the layout the signing path writes NotBefore/NotAfter
-// with (see signCSR). It is parsed back here to decide which inventory entries
-// have expired. The trailing "UTC" is a literal in the layout (Go's zone token
-// is "MST"), so parsing yields a UTC time with the recorded wall-clock digits.
-const inventoryTimeFormat = "2006-01-02T15:04:05UTC"
-
 // CleanupExpiredCerts removes certificates whose NotAfter is older than retain
 // ago from the inventory, drops their entries from the CRL, deletes their stored
 // signed certificate (when the on-disk cert still has the expired serial, so a
@@ -66,7 +60,7 @@ func (c *CA) CleanupExpiredCerts(ctx context.Context, retain time.Duration) (int
 		// Prune the inventory first; the returned entries tell us exactly which
 		// serials to drop from the CRL and which caches/blobs to clean up.
 		dropped, err := c.Storage.PruneInventory(ctx, func(e storage.InventoryEntry) bool {
-			notAfter, perr := time.Parse(inventoryTimeFormat, e.NotAfter)
+			notAfter, perr := time.Parse(storage.InventoryTimeFormat, e.NotAfter)
 			if perr != nil {
 				slog.Warn("Cleanup: keeping inventory entry with unparseable NotAfter",
 					"serial", e.Serial, "subject", e.Subject, "not_after", e.NotAfter, "error", perr)

--- a/internal/ca/importcert.go
+++ b/internal/ca/importcert.go
@@ -46,7 +46,7 @@ var ErrSerialExists = errors.New("serial number already tracked in inventory")
 // ImportResult describes the outcome of a successful ImportCertificate call.
 type ImportResult struct {
 	Subject   string
-	Serial    string // serialHexStr(cert.SerialNumber) — matches inventory/CRL/OCSP form
+	Serial    string // uppercase hex, no leading zeros — the form used in the inventory, CRL, and OCSP responses
 	NotBefore time.Time
 	NotAfter  time.Time
 	Imported  bool // false when this call was a no-op (cert already tracked identically)
@@ -80,6 +80,12 @@ func certMatchesSubject(cert *x509.Certificate, subject string) bool {
 //
 // The caller must NOT hold c.mu. Serialises on the same cluster-wide
 // per-subject lock as Sign/SignWithTTL/Renew.
+//
+// Returns, for errors.Is branching:
+//   - ErrNotInitialized — the CA certificate or key has not been loaded.
+//   - ErrImportInvalid — any client-supplied input problem (see its doc).
+//   - ErrSerialExists — the certificate's serial is already tracked.
+//   - ErrCertExists — a live certificate already exists for subject.
 func (c *CA) ImportCertificate(ctx context.Context, subject string, certPEM []byte) (*ImportResult, error) {
 	if c.CACert == nil || c.CAKey == nil {
 		return nil, ErrNotInitialized
@@ -193,12 +199,7 @@ func (c *CA) importCertificateLocked(ctx context.Context, subject, serialStr str
 		return nil, fmt.Errorf("failed to save imported cert for %s: %w", subject, err)
 	}
 
-	inventoryEntry := fmt.Sprintf("%s %s %s /%s",
-		serialStr,
-		cert.NotBefore.UTC().Format("2006-01-02T15:04:05UTC"),
-		cert.NotAfter.UTC().Format("2006-01-02T15:04:05UTC"),
-		subject,
-	)
+	inventoryEntry := storage.FormatInventoryLine(serialStr, cert.NotBefore, cert.NotAfter, subject)
 	if err := c.Storage.AppendInventory(ctx, inventoryEntry); err != nil {
 		// Roll back the cert so storage and inventory stay in sync, same as
 		// signWithDuration's rollback-on-failure.

--- a/internal/ca/importcert.go
+++ b/internal/ca/importcert.go
@@ -1,0 +1,232 @@
+// Copyright (C) 2026 Chris Boot
+// Copyright (C) 2026 Vox Pupuli and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package ca
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/voxpupuli/openvox-ca/internal/storage"
+)
+
+// ErrImportInvalid is returned by ImportCertificate for any client-supplied
+// input problem: malformed/undecodable PEM, a signature that does not chain
+// to this CA, a CA certificate (IsCA=true), a subject that fails
+// ValidateSubject or does not match the certificate's CN/SANs, or a
+// malformed validity window. The wrapped message is safe to return to the
+// caller verbatim (contains no filesystem paths).
+var ErrImportInvalid = errors.New("invalid certificate for import")
+
+// ErrSerialExists is returned by ImportCertificate when the certificate's
+// serial number is already present in the inventory, under this subject or
+// another one.
+var ErrSerialExists = errors.New("serial number already tracked in inventory")
+
+// ImportResult describes the outcome of a successful ImportCertificate call.
+type ImportResult struct {
+	Subject   string
+	Serial    string // serialHexStr(cert.SerialNumber) — matches inventory/CRL/OCSP form
+	NotBefore time.Time
+	NotAfter  time.Time
+	Imported  bool // false when this call was a no-op (cert already tracked identically)
+}
+
+// certMatchesSubject reports whether subject equals the certificate's CN or
+// one of its DNS Subject Alternative Names.
+func certMatchesSubject(cert *x509.Certificate, subject string) bool {
+	if cert.Subject.CommonName == subject {
+		return true
+	}
+	for _, name := range cert.DNSNames {
+		if name == subject {
+			return true
+		}
+	}
+	return false
+}
+
+// ImportCertificate registers a certificate that was issued OUTSIDE this
+// CA's normal signing flow (e.g. migrated from a legacy CA sharing this
+// CA's key, or produced by some other offline process) into the inventory
+// under the given subject, so it appears in listings, has its lifetime
+// tracked, and can be revoked via Revoke(subject).
+//
+// certPEM must contain exactly one CERTIFICATE block whose signature
+// verifies against this CA's certificate. No other x509.Verify constraint
+// (validity window, key usage) is enforced, so an already-expired legacy
+// certificate can still be imported for record-keeping/CRL purposes. The
+// certificate's CN or one of its DNS SANs must equal subject.
+//
+// The caller must NOT hold c.mu. Serialises on the same cluster-wide
+// per-subject lock as Sign/SignWithTTL/Renew.
+func (c *CA) ImportCertificate(ctx context.Context, subject string, certPEM []byte) (*ImportResult, error) {
+	if c.CACert == nil || c.CAKey == nil {
+		return nil, ErrNotInitialized
+	}
+	if err := ValidateSubject(subject); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrImportInvalid, err)
+	}
+
+	block, rest := pem.Decode(certPEM)
+	if block == nil {
+		return nil, fmt.Errorf("%w: failed to decode certificate PEM", ErrImportInvalid)
+	}
+	if next, _ := pem.Decode(rest); next != nil {
+		return nil, fmt.Errorf("%w: PEM input contains more than one block; submit a single certificate", ErrImportInvalid)
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrImportInvalid, err)
+	}
+
+	// SECURITY: prove this certificate was genuinely issued by this CA's key
+	// before it can enter the trusted inventory (which feeds OCSP "good"
+	// responses and by-subject revocation). CheckSignatureFrom is a pure
+	// cryptographic signature check — unlike cert.Verify, it does not enforce
+	// current-time validity, so an intentionally-expired legacy certificate
+	// being archived is still accepted.
+	if err := cert.CheckSignatureFrom(c.CACert); err != nil {
+		return nil, fmt.Errorf("%w: certificate was not signed by this CA: %v", ErrImportInvalid, err)
+	}
+
+	if cert.IsCA {
+		return nil, fmt.Errorf("%w: refusing to import a CA certificate (use openvox-ca-ctl import for CA bundles)", ErrImportInvalid)
+	}
+
+	if !certMatchesSubject(cert, subject) {
+		return nil, fmt.Errorf("%w: subject %q matches neither the certificate's CN nor its DNS SANs", ErrImportInvalid, subject)
+	}
+
+	serialStr := serialHexStr(cert.SerialNumber)
+	if cert.SerialNumber.Sign() <= 0 {
+		return nil, fmt.Errorf("%w: certificate has a non-positive serial number", ErrImportInvalid)
+	}
+
+	if !cert.NotAfter.After(cert.NotBefore) {
+		return nil, fmt.Errorf("%w: NotAfter (%s) is not after NotBefore (%s)", ErrImportInvalid, cert.NotAfter, cert.NotBefore)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, lockTimeout)
+	defer cancel()
+
+	var out *ImportResult
+	err = c.Storage.WithLock(ctx, subjectLockName(subject), func() error {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		res, err := c.importCertificateLocked(ctx, subject, serialStr, cert, certPEM)
+		if err != nil {
+			return err
+		}
+		out = res
+		return nil
+	})
+	return out, err
+}
+
+// importCertificateLocked performs the storage-mutating part of
+// ImportCertificate. c.mu must be held by the caller.
+func (c *CA) importCertificateLocked(ctx context.Context, subject, serialStr string, cert *x509.Certificate, certPEM []byte) (*ImportResult, error) {
+	// Idempotent-duplicate check: if the exact same certificate is already
+	// the live cert tracked for this subject, accept with no further writes.
+	if c.Storage.HasCert(ctx, subject) {
+		existingPEM, err := c.Storage.GetCert(ctx, subject)
+		if err == nil {
+			if block, _ := pem.Decode(existingPEM); block != nil {
+				if existingCert, err := x509.ParseCertificate(block.Bytes); err == nil {
+					if existingCert.SerialNumber.Cmp(cert.SerialNumber) == 0 && bytes.Equal(existingCert.Raw, cert.Raw) {
+						return &ImportResult{
+							Subject:   subject,
+							Serial:    serialStr,
+							NotBefore: cert.NotBefore,
+							NotAfter:  cert.NotAfter,
+							Imported:  false,
+						}, nil
+					}
+				}
+			}
+		}
+	}
+
+	// Global serial-conflict check (ordering pre-check only — see
+	// AppendInventory below for the authoritative, race-safe enforcement).
+	// This exists purely so that a request tripping both the serial-conflict
+	// and active-certificate-conflict conditions reports ErrSerialExists,
+	// matching the documented priority order, rather than whichever check
+	// happened to run first.
+	exists, err := c.Storage.SerialExists(ctx, serialStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check serial uniqueness for %s: %w", subject, err)
+	}
+	if exists {
+		return nil, fmt.Errorf("%w: serial %s", ErrSerialExists, serialStr)
+	}
+
+	// Active-certificate check / revoked eviction: blocks if a live cert
+	// already exists for this subject, evicts it if revoked.
+	if err := c.evictRevokedLocked(ctx, subject); err != nil {
+		return nil, err
+	}
+
+	if err := c.Storage.SaveCert(ctx, subject, certPEM); err != nil {
+		return nil, fmt.Errorf("failed to save imported cert for %s: %w", subject, err)
+	}
+
+	inventoryEntry := fmt.Sprintf("%s %s %s /%s",
+		serialStr,
+		cert.NotBefore.UTC().Format("2006-01-02T15:04:05UTC"),
+		cert.NotAfter.UTC().Format("2006-01-02T15:04:05UTC"),
+		subject,
+	)
+	if err := c.Storage.AppendInventory(ctx, inventoryEntry); err != nil {
+		// Roll back the cert so storage and inventory stay in sync, same as
+		// signWithDuration's rollback-on-failure.
+		if delErr := c.Storage.DeleteCert(ctx, subject); delErr != nil {
+			slog.Warn("Failed to roll back cert after inventory write failure",
+				"subject", subject, "error", delErr)
+		}
+		if errors.Is(err, storage.ErrDuplicateSerial) {
+			return nil, fmt.Errorf("%w: %v", ErrSerialExists, err)
+		}
+		return nil, fmt.Errorf("failed to update inventory for %s: %w", subject, err)
+	}
+
+	// Update in-memory serial index for O(1) OCSP lookups.
+	c.serialIndex[serialStr] = subject
+
+	slog.Info("Certificate imported",
+		"subject", subject,
+		"serial", serialStr,
+		"not_before", cert.NotBefore.Format(time.RFC3339),
+		"not_after", cert.NotAfter.Format(time.RFC3339),
+	)
+
+	return &ImportResult{
+		Subject:   subject,
+		Serial:    serialStr,
+		NotBefore: cert.NotBefore,
+		NotAfter:  cert.NotAfter,
+		Imported:  true,
+	}, nil
+}

--- a/internal/ca/importcert_test.go
+++ b/internal/ca/importcert_test.go
@@ -1,0 +1,359 @@
+// Copyright (C) 2026 Chris Boot
+// Copyright (C) 2026 Vox Pupuli and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package ca_test
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/voxpupuli/openvox-ca/internal/ca"
+	"github.com/voxpupuli/openvox-ca/internal/storage"
+	"github.com/voxpupuli/openvox-ca/internal/testutil"
+)
+
+var _ = Describe("ImportCertificate", func() {
+	var (
+		ctx    = context.Background()
+		tmpDir string
+		myCA   *ca.CA
+		store  *storage.StorageService
+		caKey  crypto.Signer
+		caCert *x509.Certificate
+	)
+
+	// leafOpts customises a leaf certificate minted for these tests.
+	type leafOpts struct {
+		cn        string
+		dnsNames  []string
+		isCA      bool
+		notBefore time.Time
+		notAfter  time.Time
+		serial    *big.Int
+	}
+
+	// signLeaf mints a leaf certificate signed by (signerKey, signerCert),
+	// entirely outside myCA's own Sign/Generate flow — exactly the scenario
+	// ImportCertificate exists to handle.
+	signLeaf := func(signerKey crypto.Signer, signerCert *x509.Certificate, o leafOpts) []byte {
+		key, err := rsa.GenerateKey(rand.Reader, 2048)
+		Expect(err).NotTo(HaveOccurred())
+
+		serial := o.serial
+		if serial == nil {
+			serial, err = rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+			Expect(err).NotTo(HaveOccurred())
+		}
+		notBefore := o.notBefore
+		if notBefore.IsZero() {
+			notBefore = time.Now().UTC().Add(-24 * time.Hour)
+		}
+		notAfter := o.notAfter
+		if notAfter.IsZero() {
+			notAfter = time.Now().UTC().Add(365 * 24 * time.Hour)
+		}
+
+		template := &x509.Certificate{
+			SerialNumber:          serial,
+			Subject:               pkix.Name{CommonName: o.cn},
+			NotBefore:             notBefore,
+			NotAfter:              notAfter,
+			DNSNames:              o.dnsNames,
+			BasicConstraintsValid: true,
+			IsCA:                  o.isCA,
+		}
+		if o.isCA {
+			template.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageCRLSign
+		}
+
+		der, err := x509.CreateCertificate(rand.Reader, template, signerCert, &key.PublicKey, signerKey)
+		Expect(err).NotTo(HaveOccurred())
+		return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	}
+
+	parseCertPEM := func(certPEM []byte) *x509.Certificate {
+		block, _ := pem.Decode(certPEM)
+		Expect(block).NotTo(BeNil(), "cert PEM must decode")
+		cert, err := x509.ParseCertificate(block.Bytes)
+		Expect(err).NotTo(HaveOccurred())
+		return cert
+	}
+
+	issue := func(subject string) *x509.Certificate {
+		csrPEM, _ := buildCSR(subject)
+		_, err := myCA.SaveRequest(ctx, subject, csrPEM)
+		Expect(err).NotTo(HaveOccurred())
+		certPEM, err := myCA.Sign(ctx, subject)
+		Expect(err).NotTo(HaveOccurred())
+		return parseCertPEM(certPEM)
+	}
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "openvox-ca-importcert-test")
+		Expect(err).NotTo(HaveOccurred())
+
+		store = storage.New(tmpDir)
+		myCA = ca.New(store, ca.AutosignConfig{Mode: "off"}, "puppet.test")
+
+		Expect(store.EnsureDirs(ctx)).To(Succeed())
+		Expect(store.SaveCAKey(ctx, cachedKeyPEM)).To(Succeed())
+		Expect(store.SaveCACert(ctx, cachedCrtPEM)).To(Succeed())
+		Expect(store.UpdateCRL(ctx, cachedCrlPEM)).To(Succeed())
+		Expect(store.WriteSerial(ctx, "0001")).To(Succeed())
+		Expect(store.TouchInventory(ctx)).To(Succeed())
+		Expect(myCA.Init(ctx)).To(Succeed())
+
+		keyBlock, _ := pem.Decode(cachedKeyPEM)
+		caKey, err = x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+		Expect(err).NotTo(HaveOccurred())
+		certBlock, _ := pem.Decode(cachedCrtPEM)
+		caCert, err = x509.ParseCertificate(certBlock.Bytes)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(tmpDir)
+	})
+
+	It("imports a certificate signed outside the normal flow, and it can then be revoked by subject", func() {
+		certPEM := signLeaf(caKey, caCert, leafOpts{cn: "imported-node", dnsNames: []string{"imported-node"}})
+		leaf := parseCertPEM(certPEM)
+
+		result, err := myCA.ImportCertificate(ctx, "imported-node", certPEM)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Imported).To(BeTrue())
+		Expect(result.Subject).To(Equal("imported-node"))
+		Expect(result.Serial).To(Equal(strings.ToUpper(leaf.SerialNumber.Text(16))))
+
+		storedPEM, err := store.GetCert(ctx, "imported-node")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(storedPEM).To(Equal(certPEM))
+
+		serial, err := store.LatestSerialForSubject(ctx, "imported-node")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(serial).To(Equal(strings.ToUpper(leaf.SerialNumber.Text(16))))
+
+		Expect(myCA.Revoke(ctx, "imported-node")).To(Succeed())
+		revoked, err := myCA.IsRevokedSerial(ctx, leaf.SerialNumber)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(revoked).To(BeTrue())
+	})
+
+	It("is idempotent when the exact same certificate is resubmitted", func() {
+		certPEM := signLeaf(caKey, caCert, leafOpts{cn: "idempotent-node", dnsNames: []string{"idempotent-node"}})
+
+		first, err := myCA.ImportCertificate(ctx, "idempotent-node", certPEM)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(first.Imported).To(BeTrue())
+
+		entriesBefore, err := store.LatestSerialForSubject(ctx, "idempotent-node")
+		Expect(err).NotTo(HaveOccurred())
+
+		second, err := myCA.ImportCertificate(ctx, "idempotent-node", certPEM)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(second.Imported).To(BeFalse())
+		Expect(second.Serial).To(Equal(first.Serial))
+
+		entriesAfter, err := store.LatestSerialForSubject(ctx, "idempotent-node")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(entriesAfter).To(Equal(entriesBefore), "resubmission must not write a new inventory entry")
+	})
+
+	It("rejects a serial that is already tracked under a different subject", func() {
+		serial := big.NewInt(0xABCDEF)
+		certA := signLeaf(caKey, caCert, leafOpts{cn: "serial-a", dnsNames: []string{"serial-a"}, serial: serial})
+		_, err := myCA.ImportCertificate(ctx, "serial-a", certA)
+		Expect(err).NotTo(HaveOccurred())
+
+		certB := signLeaf(caKey, caCert, leafOpts{cn: "serial-b", dnsNames: []string{"serial-b"}, serial: serial})
+		_, err = myCA.ImportCertificate(ctx, "serial-b", certB)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(ca.ErrSerialExists))
+	})
+
+	It("prefers ErrSerialExists over ErrCertExists when both conflicts apply", func() {
+		// subject-x already has an active cert.
+		activeCertX := signLeaf(caKey, caCert, leafOpts{cn: "subject-x", dnsNames: []string{"subject-x"}})
+		_, err := myCA.ImportCertificate(ctx, "subject-x", activeCertX)
+		Expect(err).NotTo(HaveOccurred())
+
+		// subject-y's serial is separately already tracked.
+		reusedSerial := big.NewInt(0x1234567)
+		certY := signLeaf(caKey, caCert, leafOpts{cn: "subject-y", dnsNames: []string{"subject-y"}, serial: reusedSerial})
+		_, err = myCA.ImportCertificate(ctx, "subject-y", certY)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Now try to import a cert for subject-x that reuses subject-y's serial:
+		// subject-x already has an active cert (would trip ErrCertExists), AND
+		// the serial is already tracked elsewhere (would trip ErrSerialExists).
+		// The documented priority order requires ErrSerialExists to win.
+		conflictCert := signLeaf(caKey, caCert, leafOpts{cn: "subject-x", dnsNames: []string{"subject-x"}, serial: reusedSerial})
+		_, err = myCA.ImportCertificate(ctx, "subject-x", conflictCert)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(ca.ErrSerialExists))
+		Expect(err).NotTo(MatchError(ca.ErrCertExists))
+	})
+
+	It("rejects import over an existing active certificate for the subject", func() {
+		issue("active-node")
+
+		importCert := signLeaf(caKey, caCert, leafOpts{cn: "active-node", dnsNames: []string{"active-node"}})
+		_, err := myCA.ImportCertificate(ctx, "active-node", importCert)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(ca.ErrCertExists))
+
+		// The original signed cert must be untouched.
+		storedPEM, err := store.GetCert(ctx, "active-node")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(parseCertPEM(storedPEM).Subject.CommonName).To(Equal("active-node"))
+	})
+
+	It("evicts a revoked certificate and imports the replacement", func() {
+		original := issue("revoked-node")
+		Expect(myCA.Revoke(ctx, "revoked-node")).To(Succeed())
+
+		replacement := signLeaf(caKey, caCert, leafOpts{cn: "revoked-node", dnsNames: []string{"revoked-node"}})
+		result, err := myCA.ImportCertificate(ctx, "revoked-node", replacement)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Imported).To(BeTrue())
+
+		storedPEM, err := store.GetCert(ctx, "revoked-node")
+		Expect(err).NotTo(HaveOccurred())
+		stored := parseCertPEM(storedPEM)
+		Expect(stored.SerialNumber.Cmp(original.SerialNumber)).NotTo(Equal(0))
+		Expect(stored.Raw).To(Equal(parseCertPEM(replacement).Raw))
+	})
+
+	It("rejects a certificate whose signature does not chain to this CA", func() {
+		altKeyPEM, altCertPEM, _, err := testutil.GenerateTestCA()
+		Expect(err).NotTo(HaveOccurred())
+		altKeyBlock, _ := pem.Decode(altKeyPEM)
+		altKey, err := x509.ParsePKCS1PrivateKey(altKeyBlock.Bytes)
+		Expect(err).NotTo(HaveOccurred())
+		altCertBlock, _ := pem.Decode(altCertPEM)
+		altCert, err := x509.ParseCertificate(altCertBlock.Bytes)
+		Expect(err).NotTo(HaveOccurred())
+
+		foreignCert := signLeaf(altKey, altCert, leafOpts{cn: "foreign-node", dnsNames: []string{"foreign-node"}})
+
+		_, err = myCA.ImportCertificate(ctx, "foreign-node", foreignCert)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(ca.ErrImportInvalid))
+		Expect(err.Error()).To(ContainSubstring("not signed by this CA"))
+
+		Expect(store.HasCert(ctx, "foreign-node")).To(BeFalse())
+	})
+
+	It("rejects a CA certificate", func() {
+		caLikeCert := signLeaf(caKey, caCert, leafOpts{cn: "ca-like-node", isCA: true})
+
+		_, err := myCA.ImportCertificate(ctx, "ca-like-node", caLikeCert)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(ca.ErrImportInvalid))
+		Expect(err.Error()).To(ContainSubstring("refusing to import a CA certificate"))
+	})
+
+	It("rejects a subject that fails ValidateSubject", func() {
+		certPEM := signLeaf(caKey, caCert, leafOpts{cn: "bad..subject", dnsNames: []string{"bad..subject"}})
+
+		_, err := myCA.ImportCertificate(ctx, "bad..subject", certPEM)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(ca.ErrImportInvalid))
+	})
+
+	It("rejects a subject that matches neither the CN nor any DNS SAN", func() {
+		certPEM := signLeaf(caKey, caCert, leafOpts{cn: "actual-cn", dnsNames: []string{"actual-cn"}})
+
+		_, err := myCA.ImportCertificate(ctx, "unrelated-subject", certPEM)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(ca.ErrImportInvalid))
+	})
+
+	It("accepts a subject that matches a DNS SAN but not the CN", func() {
+		certPEM := signLeaf(caKey, caCert, leafOpts{cn: "primary-cn", dnsNames: []string{"primary-cn", "alt-san-name"}})
+
+		result, err := myCA.ImportCertificate(ctx, "alt-san-name", certPEM)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Imported).To(BeTrue())
+		Expect(result.Subject).To(Equal("alt-san-name"))
+	})
+
+	It("rejects malformed PEM input", func() {
+		_, err := myCA.ImportCertificate(ctx, "malformed-node", []byte("not a pem file"))
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(ca.ErrImportInvalid))
+	})
+
+	It("rejects input containing more than one PEM block", func() {
+		certA := signLeaf(caKey, caCert, leafOpts{cn: "multi-node", dnsNames: []string{"multi-node"}})
+		certB := signLeaf(caKey, caCert, leafOpts{cn: "multi-node-2", dnsNames: []string{"multi-node-2"}})
+
+		_, err := myCA.ImportCertificate(ctx, "multi-node", append(certA, certB...))
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(ca.ErrImportInvalid))
+	})
+
+	It("rejects a certificate whose NotAfter is not after NotBefore", func() {
+		now := time.Now().UTC()
+		certPEM := signLeaf(caKey, caCert, leafOpts{
+			cn:        "backwards-node",
+			dnsNames:  []string{"backwards-node"},
+			notBefore: now,
+			notAfter:  now.Add(-1 * time.Hour),
+		})
+
+		_, err := myCA.ImportCertificate(ctx, "backwards-node", certPEM)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(ca.ErrImportInvalid))
+	})
+
+	It("rejects a certificate with a non-positive serial number", func() {
+		certPEM := signLeaf(caKey, caCert, leafOpts{cn: "zero-serial-node", dnsNames: []string{"zero-serial-node"}, serial: big.NewInt(0)})
+
+		_, err := myCA.ImportCertificate(ctx, "zero-serial-node", certPEM)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(ca.ErrImportInvalid))
+	})
+
+	It("returns ErrNotInitialized rather than panicking on an un-Init'd CA", func() {
+		rawDir, err := os.MkdirTemp("", "openvox-ca-importcert-uninit-test")
+		Expect(err).NotTo(HaveOccurred())
+		defer os.RemoveAll(rawDir)
+		rawStore := storage.New(rawDir)
+		Expect(rawStore.EnsureDirs(ctx)).To(Succeed())
+		rawCA := ca.New(rawStore, ca.AutosignConfig{Mode: "off"}, "puppet.test")
+
+		certPEM := signLeaf(caKey, caCert, leafOpts{cn: "uninit-node", dnsNames: []string{"uninit-node"}})
+
+		var result *ca.ImportResult
+		Expect(func() { result, err = rawCA.ImportCertificate(ctx, "uninit-node", certPEM) }).NotTo(Panic())
+		Expect(err).To(MatchError(ca.ErrNotInitialized))
+		Expect(result).To(BeNil())
+	})
+})

--- a/internal/ca/importcert_test.go
+++ b/internal/ca/importcert_test.go
@@ -293,6 +293,7 @@ var _ = Describe("ImportCertificate", func() {
 		_, err := myCA.ImportCertificate(ctx, "unrelated-subject", certPEM)
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(ca.ErrImportInvalid))
+		Expect(err.Error()).To(ContainSubstring("matches neither"))
 	})
 
 	It("accepts a subject that matches a DNS SAN but not the CN", func() {
@@ -308,6 +309,15 @@ var _ = Describe("ImportCertificate", func() {
 		_, err := myCA.ImportCertificate(ctx, "malformed-node", []byte("not a pem file"))
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(ca.ErrImportInvalid))
+	})
+
+	It("rejects a well-formed CERTIFICATE PEM block whose DER does not parse", func() {
+		garbagePEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("not-der")})
+
+		_, err := myCA.ImportCertificate(ctx, "garbage-der-node", garbagePEM)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(ca.ErrImportInvalid))
+		Expect(store.HasCert(ctx, "garbage-der-node")).To(BeFalse())
 	})
 
 	It("rejects input containing more than one PEM block", func() {
@@ -331,6 +341,7 @@ var _ = Describe("ImportCertificate", func() {
 		_, err := myCA.ImportCertificate(ctx, "backwards-node", certPEM)
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(ca.ErrImportInvalid))
+		Expect(err.Error()).To(ContainSubstring("NotAfter"))
 	})
 
 	It("rejects a certificate with a non-positive serial number", func() {
@@ -339,6 +350,7 @@ var _ = Describe("ImportCertificate", func() {
 		_, err := myCA.ImportCertificate(ctx, "zero-serial-node", certPEM)
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(ca.ErrImportInvalid))
+		Expect(err.Error()).To(ContainSubstring("non-positive serial number"))
 	})
 
 	It("returns ErrNotInitialized rather than panicking on an un-Init'd CA", func() {

--- a/internal/ca/signing.go
+++ b/internal/ca/signing.go
@@ -33,6 +33,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/voxpupuli/openvox-ca/internal/storage"
 )
 
 const (
@@ -359,12 +361,7 @@ func (c *CA) signWithDuration(ctx context.Context, subject string, ttl time.Dura
 		return nil, fmt.Errorf("failed to save cert for %s: %w", subject, err)
 	}
 
-	inventoryEntry := fmt.Sprintf("%s %s %s /%s",
-		serialStr,
-		template.NotBefore.Format("2006-01-02T15:04:05UTC"),
-		template.NotAfter.Format("2006-01-02T15:04:05UTC"),
-		subject,
-	)
+	inventoryEntry := storage.FormatInventoryLine(serialStr, template.NotBefore, template.NotAfter, subject)
 	if err := c.Storage.AppendInventory(ctx, inventoryEntry); err != nil {
 		// Roll back the cert so storage and inventory stay in sync. Log but don't
 		// propagate the cleanup error; the caller already has an error to handle.

--- a/internal/storage/duplicate_serial_test.go
+++ b/internal/storage/duplicate_serial_test.go
@@ -1,0 +1,103 @@
+// Copyright (C) 2026 Chris Boot
+// Copyright (C) 2026 Vox Pupuli and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package storage
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("AppendInventory duplicate serial rejection", func() {
+	It("rejects a duplicate serial under a different subject on the SQL backend", func() {
+		ctx := context.Background()
+		b := newSQLiteBackend()
+		svc := NewWithBackend(b, "")
+		Expect(svc.TouchInventory(ctx)).NotTo(HaveOccurred())
+		Expect(svc.InitHMAC(ctx)).NotTo(HaveOccurred())
+
+		Expect(svc.AppendInventory(ctx, "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1")).NotTo(HaveOccurred())
+
+		err := svc.AppendInventory(ctx, "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node2")
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, ErrDuplicateSerial)).To(BeTrue(), "expected ErrDuplicateSerial, got %v", err)
+
+		entries, err := svc.inventoryEntriesLocked(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(entries).To(HaveLen(1), "the duplicate row must not have been inserted")
+	})
+
+	It("rejects a duplicate serial under a different subject on the filesystem backend", func() {
+		ctx := context.Background()
+		dir := GinkgoT().TempDir()
+		be := NewFilesystemBackend(dir)
+		svc := NewWithBackend(be, "")
+		Expect(svc.EnsureDirs(ctx)).NotTo(HaveOccurred())
+		Expect(svc.TouchInventory(ctx)).NotTo(HaveOccurred())
+		Expect(svc.InitHMAC(ctx)).NotTo(HaveOccurred())
+
+		Expect(svc.AppendInventory(ctx, "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1")).NotTo(HaveOccurred())
+
+		err := svc.AppendInventory(ctx, "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node2")
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, ErrDuplicateSerial)).To(BeTrue(), "expected ErrDuplicateSerial, got %v", err)
+
+		inv, err := svc.ReadInventory(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(inv)).To(Equal("0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1\n"),
+			"the duplicate line must not have been appended")
+	})
+
+	It("rejects a malformed entry on the filesystem backend instead of writing it", func() {
+		ctx := context.Background()
+		dir := GinkgoT().TempDir()
+		be := NewFilesystemBackend(dir)
+		svc := NewWithBackend(be, "")
+		Expect(svc.EnsureDirs(ctx)).NotTo(HaveOccurred())
+		Expect(svc.TouchInventory(ctx)).NotTo(HaveOccurred())
+		Expect(svc.InitHMAC(ctx)).NotTo(HaveOccurred())
+
+		err := svc.AppendInventory(ctx, "too few fields")
+		Expect(err).To(HaveOccurred())
+
+		inv, err := svc.ReadInventory(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(inv)).To(BeEmpty(), "malformed entry must not have been written")
+	})
+})
+
+var _ = Describe("StorageService.SerialExists", func() {
+	It("reports presence and absence of a serial across the inventory", func() {
+		ctx := context.Background()
+		b := newSQLiteBackend()
+		svc := NewWithBackend(b, "")
+		Expect(svc.TouchInventory(ctx)).NotTo(HaveOccurred())
+		Expect(svc.InitHMAC(ctx)).NotTo(HaveOccurred())
+		Expect(svc.AppendInventory(ctx, "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1")).NotTo(HaveOccurred())
+
+		exists, err := svc.SerialExists(ctx, "0001")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(exists).To(BeTrue())
+
+		exists, err = svc.SerialExists(ctx, "DEADBEEF")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(exists).To(BeFalse())
+	})
+})

--- a/internal/storage/etcd_integration_test.go
+++ b/internal/storage/etcd_integration_test.go
@@ -258,6 +258,15 @@ var _ = Describe("EtcdBackendEndToEndViaStorageService", func() {
 		Expect(err).NotTo(HaveOccurred(), "ReadInventory")
 		Expect(string(inv)).To(Equal(line1+"\n"+line2+"\n"), "ReadInventory = %q, want %q", inv, line1+"\n"+line2+"\n")
 
+		// Re-appending line1's serial (0001) under a different subject must be
+		// rejected by the blob-path duplicate scan, and must not mutate the
+		// inventory.
+		dup := "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node3"
+		Expect(svc.AppendInventory(context.Background(), dup)).To(MatchError(ErrDuplicateSerial), "duplicate serial must be rejected")
+		inv, err = svc.ReadInventory(context.Background())
+		Expect(err).NotTo(HaveOccurred(), "ReadInventory after duplicate")
+		Expect(string(inv)).To(Equal(line1+"\n"+line2+"\n"), "inventory must be unchanged after a rejected duplicate")
+
 		Expect(svc.SaveCSR(context.Background(), "node1", []byte("csr-pem"))).To(Succeed(), "SaveCSR")
 		Expect(svc.SaveCert(context.Background(), "node1", []byte("cert-pem"))).To(Succeed(), "SaveCert")
 		csrs, err := svc.ListCSRs(context.Background())

--- a/internal/storage/etcd_integration_test.go
+++ b/internal/storage/etcd_integration_test.go
@@ -249,12 +249,14 @@ var _ = Describe("EtcdBackendEndToEndViaStorageService", func() {
 		Expect(string(got)).To(Equal("0001"), "GetSerial = %q, want 0001", got)
 
 		Expect(svc.InitHMAC(context.Background())).To(Succeed(), "InitHMAC")
-		Expect(svc.AppendInventory(context.Background(), "line 1")).To(Succeed(), "AppendInventory")
-		Expect(svc.AppendInventory(context.Background(), "line 2")).To(Succeed(), "AppendInventory")
+		const line1 = "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1"
+		const line2 = "0002 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node2"
+		Expect(svc.AppendInventory(context.Background(), line1)).To(Succeed(), "AppendInventory")
+		Expect(svc.AppendInventory(context.Background(), line2)).To(Succeed(), "AppendInventory")
 
 		inv, err := svc.ReadInventory(context.Background())
 		Expect(err).NotTo(HaveOccurred(), "ReadInventory")
-		Expect(string(inv)).To(Equal("line 1\nline 2\n"), "ReadInventory = %q, want 'line 1\\nline 2\\n'", inv)
+		Expect(string(inv)).To(Equal(line1+"\n"+line2+"\n"), "ReadInventory = %q, want %q", inv, line1+"\n"+line2+"\n")
 
 		Expect(svc.SaveCSR(context.Background(), "node1", []byte("csr-pem"))).To(Succeed(), "SaveCSR")
 		Expect(svc.SaveCert(context.Background(), "node1", []byte("cert-pem"))).To(Succeed(), "SaveCert")

--- a/internal/storage/redis_test.go
+++ b/internal/storage/redis_test.go
@@ -336,11 +336,13 @@ var _ = Describe("RedisBackend", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(got)).To(Equal("0001"))
 		Expect(svc.InitHMAC(context.Background())).NotTo(HaveOccurred())
-		Expect(svc.AppendInventory(context.Background(), "line 1")).NotTo(HaveOccurred())
-		Expect(svc.AppendInventory(context.Background(), "line 2")).NotTo(HaveOccurred())
+		const line1 = "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1"
+		const line2 = "0002 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node2"
+		Expect(svc.AppendInventory(context.Background(), line1)).NotTo(HaveOccurred())
+		Expect(svc.AppendInventory(context.Background(), line2)).NotTo(HaveOccurred())
 		inv, err := svc.ReadInventory(context.Background())
 		Expect(err).NotTo(HaveOccurred())
-		Expect(string(inv)).To(Equal("line 1\nline 2\n"))
+		Expect(string(inv)).To(Equal(line1 + "\n" + line2 + "\n"))
 		Expect(svc.SaveCSR(context.Background(), "node1", []byte("csr-pem"))).NotTo(HaveOccurred())
 		Expect(svc.SaveCert(context.Background(), "node1", []byte("cert-pem"))).NotTo(HaveOccurred())
 		csrs, err := svc.ListCSRs(context.Background())

--- a/internal/storage/redis_test.go
+++ b/internal/storage/redis_test.go
@@ -343,6 +343,16 @@ var _ = Describe("RedisBackend", func() {
 		inv, err := svc.ReadInventory(context.Background())
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(inv)).To(Equal(line1 + "\n" + line2 + "\n"))
+
+		// Re-appending line1's serial (0001) under a different subject must be
+		// rejected by the blob-path duplicate scan, and must leave the inventory
+		// untouched.
+		dup := "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node3"
+		Expect(svc.AppendInventory(context.Background(), dup)).To(MatchError(ErrDuplicateSerial))
+		inv, err = svc.ReadInventory(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(inv)).To(Equal(line1 + "\n" + line2 + "\n"))
+
 		Expect(svc.SaveCSR(context.Background(), "node1", []byte("csr-pem"))).NotTo(HaveOccurred())
 		Expect(svc.SaveCert(context.Background(), "node1", []byte("cert-pem"))).NotTo(HaveOccurred())
 		csrs, err := svc.ListCSRs(context.Background())

--- a/internal/storage/sql.go
+++ b/internal/storage/sql.go
@@ -519,7 +519,18 @@ func isUniqueSerialViolation(err error) bool {
 	}
 	var liteErr *sqlite.Error
 	if errors.As(err, &liteErr) {
-		return liteErr.Code() == 2067 || liteErr.Code() == 19 // SQLITE_CONSTRAINT_UNIQUE / SQLITE_CONSTRAINT
+		// 2067 (SQLITE_CONSTRAINT_UNIQUE) is the exact analogue of the MySQL
+		// and PostgreSQL codes above. We also accept 19 (the generic primary
+		// SQLITE_CONSTRAINT) as a deliberate driver-compatibility fallback:
+		// modernc.org/sqlite has historically surfaced the primary code rather
+		// than the extended one on some builds. This is broader than the
+		// "specific code only" intent documented above, but the breadth is
+		// harmless on puppet_ca_inventory — its only insert has an
+		// autoincrement PK and all-NOT-NULL columns populated by
+		// parseInventoryEntry, so the serial UNIQUE index is the only
+		// constraint that can realistically fire, and the violating row has
+		// already been rolled back regardless.
+		return liteErr.Code() == 2067 || liteErr.Code() == 19
 	}
 	return false
 }

--- a/internal/storage/sql.go
+++ b/internal/storage/sql.go
@@ -40,6 +40,7 @@ import (
 	"github.com/uptrace/bun/driver/sqliteshim"
 	"github.com/uptrace/bun/migrate"
 	"github.com/uptrace/bun/schema"
+	"modernc.org/sqlite"
 )
 
 // SQLDialect selects which SQL engine an SQLBackend talks to. The same backend
@@ -496,6 +497,29 @@ func isRetryableSQLError(err error) bool {
 	var myErr *mysqldriver.MySQLError
 	if errors.As(err, &myErr) {
 		return myErr.Number == 1213 || myErr.Number == 1205
+	}
+	return false
+}
+
+// isUniqueSerialViolation reports whether err is a unique-constraint
+// violation on the inventory's serial index, across every dialect this
+// project supports. Deliberately checks the specific unique-violation
+// SQLSTATE/error code for each dialect rather than a broader "integrity
+// violation" classifier, so a future schema change adding an unrelated
+// constraint (e.g. a check or foreign key) is not silently misreported as a
+// duplicate serial.
+func isUniqueSerialViolation(err error) bool {
+	var myErr *mysqldriver.MySQLError
+	if errors.As(err, &myErr) {
+		return myErr.Number == 1062 // ER_DUP_ENTRY
+	}
+	var pgErr pgdriver.Error
+	if errors.As(err, &pgErr) {
+		return pgErr.Field('C') == "23505" // SQLSTATE unique_violation
+	}
+	var liteErr *sqlite.Error
+	if errors.As(err, &liteErr) {
+		return liteErr.Code() == 2067 || liteErr.Code() == 19 // SQLITE_CONSTRAINT_UNIQUE / SQLITE_CONSTRAINT
 	}
 	return false
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -214,14 +214,20 @@ func (s *StorageService) AppendInventory(ctx context.Context, entry string) erro
 		return nil
 	}
 
-	// Blob backends have no native uniqueness constraint on serial, so check
-	// explicitly under inventoryMu (already held) before appending.
-	existing, err := s.inventoryEntriesLocked(ctx)
+	// Blob backends have no native uniqueness constraint on serial, so scan the
+	// current inventory under inventoryMu (already held) before appending. Read
+	// the whole blob once here and reuse those bytes for both the duplicate scan
+	// and the HMAC recompute below, so the append path does a single whole-blob
+	// read rather than reading it again inside updateInventoryHMACLocked.
+	data, err := s.readInventoryForHMAC(ctx)
 	if err != nil {
 		return err
 	}
-	for _, e := range existing {
-		if e.Serial == parsed.Serial {
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		if e, ok := parseInventoryEntry(line); ok && e.Serial == parsed.Serial {
 			return fmt.Errorf("%w: %s", ErrDuplicateSerial, parsed.Serial)
 		}
 	}
@@ -231,22 +237,30 @@ func (s *StorageService) AppendInventory(ctx context.Context, entry string) erro
 	}
 
 	if s.hmacKey != nil {
-		if err := s.updateInventoryHMACLocked(ctx, s.hmacKey); err != nil {
+		// AppendLine is a literal byte-append, so the stored blob is now exactly
+		// data + entry + "\n". Hash that reconstruction directly instead of
+		// re-reading the blob (which computeInventoryHMAC would do), keeping the
+		// value byte-identical to a fresh whole-blob recompute.
+		newBlob := make([]byte, 0, len(data)+len(entry)+1)
+		newBlob = append(newBlob, data...)
+		newBlob = append(newBlob, entry...)
+		newBlob = append(newBlob, '\n')
+		if err := s.backend.Put(ctx, KeyInventoryHMAC, wholeBlobInventoryMAC(s.hmacKey, newBlob), BlobPrivate); err != nil {
 			// The line is already durably appended, but the stored HMAC now
 			// lags the inventory: the next verify would falsely report
 			// tampering. Surface the failure so the caller can react (e.g.
 			// roll back the just-written cert) rather than hiding it.
 			//
 			// We deliberately do not try to make the line-append and the
-			// HMAC-recompute a single atomic unit here (e.g. stage both in
-			// temp files and rename-swap). A rename only narrows, not closes,
-			// the window — a crash between the two renames still leaves the
-			// pair inconsistent — and the structured InventoryStore backends
-			// (see the AppendEntry path above) already advance the integrity
-			// head atomically via an O(1) hash chain, which is the durable
-			// path operators should prefer. For the whole-blob fallback the
-			// honest contract is: report the failure so the caller decides,
-			// not silently leave a mismatch behind.
+			// HMAC-write a single atomic unit here (e.g. stage both in temp
+			// files and rename-swap). A rename only narrows, not closes, the
+			// window — a crash between the two renames still leaves the pair
+			// inconsistent — and the structured InventoryStore backends (see
+			// the AppendEntry path above) already advance the integrity head
+			// atomically via an O(1) hash chain, which is the durable path
+			// operators should prefer. For the whole-blob fallback the honest
+			// contract is: report the failure so the caller decides, not
+			// silently leave a mismatch behind.
 			return fmt.Errorf("updating inventory HMAC after append: %w", err)
 		}
 	}
@@ -752,9 +766,17 @@ func (s *StorageService) computeInventoryHMAC(ctx context.Context, hmacKey []byt
 	if err != nil {
 		return nil, err
 	}
-	mac := hmac.New(sha256.New, hmacKey)
-	mac.Write(data)
-	return mac.Sum(nil), nil
+	return wholeBlobInventoryMAC(hmacKey, data), nil
+}
+
+// wholeBlobInventoryMAC is the whole-blob inventory integrity value:
+// HMAC-SHA256(key, blob). It is the single definition of the blob-backend HMAC
+// so the recompute-from-storage path (computeInventoryHMAC) and the
+// append-in-place path (AppendInventory) cannot diverge.
+func wholeBlobInventoryMAC(key, blob []byte) []byte {
+	mac := hmac.New(sha256.New, key)
+	mac.Write(blob)
+	return mac.Sum(nil)
 }
 
 // chainInventoryMAC advances the inventory hash chain by one entry:

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -170,26 +170,60 @@ func (s *StorageService) InitHMAC(ctx context.Context) error {
 	return s.VerifyInventoryHMAC(ctx, key)
 }
 
+// ErrDuplicateSerial is returned by AppendInventory when the entry's serial
+// number already exists in the inventory. SQL backends detect this via their
+// unique index (translated from the dialect-specific driver error); blob
+// backends via an explicit scan performed under the same inventoryMu that
+// already serialises every append within a process.
+//
+// This is NOT a cross-replica guarantee on non-SQL backends: nothing today
+// wraps the whole AppendInventory call in a distributed lock for
+// filesystem/etcd/redis backends (see the blob-fallback HMAC-update comment
+// below, which already documents a similar limitation for that path).
+// Structured (SQL) backends remain the only ones with a true cluster-wide
+// guarantee, via the database's own unique index.
+var ErrDuplicateSerial = errors.New("serial number already exists in inventory")
+
 // AppendInventory adds entry (a single inventory.txt line, without a trailing
 // newline) to the inventory. On backends that implement InventoryStore the
 // entry is stored as a structured record and the integrity head is advanced by
 // a hash chain in O(1); otherwise the line is appended to the KeyInventory blob
-// and the whole-blob HMAC is recomputed.
+// and the whole-blob HMAC is recomputed. Returns ErrDuplicateSerial (wrapped)
+// if the entry's serial is already present anywhere in the inventory.
 func (s *StorageService) AppendInventory(ctx context.Context, entry string) error {
 	s.inventoryMu.Lock()
 	defer s.inventoryMu.Unlock()
 
+	parsed, ok := parseInventoryEntry(entry)
+	if !ok {
+		return fmt.Errorf("malformed inventory entry %q", entry)
+	}
+
 	if store, ok := s.backend.(InventoryStore); ok {
-		parsed, ok := parseInventoryEntry(entry)
-		if !ok {
-			return fmt.Errorf("malformed inventory entry %q", entry)
-		}
 		var newHead func(prev []byte) []byte
 		if s.hmacKey != nil {
 			key := s.hmacKey
 			newHead = func(prev []byte) []byte { return chainInventoryMAC(key, prev, entry) }
 		}
-		return store.AppendEntry(ctx, parsed, newHead)
+		if err := store.AppendEntry(ctx, parsed, newHead); err != nil {
+			if isUniqueSerialViolation(err) {
+				return fmt.Errorf("%w: %s", ErrDuplicateSerial, parsed.Serial)
+			}
+			return err
+		}
+		return nil
+	}
+
+	// Blob backends have no native uniqueness constraint on serial, so check
+	// explicitly under inventoryMu (already held) before appending.
+	existing, err := s.inventoryEntriesLocked(ctx)
+	if err != nil {
+		return err
+	}
+	for _, e := range existing {
+		if e.Serial == parsed.Serial {
+			return fmt.Errorf("%w: %s", ErrDuplicateSerial, parsed.Serial)
+		}
 	}
 
 	if err := s.backend.AppendLine(ctx, KeyInventory, []byte(entry+"\n"), BlobPrivate); err != nil {
@@ -217,6 +251,27 @@ func (s *StorageService) AppendInventory(ctx context.Context, entry string) erro
 		}
 	}
 	return nil
+}
+
+// SerialExists reports whether any inventory entry — for any subject, current
+// or historical — already carries the given serial number. This is a
+// best-effort, non-authoritative check: callers needing a real guarantee
+// must rely on AppendInventory's own atomic duplicate check
+// (ErrDuplicateSerial), not this method, since SerialExists does not hold
+// inventoryMu across its caller's subsequent write.
+func (s *StorageService) SerialExists(ctx context.Context, serial string) (bool, error) {
+	s.inventoryMu.RLock()
+	defer s.inventoryMu.RUnlock()
+	entries, err := s.inventoryEntriesLocked(ctx)
+	if err != nil {
+		return false, err
+	}
+	for _, e := range entries {
+		if e.Serial == serial {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // LatestSerialForSubject returns the most recently issued serial for subject.

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -770,11 +770,31 @@ func chainInventoryMAC(key, prev []byte, line string) []byte {
 	return mac.Sum(nil)
 }
 
+// InventoryTimeFormat is the layout for the NotBefore/NotAfter timestamps in
+// an inventory.txt line. It is part of the on-disk wire format. The trailing
+// "UTC" is a literal in the layout (Go's zone token is "MST"), so formatting a
+// UTC time records its wall-clock digits and parsing yields them back as UTC.
+const InventoryTimeFormat = "2006-01-02T15:04:05UTC"
+
 // canonicalInventoryLine renders e to its inventory.txt line (without the
 // trailing newline). It is the single source of truth for the on-disk blob
 // format and the input to the integrity hash chain, so the two cannot drift.
 func canonicalInventoryLine(e InventoryEntry) string {
 	return fmt.Sprintf("%s %s %s /%s", e.Serial, e.NotBefore, e.NotAfter, e.Subject)
+}
+
+// FormatInventoryLine builds the canonical inventory.txt line (without the
+// trailing newline) from the semantic fields, formatting the timestamps in UTC
+// via InventoryTimeFormat. Issuance paths (signing, import) must construct
+// inventory lines through this single constructor so they cannot drift from the
+// reader/writer/HMAC format owned by canonicalInventoryLine.
+func FormatInventoryLine(serial string, notBefore, notAfter time.Time, subject string) string {
+	return canonicalInventoryLine(InventoryEntry{
+		Serial:    serial,
+		NotBefore: notBefore.UTC().Format(InventoryTimeFormat),
+		NotAfter:  notAfter.UTC().Format(InventoryTimeFormat),
+		Subject:   subject,
+	})
 }
 
 // parseInventoryEntry parses a single inventory.txt line into an InventoryEntry.


### PR DESCRIPTION
Certificates issued outside this CA's normal `Sign`/`Generate` flow (e.g. migrated from a legacy CA sharing this CA's key) previously had no way to enter the inventory, so they were invisible to listing, expiry cleanup, and by-subject revocation, even though they were genuinely signed by this CA.

This adds `PUT /certificate/{subject}` (admin-only, sharing its path with the existing public `GET /certificate/{subject}`) and an `openvox-ca-ctl import-cert --certname --cert-file` CLI command to import such a certificate:

- The certificate's signature must verify against this CA's certificate (a pure cryptographic check via `CheckSignatureFrom`, so an already-expired legacy certificate is still accepted for record-keeping).
- The path `{subject}` must match the certificate's CN or one of its DNS SANs.
- CA certificates (`IsCA: true`) are rejected — use `openvox-ca-ctl import` for CA bundle import instead.
- Conflict handling, in priority order: (1) resubmitting the exact same certificate is an idempotent no-op; (2) a serial already tracked anywhere in the inventory is rejected (`409`); (3) an existing active certificate for the subject is rejected (`409`), or evicted if it's revoked.

Once imported, the certificate is tracked exactly like a normally-issued one: it shows up in listings, gets cleaned up by the expiry sweep, and can be revoked via the normal `PUT /certificate_status/{subject}` (`desired_state: "revoked"`) mechanism.

Also hardens `AppendInventory` to reject a duplicate serial atomically on **every** storage backend — previously only the SQL backend enforced this, via its DB-level unique index; filesystem/etcd/redis backends had no equivalent check at all. This benefits normal certificate issuance too, not just the new import path, and is what the import feature's serial-conflict check ultimately relies on for race-safety (a separate best-effort pre-check exists only to get error precedence right in the common, non-racing case).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>