### PR TITLE
Handle log file close errors on shutdown

### DIFF
--- a/cmd/openvox-ca/main.go
+++ b/cmd/openvox-ca/main.go
@@ -372,7 +372,13 @@ func newRootCmd() *cobra.Command {
 				return err
 			}
 			if logFile != nil {
-				defer logFile.Close()
+				defer func() {
+					// Report on stderr, not slog: the default logger writes to
+					// this very file, which is being closed here.
+					if cerr := logFile.Close(); cerr != nil {
+						fmt.Fprintf(os.Stderr, "failed to close log file: %v\n", cerr)
+					}
+				}()
 			}
 
 			slog.Info("Starting Puppet CA",
@@ -742,7 +748,13 @@ func runSignerMode(ctx context.Context, cfg *serverConfig, absCADir string) erro
 		slog.Warn("Failed to open log file, using stderr", "error", err)
 	}
 	if logFile != nil {
-		defer logFile.Close()
+		defer func() {
+			// Report on stderr, not slog: the default logger writes to this
+			// very file, which is being closed here.
+			if cerr := logFile.Close(); cerr != nil {
+				fmt.Fprintf(os.Stderr, "failed to close log file: %v\n", cerr)
+			}
+		}()
 	}
 
 	slog.Info("Starting CA signer process",


### PR DESCRIPTION
CodeQL's `go/unhandled-writable-file-close` flagged both `defer logFile.Close()` sites in `cmd/openvox-ca/main.go`. On a writable file, a deferred close that discards its error can silently lose buffered write failures, so the alert is worth addressing rather than dismissing.

This handles the close error in both the frontend/single-process path and the signer path. The failure is reported on `os.Stderr` rather than via `slog`, because the default logger writes to the very file being closed — logging the failure through slog at that point would be futile.

Alongside this change I triaged the rest of the open CodeQL alerts on the repo and dismissed them as false positives with documented reasons:

- **25× `go/log-injection`** — every flagged site is a structured `slog` call where user input is an attribute *value*. Both handlers configured here (JSONHandler to file, TextHandler to stderr) escape control characters/newlines in values, and certname/subject values are further constrained by `subjectRegex` (`^[a-z0-9_.][a-z0-9._-]*$`), which cannot contain a newline.
- **1× `go/allocation-size-overflow`** — `make([]byte, 8+len(data))` in `internal/storage/etcd.go`, where `len(data)` is the length of an already-allocated slice, bounded far below `MaxInt-8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)