### PR TITLE
Annotate the etcd backoff jitter for semgrep

### DIFF
--- a/internal/storage/etcd.go
+++ b/internal/storage/etcd.go
@@ -349,6 +349,12 @@ func (b *EtcdBackend) AppendLine(ctx context.Context, key string, data []byte, _
 		// under load). Honour the caller's cancellation rather than spinning
 		// past it.
 		window := time.Duration(attempt+1) * 10 * time.Millisecond
+		// math/rand/v2 is deliberate here: this value is retry timing only,
+		// never a token or key, and the v2 generator is ChaCha8 seeded
+		// per-process from OS entropy, so remote writers cannot predict each
+		// other's jitter. All security-relevant randomness in this codebase
+		// uses crypto/rand.
+		// nosemgrep: go.lang.security.audit.crypto.math_random.math-random-used
 		backoff := time.Duration(rand.Int64N(int64(window))) //nolint:gosec // jitter, not security-sensitive
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
Fixes #148.

The threat-model finding flagged the `math/rand/v2` use at the top of `internal/storage/etcd.go`. Reviewing the single call site confirms the finding's own \"likely benign\" assessment: the value is full-jitter backoff in the `AppendLine` compare-and-swap retry loop — retry timing only, never a token, key, or lock identity. All security-relevant randomness in this codebase (CA keys, serials, HMAC keys, Redis lock tokens) already uses `crypto/rand`.

The finding's DoS theory (predictable jitter enabling coordinated thundering-herd contention) also does not apply to `math/rand/v2`: unlike the legacy `math/rand` global with its fixed default seed, the v2 top-level generator is ChaCha8 seeded per-process from OS entropy, so remote writers cannot predict each other's jitter.

No behavioural change is needed, so this applies the finding's suggested detective control instead: a `nosemgrep` annotation for `go.lang.security.audit.crypto.math_random.math-random-used` with an explanatory comment, alongside the existing `//nolint:gosec` annotation that already covers golangci-lint. Comment-only change — no crypto paths touched, so the FIPS/boringcrypto contract is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)