### PR TITLE
Extend inventory table as certificate index (CertIndex capability)

### DIFF
--- a/docs/development/inventory-store.md
+++ b/docs/development/inventory-store.md
@@ -61,12 +61,13 @@ type InventoryEntry struct {
 // render → scan → reparse round-trip. Backends that do not implement it keep
 // using the KeyInventory blob via AppendLine/Get.
 type InventoryStore interface {
-    // AppendEntry inserts e and advances the integrity head atomically.
+    // AppendEntry inserts rec and advances the integrity head atomically.
     // newHead computes the chained head MAC from the previous head (nil when
     // the inventory is empty); the backend MUST invoke it inside the same
     // transaction/lock that serialises appends so the chain cannot fork under
-    // concurrent appenders.
-    AppendEntry(ctx context.Context, e InventoryEntry, newHead func(prev []byte) []byte) error
+    // concurrent appenders. rec is a CertRecord (see "The certificate index"
+    // below); only its canonical InventoryEntry fields feed the chain.
+    AppendEntry(ctx context.Context, rec CertRecord, newHead func(prev []byte) []byte) error
 
     // Entries returns every entry in issuance order, for the OCSP index build
     // and for chain verification.
@@ -136,6 +137,51 @@ blob HMAC ≠ a chain head over the same entries). So after the copy,
 recomputes the destination's integrity head from its entries
 (`RebuildInventoryHMAC`). This resolves the otherwise-spurious
 `ErrInventoryTampered` that copying a foreign `inventory_hmac` would cause.
+
+### The certificate index (`CertIndex`)
+
+The inventory table doubles as a **certificate index**: alongside the four
+canonical columns, each row carries a denormalised display projection
+(`fingerprint_sha256`, `dns_alt_names`, `auth_extensions`, filled at signing)
+and the one mutable fact, revocation (`state`, `revoked_at`). Backends owning
+the rows may advertise a second optional capability:
+
+```go
+type CertIndex interface {
+    // One record per subject with a stored certificate (latest issuance),
+    // optionally filtered by state ("signed"/"revoked").
+    Statuses(ctx context.Context, stateFilter string) ([]CertRecord, error)
+    SetRevoked(ctx context.Context, serial string, at time.Time) error
+    ClearRevoked(ctx context.Context, serial string) error
+    SetProjection(ctx context.Context, serial string, proj CertProjection) error
+}
+```
+
+`GET /certificate_statuses` probes it (via `StorageService.CertStatuses`,
+mirroring `asInventoryStore`) and collapses from an O(N) *list-certs →
+read-PEM → parse → CRL-check* scan to indexed queries; blob backends keep the
+scan path verbatim. Pending CSRs are not issued certificates and stay on the
+`csr/` list-and-parse path.
+
+Design rules that keep the index honest:
+
+- **The PEM and the signed CRL stay authoritative.** The projection columns
+  are immutable copies of fields fixed at signing (so they cannot drift); the
+  revocation columns are written by the revoke path right after the CRL is
+  re-signed. Every column is rebuildable from the artefacts.
+- **The hash chain covers only the canonical columns.** Chaining the
+  projection would add nothing: each projected field is independently
+  verifiable against a signed artefact.
+- **Blob-imported rows carry no projection** (`fingerprint_sha256` NULL). The
+  CA runs an index repair pass at startup (`rebuildCertIndex`) that backfills
+  projections from the stored PEMs and reconciles `state` against the CRL —
+  this is what makes a `storage migrate` from a blob backend converge. Until
+  repair runs, the statuses handler falls back to the PEM per projection-less
+  record.
+- **Statuses is gated on blob existence.** Historical rows survive cleaning
+  (that is the inventory's job), so the index reports only subjects whose
+  `cert/<subject>` blob still exists, and only their latest issuance —
+  matching what the scan path would have listed.
 
 ## Scope
 

--- a/docs/development/storage-internals.md
+++ b/docs/development/storage-internals.md
@@ -157,10 +157,55 @@ Most logical keys live in a key-value table, `puppet_ca_blobs`:
 
 Migrations are managed by [bun](https://bun.uptrace.dev/)'s migrator. On every
 start the backend runs any pending migrations and records applied versions in
-its own `bun_migrations` table; a `bun_migration_locks` table serialises
-concurrent runners so multiple replicas can start against the same database
-safely. Migrations are defined as Go functions, so one definition emits
-dialect-correct DDL across SQLite, PostgreSQL, and MySQL/MariaDB.
+its own `bun_migrations` table. Migrations are defined as Go functions, so one
+definition emits dialect-correct DDL across SQLite, PostgreSQL, and
+MySQL/MariaDB.
+
+bun does **not** serialise concurrent migration runners on its own. It creates a
+`bun_migration_locks` table and exposes `Migrator.Lock`/`Unlock`, but `Migrate`
+never calls them, and it records a migration as applied *before* running it. Two
+processes starting together — separate replicas, or the signer and frontend of
+one replica — will therefore both see a version as unapplied, both record it,
+and both run its DDL; the loser fails on work the winner already did, and the
+version stays recorded and is never retried. `EnsureReady` closes that hole with
+four measures:
+
+- It holds the backend's own distributed lock (`sql-schema-migrate`) across the
+  whole run, taken before any migration state is read.
+- It passes `WithMarkAppliedOnSuccess`, so a failed migration is retried on the
+  next start rather than remembered as done.
+- Each migration's DDL runs in a transaction where the dialect has transactional
+  DDL (PostgreSQL and SQLite), and every statement is idempotent, so MySQL —
+  which commits implicitly on each DDL statement — recovers by re-running.
+- The run gets its own timeout rather than the per-statement request timeout, so
+  a slow index build cannot be cut off part-way.
+
+SQLite has no distributed lock and falls back to a process-local mutex. Two
+processes sharing one file can still race there; the transactional, idempotent
+migrations mean the loser fails cleanly and succeeds on its next start rather
+than leaving the schema half-changed.
+
+#### Recovering a half-migrated schema
+
+A database migrated by a build without those measures can hold a version in
+`bun_migrations` whose DDL only partly ran — typically visible as a startup
+failure naming a column that does not exist, reported as an inventory integrity
+failure because the integrity check is the first thing to read the table.
+Confirm it by listing the table's columns and the recorded versions:
+
+```sql
+SELECT column_name FROM information_schema.columns
+ WHERE table_name = 'puppet_ca_inventory' ORDER BY ordinal_position;
+SELECT id, name, group_id, migrated_at FROM bun_migrations ORDER BY id;
+```
+
+Two rows for one version, recorded milliseconds apart, are the fingerprint of
+two runners having raced. To recover, stop every replica, delete the duplicate
+rows for the affected version, and start one replica: migrations are idempotent,
+so the run completes the missing DDL and leaves the already-applied statements
+alone. Applying the remaining DDL by hand and leaving the rows in place works
+equally well and is the safer choice on a large table, where the missing
+statement may be a long index build you would rather schedule.
 
 On MySQL/MariaDB, the first-run migration widens the `data` column to `LONGBLOB`
 (MySQL's default `BLOB` caps at 64 KiB, too small for large blobs such as the
@@ -178,6 +223,16 @@ indexed by subject:
 | `serial` | certificate serial (unique) |
 | `subject` | certificate subject (indexed) |
 | `not_before` / `not_after` | validity window, stored as the inventory.txt strings |
+| `fingerprint_sha256` | SHA-256 fingerprint; `NULL` means "no projection, read the PEM" |
+| `dns_alt_names` | subject alternative names, JSON array; `NULL` when empty |
+| `auth_extensions` | Puppet auth extensions, JSON object; `NULL` when empty |
+| `state` | `signed` or `revoked`, projected from the signed CRL (indexed) |
+| `revoked_at` | revocation time; `NULL` unless revoked |
+
+The last five columns make the table double as the certificate index; see
+[the inventory store](inventory-store.md) for what reads them and how a missing
+projection falls back to the stored PEM. `not_after` is indexed alongside
+`state` for consumers that have not landed yet (see the migration's own note).
 
 This turns appends and revocation lookups (`LatestSerialForSubject`) into
 single-row operations instead of scanning the whole inventory. Integrity uses a

--- a/docs/storage-backends.md
+++ b/docs/storage-backends.md
@@ -314,7 +314,7 @@ cadir: /var/lib/puppet-ca                # still needed for per-subject keys
 sql_dsn: "postgres://puppetca:secret@db.example.com:5432/puppetca?sslmode=require"
 
 sql_request_timeout_sec: 10              # per-operation timeout (default 10)
-sql_max_open_conns: 0                    # 0 = database/sql default
+sql_max_open_conns: 0                    # 0 = database/sql default; min 4 when set
 sql_max_idle_conns: 0                    # 0 = database/sql default
 
 # Optional mTLS to PostgreSQL (alternative to sslmode/ssl params in the DSN).
@@ -386,6 +386,16 @@ The SQL backends share one set of config keys and environment variables:
 
 The pool-tuning and TLS settings apply only to the networked SQL dialects;
 SQLite ignores them.
+
+`sql_max_open_conns`, when set to a non-zero value below 4, is raised to 4 and
+the effective value is logged at startup. The distributed locks are
+session-scoped (PostgreSQL advisory locks and MySQL `GET_LOCK` both bind to
+their connection), so each lock held occupies a connection for its lifetime
+while the work under it needs another. A `migrate` run nests three deep — the
+bootstrap lock, the migration lock inside it, and the migration's own
+statements. A smaller pool would not merely be slow, it would deadlock, so the
+floor is not negotiable. Leave the setting at 0 unless you have measured a
+reason to cap it.
 
 ---
 

--- a/docs/storage-backends.md
+++ b/docs/storage-backends.md
@@ -263,6 +263,13 @@ backend creates and upgrades its own tables automatically on startup, so
 multiple replicas can start against the same database safely. `cadir` is still
 required for per-subject keys and ancillary local state.
 
+SQL backends additionally maintain a certificate index: `GET
+/certificate_statuses` (`puppetserver ca list`) is answered from indexed
+columns instead of reading and parsing every stored certificate, which matters
+for large fleets. The index is a rebuildable projection of the stored
+certificates and the CRL — after migrating from another backend it is
+backfilled automatically on the next server start.
+
 ### SQLite backend
 
 Stores the entire CA in one SQLite database file — a convenient, dependency-free

--- a/internal/api/certindex_statuses_test.go
+++ b/internal/api/certindex_statuses_test.go
@@ -1,0 +1,203 @@
+// Copyright (C) 2026 Chris Boot
+// Copyright (C) 2026 Vox Pupuli and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package api_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/voxpupuli/openvox-ca/internal/api"
+	"github.com/voxpupuli/openvox-ca/internal/ca"
+	"github.com/voxpupuli/openvox-ca/internal/storage"
+	"github.com/voxpupuli/openvox-ca/internal/testutil"
+)
+
+// generateCSRWithSANs builds a CSR carrying explicit DNS subject alternative
+// names, which the signing path copies onto the issued certificate and the
+// certificate index projects into dns_alt_names.
+func generateCSRWithSANs(commonName string, dnsNames []string) []byte {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	Expect(err).NotTo(HaveOccurred())
+	template := &x509.CertificateRequest{
+		Subject:            pkix.Name{CommonName: commonName},
+		DNSNames:           dnsNames,
+		SignatureAlgorithm: x509.SHA256WithRSA,
+	}
+	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, template, key)
+	Expect(err).NotTo(HaveOccurred())
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrBytes})
+}
+
+// This suite runs the certificate_statuses endpoint against a SQL backend, so
+// the handler serves from the certificate index instead of walking the stored
+// PEMs. The assertions derive every expected value from the stored PEM — the
+// authoritative artefact the fallback path would have parsed — pinning the
+// index path to byte-identical output.
+var _ = Describe("Certificate statuses via the certificate index", func() {
+	var (
+		ctx   = context.Background()
+		store *storage.StorageService
+		myCA  *ca.CA
+		mux   http.Handler
+	)
+
+	BeforeEach(func() {
+		dir := GinkgoT().TempDir()
+		backend, err := storage.NewSQLBackend(storage.SQLConfig{
+			Dialect: storage.SQLitePure,
+			DSN:     "file:" + filepath.Join(dir, "ca.db"),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = backend.Close() })
+		store = storage.NewWithBackend(backend, dir)
+		myCA = ca.New(store, ca.AutosignConfig{Mode: "off"}, "puppet.test")
+
+		Expect(store.EnsureDirs(ctx)).To(Succeed())
+		Expect(store.SaveCAKey(ctx, cachedKeyPEM)).To(Succeed())
+		Expect(store.SaveCACert(ctx, cachedCrtPEM)).To(Succeed())
+		Expect(store.UpdateCRL(ctx, cachedCrlPEM)).To(Succeed())
+		Expect(store.WriteSerial(ctx, "0001")).To(Succeed())
+		Expect(store.TouchInventory(ctx)).To(Succeed())
+		Expect(myCA.Init(ctx)).To(Succeed())
+
+		mux = api.New(myCA).Routes()
+	})
+
+	submitAndSign := func(subject string, csrPEM []byte) {
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, httptest.NewRequest("PUT", "/certificate_request/"+subject, bytes.NewReader(csrPEM)))
+		Expect(rr.Code).To(Equal(http.StatusOK), "PUT certificate_request/"+subject)
+		body, err := json.Marshal(api.PutStatusBody{DesiredState: "signed"})
+		Expect(err).NotTo(HaveOccurred())
+		rr = httptest.NewRecorder()
+		mux.ServeHTTP(rr, httptest.NewRequest("PUT", "/certificate_status/"+subject, bytes.NewReader(body)))
+		Expect(rr.Code).To(Equal(http.StatusNoContent), "PUT certificate_status/"+subject)
+	}
+
+	getStatuses := func(query string) []api.CertStatusResponse {
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, httptest.NewRequest("GET", "/certificate_statuses/any"+query, nil))
+		Expect(rr.Code).To(Equal(http.StatusOK), "GET certificate_statuses"+query)
+		var statuses []api.CertStatusResponse
+		Expect(json.Unmarshal(rr.Body.Bytes(), &statuses)).To(Succeed())
+		return statuses
+	}
+
+	It("serves indexed statuses identical to what the stored PEM would produce", func() {
+		sans := []string{"idx-node.example.com", "idx-node.alt.example.com"}
+		submitAndSign("idx-node", generateCSRWithSANs("idx-node", sans))
+
+		statuses := getStatuses("")
+		Expect(statuses).To(HaveLen(1))
+		got := statuses[0]
+
+		// Derive the expected response from the authoritative PEM, exactly as
+		// the non-indexed fallback path would.
+		certPEM, err := store.GetCert(ctx, "idx-node")
+		Expect(err).NotTo(HaveOccurred())
+		block, _ := pem.Decode(certPEM)
+		Expect(block).NotTo(BeNil())
+		cert, err := x509.ParseCertificate(block.Bytes)
+		Expect(err).NotTo(HaveOccurred())
+		wantFP := ca.SHA256ColonFingerprint(block.Bytes)
+
+		Expect(got.Name).To(Equal("idx-node"))
+		Expect(got.State).To(Equal("signed"))
+		Expect(got.Fingerprint).To(Equal(wantFP))
+		Expect(got.Fingerprints).To(Equal(map[string]string{"SHA256": wantFP, "default": wantFP}))
+		Expect(got.DNSAltNames).To(Equal(sans))
+		Expect(got.SubjectAltNames).To(Equal(sans))
+		Expect(got.AuthorizationExtensions).To(BeEmpty())
+		Expect(got.AuthorizationExtensions).NotTo(BeNil())
+		Expect(got.SerialNumber).NotTo(BeNil())
+		Expect(*got.SerialNumber).To(Equal(cert.SerialNumber.Text(10)))
+		Expect(got.NotBefore).NotTo(BeNil())
+		Expect(*got.NotBefore).To(Equal(cert.NotBefore.UTC().Format(time.RFC3339)))
+		Expect(got.NotAfter).NotTo(BeNil())
+		Expect(*got.NotAfter).To(Equal(cert.NotAfter.UTC().Format(time.RFC3339)))
+	})
+
+	It("partitions signed, revoked, and requested across the state filters", func() {
+		submitAndSign("idx-signed", generateCSRWithSANs("idx-signed", []string{"idx-signed"}))
+		submitAndSign("idx-revoked", generateCSRWithSANs("idx-revoked", []string{"idx-revoked"}))
+
+		body, err := json.Marshal(api.PutStatusBody{DesiredState: "revoked"})
+		Expect(err).NotTo(HaveOccurred())
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, httptest.NewRequest("PUT", "/certificate_status/idx-revoked", bytes.NewReader(body)))
+		Expect(rr.Code).To(Equal(http.StatusNoContent), "PUT certificate_status (revoke)")
+
+		csrPEM, err := testutil.GenerateCSR("idx-pending")
+		Expect(err).NotTo(HaveOccurred())
+		rr = httptest.NewRecorder()
+		mux.ServeHTTP(rr, httptest.NewRequest("PUT", "/certificate_request/idx-pending", bytes.NewReader(csrPEM)))
+		Expect(rr.Code).To(Equal(http.StatusOK))
+
+		all := getStatuses("")
+		Expect(all).To(HaveLen(3))
+		states := map[string]string{}
+		for _, s := range all {
+			states[s.Name] = s.State
+		}
+		Expect(states).To(Equal(map[string]string{
+			"idx-signed":  "signed",
+			"idx-revoked": "revoked",
+			"idx-pending": "requested",
+		}))
+
+		signed := getStatuses("?state=signed")
+		Expect(signed).To(HaveLen(1))
+		Expect(signed[0].Name).To(Equal("idx-signed"))
+
+		revoked := getStatuses("?state=revoked")
+		Expect(revoked).To(HaveLen(1))
+		Expect(revoked[0].Name).To(Equal("idx-revoked"))
+		Expect(revoked[0].State).To(Equal("revoked"))
+
+		requested := getStatuses("?state=requested")
+		Expect(requested).To(HaveLen(1))
+		Expect(requested[0].Name).To(Equal("idx-pending"))
+	})
+
+	It("serialises an empty index as [] and projects a promoted CN SAN", func() {
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, httptest.NewRequest("GET", "/certificate_statuses/any", nil))
+		Expect(rr.Code).To(Equal(http.StatusOK))
+		Expect(rr.Body.String()).To(MatchJSON("[]"))
+
+		// A SAN-less CSR gets its CN promoted to a DNS SAN at signing
+		// (PromoteCNToSAN); the index must reflect the certificate as issued,
+		// not the CSR as submitted.
+		submitAndSign("idx-plain", generateCSRWithSANs("idx-plain", nil))
+		statuses := getStatuses("")
+		Expect(statuses).To(HaveLen(1))
+		Expect(statuses[0].DNSAltNames).To(Equal([]string{"idx-plain"}))
+	})
+})

--- a/internal/api/certindex_statuses_test.go
+++ b/internal/api/certindex_statuses_test.go
@@ -186,6 +186,76 @@ var _ = Describe("Certificate statuses via the certificate index", func() {
 		Expect(requested[0].Name).To(Equal("idx-pending"))
 	})
 
+	It("falls back to the stored PEM for a projection-less record, keeping the record's state", func() {
+		submitAndSign("idx-legacy", generateCSRWithSANs("idx-legacy", []string{"idx-legacy"}))
+
+		// Append a projection-less inventory row for the same subject, as a
+		// legacy blob import (or the crash window between blob and inventory
+		// writes) would leave behind. Being the subject's latest issuance it
+		// is the row the index serves, its serial does not match the stored
+		// PEM, and no repair pass runs between here and the request.
+		Expect(store.AppendInventory(ctx,
+			"0FFF 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /idx-legacy")).To(Succeed())
+
+		statuses := getStatuses("")
+		Expect(statuses).To(HaveLen(1))
+		got := statuses[0]
+
+		// Every display field must come from the authoritative PEM, not the
+		// bogus row: same derivation as the non-indexed path.
+		certPEM, err := store.GetCert(ctx, "idx-legacy")
+		Expect(err).NotTo(HaveOccurred())
+		block, _ := pem.Decode(certPEM)
+		Expect(block).NotTo(BeNil())
+		cert, err := x509.ParseCertificate(block.Bytes)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(got.Name).To(Equal("idx-legacy"))
+		Expect(got.State).To(Equal("signed"))
+		Expect(got.Fingerprint).To(Equal(ca.SHA256ColonFingerprint(block.Bytes)))
+		Expect(got.SerialNumber).NotTo(BeNil())
+		Expect(*got.SerialNumber).To(Equal(cert.SerialNumber.Text(10)),
+			"the serial must be the PEM's, not the projection-less row's")
+		Expect(got.DNSAltNames).To(Equal([]string{"idx-legacy"}))
+	})
+
+	It("suppresses a pending re-submission for an already-certified subject", func() {
+		submitAndSign("idx-dual", generateCSRWithSANs("idx-dual", []string{"idx-dual"}))
+
+		// SaveRequest refuses a CSR while a live certificate exists, so plant
+		// the pending CSR directly in storage — the state a clean-then-crash
+		// or an out-of-band write can produce, and exactly what the handler's
+		// seen-map dedup exists for.
+		csrPEM, err := testutil.GenerateCSR("idx-dual")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(store.SaveCSR(ctx, "idx-dual", csrPEM)).To(Succeed())
+
+		// A genuinely pending subject as the positive control.
+		csrPEM, err = testutil.GenerateCSR("idx-pending")
+		Expect(err).NotTo(HaveOccurred())
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, httptest.NewRequest("PUT", "/certificate_request/idx-pending", bytes.NewReader(csrPEM)))
+		Expect(rr.Code).To(Equal(http.StatusOK))
+
+		// Unfiltered: the certificate wins; idx-dual appears exactly once.
+		all := getStatuses("")
+		states := map[string]string{}
+		for _, s := range all {
+			states[s.Name] = s.State
+		}
+		Expect(all).To(HaveLen(2))
+		Expect(states).To(Equal(map[string]string{
+			"idx-dual":    "signed",
+			"idx-pending": "requested",
+		}))
+
+		// Under the requested filter the certified subject must stay
+		// suppressed even though no certificate rows are emitted.
+		requested := getStatuses("?state=requested")
+		Expect(requested).To(HaveLen(1))
+		Expect(requested[0].Name).To(Equal("idx-pending"))
+	})
+
 	It("serialises an empty index as [] and projects a promoted CN SAN", func() {
 		rr := httptest.NewRecorder()
 		mux.ServeHTTP(rr, httptest.NewRequest("GET", "/certificate_statuses/any", nil))

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -20,22 +20,21 @@ package api
 
 import (
 	"context"
-	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/asn1"
-	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"math/big"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/voxpupuli/openvox-ca/internal/ca"
+	"github.com/voxpupuli/openvox-ca/internal/storage"
 )
 
 // maxJSONBody caps the size of JSON request bodies accepted by the POST/PUT
@@ -623,39 +622,22 @@ func parseCSR(pemData []byte) (*x509.CertificateRequest, error) {
 
 // authExtensions extracts Puppet authorization extensions (OID arc 1.3.6.1.4.1.34380.1.3)
 // from a certificate or CSR extension list and returns them as a name→value map.
-// The key is the Puppet short name when known (e.g. "pp_auth_role"), otherwise
-// the raw dotted OID string. The value is the decoded UTF-8 string.
-// Always returns a non-nil map (empty when no auth extensions are present).
+// See ca.AuthExtensionMap, which is shared with the certificate index
+// projection so the two can never disagree on the display form.
 func authExtensions(exts []pkix.Extension) map[string]string {
-	result := make(map[string]string)
-	for _, ext := range exts {
-		if !ca.IsAuthOID(ext.Id) {
-			continue
-		}
-		key := ca.OIDKey(ext.Id)
-		var s string
-		if _, err := asn1.Unmarshal(ext.Value, &s); err == nil {
-			result[key] = s
-		} else {
-			result[key] = hex.EncodeToString(ext.Value)
-		}
-	}
-	return result
+	return ca.AuthExtensionMap(exts)
 }
 
+// fingerprint renders the SHA-256 fingerprint of a PEM-encoded certificate or
+// CSR as Puppet's colon-separated hex pairs, or "" when data is not PEM. The
+// digest formatting is shared with the certificate index projection (see
+// ca.SHA256ColonFingerprint).
 func fingerprint(data []byte) string {
 	block, _ := pem.Decode(data)
 	if block == nil {
 		return ""
 	}
-	sum := sha256.Sum256(block.Bytes)
-	// Puppet formats fingerprints as colon-separated hex pairs.
-	raw := hex.EncodeToString(sum[:])
-	var parts []string
-	for i := 0; i < len(raw); i += 2 {
-		parts = append(parts, raw[i:i+2])
-	}
-	return strings.Join(parts, ":")
+	return ca.SHA256ColonFingerprint(block.Bytes)
 }
 
 // noNilSlice returns s unchanged when non-nil, or an empty non-nil slice.
@@ -708,6 +690,50 @@ func certStatusFromCert(subject string, certPEM []byte, state string, timeFmt st
 		NotBefore:               &nb,
 		NotAfter:                &na,
 	}
+}
+
+// certStatusFromRecord builds a CertStatusResponse from a certificate-index
+// record without touching the stored PEM. ok=false means the record cannot
+// stand alone — its display projection was never populated (legacy inventory
+// import) or a canonical field does not parse — and the caller should fall
+// back to the PEM path for that subject.
+func certStatusFromRecord(rec storage.CertRecord, timeFmt string) (CertStatusResponse, bool) {
+	if rec.Fingerprint == "" {
+		return CertStatusResponse{}, false
+	}
+	serialInt := new(big.Int)
+	if _, ok := serialInt.SetString(rec.Serial, 16); !ok {
+		return CertStatusResponse{}, false
+	}
+	nb, err := time.Parse(storage.InventoryTimeFormat, rec.NotBefore)
+	if err != nil {
+		return CertStatusResponse{}, false
+	}
+	na, err := time.Parse(storage.InventoryTimeFormat, rec.NotAfter)
+	if err != nil {
+		return CertStatusResponse{}, false
+	}
+
+	serial := serialInt.Text(10) // decimal string; preserves full 128-bit value
+	nbs := nb.UTC().Format(timeFmt)
+	nas := na.UTC().Format(timeFmt)
+	dnsNames := noNilSlice(rec.DNSAltNames)
+	authExts := rec.AuthExtensions
+	if authExts == nil {
+		authExts = map[string]string{}
+	}
+	return CertStatusResponse{
+		Name:                    rec.Subject,
+		State:                   rec.State,
+		Fingerprint:             rec.Fingerprint,
+		Fingerprints:            map[string]string{"SHA256": rec.Fingerprint, "default": rec.Fingerprint},
+		DNSAltNames:             dnsNames,
+		SubjectAltNames:         dnsNames,
+		AuthorizationExtensions: authExts,
+		SerialNumber:            &serial,
+		NotBefore:               &nbs,
+		NotAfter:                &nas,
+	}, true
 }
 
 // certStatusFromCSR builds a CertStatusResponse for a pending (requested) CSR.
@@ -771,36 +797,73 @@ func (s *Server) handleGetStatuses(w http.ResponseWriter, r *http.Request) {
 
 	stateFilter := r.URL.Query().Get("state") // "requested", "signed", "revoked", or ""
 
-	certs, err := s.CA.Storage.ListCerts(r.Context())
+	statuses := []CertStatusResponse{}
+	seen := make(map[string]bool)
+
+	// Signed/revoked certificates. Backends with a certificate index answer
+	// this from indexed columns — one query instead of a read-PEM-parse-and-
+	// CRL-check per subject; all others walk the stored PEMs. Either way,
+	// every subject holding a certificate lands in seen, so that under a
+	// "requested" filter a pending re-submission for an already-certified
+	// subject is not listed (the certificate wins until it is cleaned).
+	//
+	// The index is queried unfiltered: the state filter is applied against
+	// each record below, which both keeps seen complete and pins filter
+	// semantics to the same value the response would show.
+	records, indexed, err := s.CA.Storage.CertStatuses(r.Context(), "")
 	if err != nil {
-		slog.Error("list certs failed", "error", err)
+		slog.Error("certificate index statuses failed", "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
+	if indexed {
+		for _, rec := range records {
+			seen[rec.Subject] = true
+			if stateFilter != "" && rec.State != stateFilter {
+				continue
+			}
+			resp, ok := certStatusFromRecord(rec, s.timeFormat())
+			if !ok {
+				// Projection not (yet) populated for this record — fall back
+				// to the stored PEM for this one subject, keeping the record's
+				// state so the response matches the filter just applied.
+				certPEM, err := s.CA.Storage.GetCert(r.Context(), rec.Subject)
+				if err != nil {
+					continue
+				}
+				resp = certStatusFromCert(rec.Subject, certPEM, rec.State, s.timeFormat())
+			}
+			statuses = append(statuses, resp)
+		}
+	} else {
+		certs, err := s.CA.Storage.ListCerts(r.Context())
+		if err != nil {
+			slog.Error("list certs failed", "error", err)
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+			return
+		}
+		for _, subject := range certs {
+			seen[subject] = true
+			certPEM, err := s.CA.Storage.GetCert(r.Context(), subject)
+			if err != nil {
+				continue
+			}
+			state := "signed"
+			if s.CA.IsRevoked(r.Context(), subject) {
+				state = "revoked"
+			}
+			if stateFilter != "" && state != stateFilter {
+				continue
+			}
+			statuses = append(statuses, certStatusFromCert(subject, certPEM, state, s.timeFormat()))
+		}
+	}
+
 	csrs, err := s.CA.Storage.ListCSRs(r.Context())
 	if err != nil {
 		slog.Error("list CSRs failed", "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
-	}
-
-	statuses := make([]CertStatusResponse, 0, len(certs)+len(csrs))
-
-	seen := make(map[string]bool)
-	for _, subject := range certs {
-		seen[subject] = true
-		certPEM, err := s.CA.Storage.GetCert(r.Context(), subject)
-		if err != nil {
-			continue
-		}
-		state := "signed"
-		if s.CA.IsRevoked(r.Context(), subject) {
-			state = "revoked"
-		}
-		if stateFilter != "" && state != stateFilter {
-			continue
-		}
-		statuses = append(statuses, certStatusFromCert(subject, certPEM, state, s.timeFormat()))
 	}
 	for _, subject := range csrs {
 		if seen[subject] {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -829,6 +829,8 @@ func (s *Server) handleGetStatuses(w http.ResponseWriter, r *http.Request) {
 				// state so the response matches the filter just applied.
 				certPEM, err := s.CA.Storage.GetCert(r.Context(), rec.Subject)
 				if err != nil {
+					slog.Warn("statuses: reading stored certificate failed, omitting subject",
+						"subject", rec.Subject, "error", err)
 					continue
 				}
 				resp = certStatusFromCert(rec.Subject, certPEM, rec.State, s.timeFormat())
@@ -846,6 +848,8 @@ func (s *Server) handleGetStatuses(w http.ResponseWriter, r *http.Request) {
 			seen[subject] = true
 			certPEM, err := s.CA.Storage.GetCert(r.Context(), subject)
 			if err != nil {
+				slog.Warn("statuses: reading stored certificate failed, omitting subject",
+					"subject", subject, "error", err)
 				continue
 			}
 			state := "signed"

--- a/internal/ca/certindex.go
+++ b/internal/ca/certindex.go
@@ -95,10 +95,31 @@ func (c *CA) rebuildCertIndex(ctx context.Context) {
 		}
 	}
 
+	// The backfill reads and parses one stored PEM per projection-less record,
+	// so the first start after a blob→SQL migration legitimately takes a while
+	// on a large fleet. Announce the work up front and report progress, so the
+	// operator watching that first start sees a moving backfill rather than an
+	// apparent hang between "Loaded existing CA" and the listener coming up.
+	var missing int
+	for _, rec := range records {
+		if rec.Fingerprint == "" {
+			missing++
+		}
+	}
+	if missing > 0 {
+		slog.Info("Certificate index repair: backfilling projections from stored certificates",
+			"records", missing)
+	}
+
+	const progressEvery = 1000
 	var projected, restated int
 	for _, rec := range records {
 		if rec.Fingerprint == "" && c.backfillCertProjection(ctx, rec) {
 			projected++
+			if projected%progressEvery == 0 {
+				slog.Info("Certificate index repair: backfill progress",
+					"done", projected, "total", missing)
+			}
 		}
 
 		// Serials are stored verbatim as issued; normalise through big.Int for

--- a/internal/ca/certindex.go
+++ b/internal/ca/certindex.go
@@ -1,0 +1,177 @@
+// Copyright (C) 2026 Chris Boot
+// Copyright (C) 2026 Vox Pupuli and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package ca
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"log/slog"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/voxpupuli/openvox-ca/internal/storage"
+)
+
+// SHA256ColonFingerprint renders the SHA-256 digest of der as colon-separated
+// hex pairs, the form Puppet displays certificate fingerprints in. It is the
+// single producer of the fingerprint stored in the certificate index and
+// emitted by the status API, so the two can never disagree on format.
+func SHA256ColonFingerprint(der []byte) string {
+	sum := sha256.Sum256(der)
+	raw := hex.EncodeToString(sum[:])
+	parts := make([]string, 0, len(sum))
+	for i := 0; i < len(raw); i += 2 {
+		parts = append(parts, raw[i:i+2])
+	}
+	return strings.Join(parts, ":")
+}
+
+// certProjectionFor derives the certificate-index display projection from a
+// parsed certificate. Every field is immutable for the certificate's life,
+// which is what makes storing them alongside the inventory row safe: they can
+// never drift from the PEM because neither can change after signing.
+func certProjectionFor(cert *x509.Certificate) storage.CertProjection {
+	return storage.CertProjection{
+		Fingerprint:    SHA256ColonFingerprint(cert.Raw),
+		DNSAltNames:    cert.DNSNames,
+		AuthExtensions: AuthExtensionMap(cert.Extensions),
+	}
+}
+
+// rebuildCertIndex reconciles the certificate index with its authoritative
+// sources: stored certificate PEMs (for the display projection) and the
+// in-memory CRL cache (for revocation state). It is a no-op on backends
+// without the CertIndex capability, cheap when the index is already in sync,
+// and safe to re-run at every startup — the index is a projection, and this
+// is the repair path that makes that claim honest. Rows are touched only when
+// they disagree with the artefacts:
+//
+//   - a record missing its projection (typically imported from a legacy
+//     inventory blob, where rows carry no display fields) is backfilled by
+//     parsing the subject's stored PEM once;
+//   - a record whose revocation state disagrees with the signed CRL is
+//     rewritten to match it.
+//
+// Only records the index can ever serve (the latest issuance per subject with
+// a stored certificate) are reconciled; historical rows are invisible to
+// Statuses, so their staleness is harmless. Failures are logged and skipped
+// rather than propagated: a partially repaired index still degrades
+// gracefully, because readers fall back to the PEM for any record left
+// without a projection. c.mu must be held by the caller (for cachedCRL).
+func (c *CA) rebuildCertIndex(ctx context.Context) {
+	records, ok, err := c.Storage.CertStatuses(ctx, "")
+	if !ok {
+		return
+	}
+	if err != nil {
+		slog.Warn("Certificate index repair: listing index records failed", "error", err)
+		return
+	}
+
+	// Normalised serial → revocation time, from the signed CRL.
+	revoked := make(map[string]time.Time)
+	if c.cachedCRL != nil {
+		for _, entry := range c.cachedCRL.RevokedCertificateEntries {
+			revoked[serialHexStr(entry.SerialNumber)] = entry.RevocationTime
+		}
+	}
+
+	var projected, restated int
+	for _, rec := range records {
+		if rec.Fingerprint == "" && c.backfillCertProjection(ctx, rec) {
+			projected++
+		}
+
+		// Serials are stored verbatim as issued; normalise through big.Int for
+		// the CRL comparison so legacy zero-padded forms still match, but keep
+		// the verbatim form for the row update.
+		n := new(big.Int)
+		if _, ok := n.SetString(rec.Serial, 16); !ok {
+			slog.Warn("Certificate index repair: malformed serial in index record",
+				"subject", rec.Subject, "serial", rec.Serial)
+			continue
+		}
+		revokedAt, inCRL := revoked[serialHexStr(n)]
+		switch {
+		case inCRL && rec.State != storage.CertStateRevoked:
+			if err := c.Storage.MarkCertRevoked(ctx, rec.Serial, revokedAt); err != nil {
+				slog.Warn("Certificate index repair: marking record revoked failed",
+					"subject", rec.Subject, "serial", rec.Serial, "error", err)
+			} else {
+				restated++
+			}
+		case !inCRL && rec.State == storage.CertStateRevoked:
+			if err := c.Storage.ClearCertRevoked(ctx, rec.Serial); err != nil {
+				slog.Warn("Certificate index repair: clearing stale revocation failed",
+					"subject", rec.Subject, "serial", rec.Serial, "error", err)
+			} else {
+				restated++
+			}
+		}
+	}
+	if projected > 0 || restated > 0 {
+		slog.Info("Certificate index repaired",
+			"projections_backfilled", projected, "states_corrected", restated)
+	}
+}
+
+// backfillCertProjection fills rec's missing display projection from the
+// subject's stored PEM, reporting whether it did. The PEM must carry rec's
+// serial: a mismatch means the row does not describe the stored certificate
+// (e.g. a crash window between blob and inventory writes) and is left alone
+// rather than stamped with another certificate's fields.
+func (c *CA) backfillCertProjection(ctx context.Context, rec storage.CertRecord) bool {
+	certPEM, err := c.Storage.GetCert(ctx, rec.Subject)
+	if err != nil {
+		slog.Warn("Certificate index repair: reading stored certificate failed",
+			"subject", rec.Subject, "error", err)
+		return false
+	}
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		slog.Warn("Certificate index repair: stored certificate is not PEM", "subject", rec.Subject)
+		return false
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		slog.Warn("Certificate index repair: parsing stored certificate failed",
+			"subject", rec.Subject, "error", err)
+		return false
+	}
+
+	recSerial := new(big.Int)
+	if _, ok := recSerial.SetString(rec.Serial, 16); !ok {
+		return false
+	}
+	if recSerial.Cmp(cert.SerialNumber) != 0 {
+		slog.Warn("Certificate index repair: stored certificate serial does not match index record, leaving projection empty",
+			"subject", rec.Subject, "index_serial", rec.Serial, "cert_serial", serialHexStr(cert.SerialNumber))
+		return false
+	}
+
+	if err := c.Storage.SetCertProjection(ctx, rec.Serial, certProjectionFor(cert)); err != nil {
+		slog.Warn("Certificate index repair: writing projection failed",
+			"subject", rec.Subject, "serial", rec.Serial, "error", err)
+		return false
+	}
+	return true
+}

--- a/internal/ca/certindex_test.go
+++ b/internal/ca/certindex_test.go
@@ -1,0 +1,169 @@
+// Copyright (C) 2026 Chris Boot
+// Copyright (C) 2026 Vox Pupuli and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package ca_test
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/voxpupuli/openvox-ca/internal/ca"
+	"github.com/voxpupuli/openvox-ca/internal/storage"
+	"github.com/voxpupuli/openvox-ca/internal/testutil"
+)
+
+var _ = Describe("CA certificate index", func() {
+	var (
+		ctx   = context.Background()
+		myCA  *ca.CA
+		store *storage.StorageService
+	)
+
+	// newCA builds and initialises a CA over the given storage service,
+	// pre-seeded with the cached test CA material.
+	newCA := func(s *storage.StorageService) *ca.CA {
+		c := ca.New(s, ca.AutosignConfig{Mode: "off"}, "puppet.test")
+		Expect(s.EnsureDirs(ctx)).To(Succeed())
+		Expect(s.SaveCAKey(ctx, cachedKeyPEM)).To(Succeed())
+		Expect(s.SaveCACert(ctx, cachedCrtPEM)).To(Succeed())
+		Expect(s.UpdateCRL(ctx, cachedCrlPEM)).To(Succeed())
+		Expect(s.WriteSerial(ctx, "0001")).To(Succeed())
+		Expect(s.TouchInventory(ctx)).To(Succeed())
+		Expect(c.Init(ctx)).To(Succeed())
+		return c
+	}
+
+	signLive := func(c *ca.CA, subject string) {
+		csrPEM, err := testutil.GenerateCSR(subject)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = c.SaveRequest(ctx, subject, csrPEM)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = c.Sign(ctx, subject)
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	// storedFingerprint computes the display fingerprint of the certificate
+	// currently stored for subject, from the authoritative PEM.
+	storedFingerprint := func(s *storage.StorageService, subject string) string {
+		certPEM, err := s.GetCert(ctx, subject)
+		Expect(err).NotTo(HaveOccurred())
+		block, _ := pem.Decode(certPEM)
+		Expect(block).NotTo(BeNil())
+		return ca.SHA256ColonFingerprint(block.Bytes)
+	}
+
+	newSQLiteService := func() *storage.StorageService {
+		dir := GinkgoT().TempDir()
+		b, err := storage.NewSQLBackend(storage.SQLConfig{
+			Dialect: storage.SQLitePure,
+			DSN:     "file:" + filepath.Join(dir, "ca.db"),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = b.Close() })
+		Expect(b.EnsureReady(ctx)).To(Succeed())
+		return storage.NewWithBackend(b, dir)
+	}
+
+	Context("on a SQL backend", func() {
+		BeforeEach(func() {
+			store = newSQLiteService()
+			myCA = newCA(store)
+		})
+
+		It("records the projection at signing and the revocation at revoke time", func() {
+			signLive(myCA, "node1")
+			signLive(myCA, "node2")
+			Expect(myCA.Revoke(ctx, "node2")).To(Succeed())
+
+			recs, ok, err := store.CertStatuses(ctx, "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+			Expect(recs).To(HaveLen(2))
+
+			bySubject := map[string]storage.CertRecord{}
+			for _, r := range recs {
+				bySubject[r.Subject] = r
+			}
+			Expect(bySubject["node1"].State).To(Equal(storage.CertStateSigned))
+			Expect(bySubject["node1"].RevokedAt).To(BeNil())
+			Expect(bySubject["node1"].Fingerprint).To(Equal(storedFingerprint(store, "node1")),
+				"the projected fingerprint must match the stored PEM")
+			Expect(bySubject["node2"].State).To(Equal(storage.CertStateRevoked),
+				"Revoke must project into the index without a restart")
+			Expect(bySubject["node2"].RevokedAt).NotTo(BeNil())
+		})
+	})
+
+	Context("after migrating a blob-backed CA into a SQL backend", func() {
+		It("backfills projections and revocation state from the PEMs and CRL at startup", func() {
+			// Build a filesystem CA with one live and one revoked certificate.
+			fsDir := GinkgoT().TempDir()
+			fsStore := storage.New(fsDir)
+			fsCA := newCA(fsStore)
+			signLive(fsCA, "node1")
+			signLive(fsCA, "node2")
+			Expect(fsCA.Revoke(ctx, "node2")).To(Succeed())
+
+			// Migrate it into a fresh SQLite backend. The inventory arrives as
+			// parsed rows with no projection and no revocation state.
+			sqlStore := newSQLiteService()
+			_, err := storage.MigrateService(ctx, fsStore, sqlStore, storage.MigrateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			recs, ok, err := sqlStore.CertStatuses(ctx, "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+			Expect(recs).To(HaveLen(2))
+			for _, r := range recs {
+				Expect(r.Fingerprint).To(BeEmpty(), "migrated rows start projection-less")
+				Expect(r.State).To(Equal(storage.CertStateSigned))
+			}
+
+			// Initialising a CA over the migrated backend runs the index
+			// repair pass, which reconciles the rows from the authoritative
+			// artefacts: the stored PEMs and the signed CRL.
+			sqlCA := ca.New(sqlStore, ca.AutosignConfig{Mode: "off"}, "puppet.test")
+			Expect(sqlCA.Init(ctx)).To(Succeed())
+
+			recs, _, err = sqlStore.CertStatuses(ctx, "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(recs).To(HaveLen(2))
+			bySubject := map[string]storage.CertRecord{}
+			for _, r := range recs {
+				bySubject[r.Subject] = r
+			}
+			Expect(bySubject["node1"].Fingerprint).To(Equal(storedFingerprint(sqlStore, "node1")))
+			Expect(bySubject["node1"].State).To(Equal(storage.CertStateSigned))
+			Expect(bySubject["node2"].Fingerprint).To(Equal(storedFingerprint(sqlStore, "node2")))
+			Expect(bySubject["node2"].State).To(Equal(storage.CertStateRevoked))
+			Expect(bySubject["node2"].RevokedAt).NotTo(BeNil())
+
+			// The repaired states must agree with the CRL, entry for entry.
+			crlPEM, err := sqlStore.GetCRL(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			block, _ := pem.Decode(crlPEM)
+			Expect(block).NotTo(BeNil())
+			crl, err := x509.ParseRevocationList(block.Bytes)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(crl.RevokedCertificateEntries).To(HaveLen(1))
+		})
+	})
+})

--- a/internal/ca/certindex_test.go
+++ b/internal/ca/certindex_test.go
@@ -19,9 +19,15 @@ package ca_test
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
 	"encoding/pem"
+	"math/big"
 	"path/filepath"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -29,6 +35,41 @@ import (
 	"github.com/voxpupuli/openvox-ca/internal/storage"
 	"github.com/voxpupuli/openvox-ca/internal/testutil"
 )
+
+// signLeafWithAuthRole builds a leaf certificate for subject signed directly
+// by the cached test CA, carrying a pp_auth_role authorization extension —
+// something the normal signing path can never produce, since it strips
+// auth-arc OIDs from CSRs. Returns the certificate PEM, ready for
+// ImportCertificate.
+func signLeafWithAuthRole(subject, role string) []byte {
+	keyBlock, _ := pem.Decode(cachedKeyPEM)
+	Expect(keyBlock).NotTo(BeNil())
+	caKey, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+	Expect(err).NotTo(HaveOccurred())
+	certBlock, _ := pem.Decode(cachedCrtPEM)
+	Expect(certBlock).NotTo(BeNil())
+	caCert, err := x509.ParseCertificate(certBlock.Bytes)
+	Expect(err).NotTo(HaveOccurred())
+
+	leafKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	Expect(err).NotTo(HaveOccurred())
+	roleValue, err := asn1.MarshalWithParams(role, "utf8")
+	Expect(err).NotTo(HaveOccurred())
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(0x1D01),
+		Subject:      pkix.Name{CommonName: subject},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		ExtraExtensions: []pkix.Extension{{
+			Id:    asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 34380, 1, 3, 13}, // pp_auth_role
+			Value: roleValue,
+		}},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, caCert, &leafKey.PublicKey, caKey)
+	Expect(err).NotTo(HaveOccurred())
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
 
 var _ = Describe("CA certificate index", func() {
 	var (
@@ -86,6 +127,48 @@ var _ = Describe("CA certificate index", func() {
 		BeforeEach(func() {
 			store = newSQLiteService()
 			myCA = newCA(store)
+		})
+
+		It("clears a revocation the CRL no longer corroborates when repair runs", func() {
+			signLive(myCA, "node1")
+			Expect(myCA.Revoke(ctx, "node1")).To(Succeed())
+
+			recs, _, err := store.CertStatuses(ctx, "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(recs).To(HaveLen(1))
+			Expect(recs[0].State).To(Equal(storage.CertStateRevoked))
+
+			// Restore the pristine (empty) CRL over the one Revoke signed —
+			// the CRL-from-backup scenario. The index row still claims a
+			// revocation the signed CRL no longer corroborates; the repair
+			// pass at the next startup must clear it.
+			Expect(store.UpdateCRL(ctx, cachedCrlPEM)).To(Succeed())
+			restarted := ca.New(store, ca.AutosignConfig{Mode: "off"}, "puppet.test")
+			Expect(restarted.Init(ctx)).To(Succeed())
+
+			recs, _, err = store.CertStatuses(ctx, "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(recs).To(HaveLen(1))
+			Expect(recs[0].State).To(Equal(storage.CertStateSigned))
+			Expect(recs[0].RevokedAt).To(BeNil())
+		})
+
+		It("projects auth extensions from an imported certificate through the index", func() {
+			// Signing strips auth-arc OIDs from CSRs (privilege escalation
+			// guard), so the only way a stored certificate legitimately
+			// carries one is the import path — build a leaf signed directly
+			// by the test CA with pp_auth_role and import it.
+			certPEM := signLeafWithAuthRole("import-node", "webserver")
+			res, err := myCA.ImportCertificate(ctx, "import-node", certPEM)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Imported).To(BeTrue())
+
+			recs, _, err := store.CertStatuses(ctx, "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(recs).To(HaveLen(1))
+			Expect(recs[0].AuthExtensions).To(Equal(map[string]string{"pp_auth_role": "webserver"}),
+				"the auth extension must survive sign→projection→JSON column→record")
+			Expect(recs[0].Fingerprint).To(Equal(storedFingerprint(store, "import-node")))
 		})
 
 		It("records the projection at signing and the revocation at revoke time", func() {
@@ -156,7 +239,8 @@ var _ = Describe("CA certificate index", func() {
 			Expect(bySubject["node2"].State).To(Equal(storage.CertStateRevoked))
 			Expect(bySubject["node2"].RevokedAt).NotTo(BeNil())
 
-			// The repaired states must agree with the CRL, entry for entry.
+			// The repaired states must agree with the CRL, entry for entry:
+			// the single CRL entry carries node2's serial.
 			crlPEM, err := sqlStore.GetCRL(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			block, _ := pem.Decode(crlPEM)
@@ -164,6 +248,11 @@ var _ = Describe("CA certificate index", func() {
 			crl, err := x509.ParseRevocationList(block.Bytes)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crl.RevokedCertificateEntries).To(HaveLen(1))
+			node2Serial := new(big.Int)
+			_, ok = node2Serial.SetString(bySubject["node2"].Serial, 16)
+			Expect(ok).To(BeTrue(), "index serial must be hex")
+			Expect(crl.RevokedCertificateEntries[0].SerialNumber.Cmp(node2Serial)).To(BeZero(),
+				"the revoked index record's serial must be the CRL entry's serial")
 		})
 	})
 })

--- a/internal/ca/importcert.go
+++ b/internal/ca/importcert.go
@@ -199,8 +199,9 @@ func (c *CA) importCertificateLocked(ctx context.Context, subject, serialStr str
 		return nil, fmt.Errorf("failed to save imported cert for %s: %w", subject, err)
 	}
 
+	proj := certProjectionFor(cert)
 	inventoryEntry := storage.FormatInventoryLine(serialStr, cert.NotBefore, cert.NotAfter, subject)
-	if err := c.Storage.AppendInventory(ctx, inventoryEntry); err != nil {
+	if err := c.Storage.AppendInventoryRecord(ctx, inventoryEntry, &proj); err != nil {
 		// Roll back the cert so storage and inventory stay in sync, same as
 		// signWithDuration's rollback-on-failure.
 		if delErr := c.Storage.DeleteCert(ctx, subject); delErr != nil {

--- a/internal/ca/init.go
+++ b/internal/ca/init.go
@@ -142,6 +142,7 @@ func (c *CA) finishLoadExisting(ctx context.Context) error {
 	}
 	err := c.loadCRLCache(ctx)
 	if err == nil {
+		c.rebuildCertIndex(ctx)
 		return nil
 	}
 	if !errors.Is(err, fs.ErrNotExist) {
@@ -155,7 +156,13 @@ func (c *CA) finishLoadExisting(ctx context.Context) error {
 	if err := c.seedSupportingState(ctx); err != nil {
 		return fmt.Errorf("seeding CA supporting state: %w", err)
 	}
-	return c.loadCRLCache(ctx)
+	if err := c.loadCRLCache(ctx); err != nil {
+		return err
+	}
+	// A freshly seeded CA has an empty index; running the repair pass anyway
+	// keeps this path identical to the loaded-CRL one (it is a no-op then).
+	c.rebuildCertIndex(ctx)
+	return nil
 }
 
 // seedSupportingState writes the CRL, inventory, and serial counter that

--- a/internal/ca/oids.go
+++ b/internal/ca/oids.go
@@ -17,7 +17,11 @@
 
 package ca
 
-import "encoding/asn1"
+import (
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/hex"
+)
 
 var (
 	// OIDAIA is the Authority Information Access extension (RFC 5280 §4.2.2.1).
@@ -119,4 +123,28 @@ func OIDKey(oid asn1.ObjectIdentifier) string {
 		return short
 	}
 	return s
+}
+
+// AuthExtensionMap extracts Puppet authorization extensions (the
+// PuppetAuthOIDArc) from a certificate or CSR extension list as a name→value
+// map. Keys are Puppet short names when known (e.g. "pp_auth_role"), raw
+// dotted OID strings otherwise; values are the decoded UTF-8 strings, or the
+// hex-encoded raw bytes when the value is not an ASN.1 string. Always returns
+// a non-nil map. This is the single producer of the auth-extension display
+// form, shared by the status API and the certificate index projection.
+func AuthExtensionMap(exts []pkix.Extension) map[string]string {
+	result := make(map[string]string)
+	for _, ext := range exts {
+		if !IsAuthOID(ext.Id) {
+			continue
+		}
+		key := OIDKey(ext.Id)
+		var s string
+		if _, err := asn1.Unmarshal(ext.Value, &s); err == nil {
+			result[key] = s
+		} else {
+			result[key] = hex.EncodeToString(ext.Value)
+		}
+	}
+	return result
 }

--- a/internal/ca/revoke.go
+++ b/internal/ca/revoke.go
@@ -91,6 +91,10 @@ func (c *CA) revokeSerialLocked(ctx context.Context, serialStr string) error {
 	for _, entry := range crl.RevokedCertificateEntries {
 		if entry.SerialNumber.Cmp(serialInt) == 0 {
 			slog.Debug("Certificate already revoked", "serial", serialStr)
+			// Still project the state into the certificate index: a retried
+			// revocation may be exactly the case where the CRL write landed
+			// but the index update did not.
+			c.markCertRevokedIndex(ctx, serialStr, entry.RevocationTime)
 			return nil
 		}
 	}
@@ -110,12 +114,27 @@ func (c *CA) revokeSerialLocked(ctx context.Context, serialStr string) error {
 		return err
 	}
 
+	// Project the revocation into the certificate index. The signed CRL just
+	// written is the source of truth; the index column is a display cache of
+	// it, so a failure here is logged, not propagated — the revocation has
+	// already happened, and the startup index repair reconverges the column.
+	c.markCertRevokedIndex(ctx, serialStr, newRevoked.RevocationTime)
+
 	// Invalidate the cached OCSP response for this serial so the next query
 	// returns the correct Revoked status instead of a stale Good response.
 	// Use the same normalised key as the OCSP index (uppercase hex, no padding).
 	delete(c.ocspCache, serialHexStr(serialInt))
 
 	return nil
+}
+
+// markCertRevokedIndex is the log-and-continue wrapper around
+// StorageService.MarkCertRevoked used by the revocation paths.
+func (c *CA) markCertRevokedIndex(ctx context.Context, serialStr string, at time.Time) {
+	if err := c.Storage.MarkCertRevoked(ctx, serialStr, at); err != nil {
+		slog.Warn("Failed to project revocation into certificate index",
+			"serial", serialStr, "error", err)
+	}
 }
 
 // parseInventoryLine parses a single line of the certificate inventory file.

--- a/internal/ca/signing.go
+++ b/internal/ca/signing.go
@@ -433,8 +433,23 @@ func (c *CA) issueLeafLocked(ctx context.Context, subject string, subjectName pk
 		return nil, fmt.Errorf("failed to save cert for %s: %w", subject, err)
 	}
 
+	// Denormalise the display projection for the certificate index from the
+	// certificate as actually signed (parsed back from the DER, not the
+	// template, so the recorded extensions are exactly what verifiers see).
+	// A parse failure here is unreachable for bytes CreateCertificate just
+	// produced; degrade to a projection-less record rather than failing the
+	// issuance.
+	var proj *storage.CertProjection
+	if signedCert, perr := x509.ParseCertificate(certBytes); perr == nil {
+		p := certProjectionFor(signedCert)
+		proj = &p
+	} else {
+		slog.Warn("Failed to parse just-signed certificate for index projection",
+			"subject", subject, "error", perr)
+	}
+
 	inventoryEntry := storage.FormatInventoryLine(serialStr, template.NotBefore, template.NotAfter, subject)
-	if err := c.Storage.AppendInventory(ctx, inventoryEntry); err != nil {
+	if err := c.Storage.AppendInventoryRecord(ctx, inventoryEntry, proj); err != nil {
 		// Roll back the cert so storage and inventory stay in sync. Log but don't
 		// propagate the cleanup error; the caller already has an error to handle.
 		if delErr := c.Storage.DeleteCert(ctx, subject); delErr != nil {

--- a/internal/storage/20260101000000_init.go
+++ b/internal/storage/20260101000000_init.go
@@ -19,39 +19,56 @@ package storage
 
 import (
 	"context"
+	"time"
 
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/dialect"
 )
 
+// sqlBlobV1 is the blob table exactly as this migration created it, frozen so
+// later schema changes to the live sqlBlob model cannot leak into this
+// migration's DDL. Same reasoning as sqlInventoryRowV1.
+type sqlBlobV1 struct {
+	bun.BaseModel `bun:"table:puppet_ca_blobs,alias:b"`
+
+	Key        string    `bun:"blob_key,pk,type:varchar(512)"`
+	Data       []byte    `bun:"data"`
+	Kind       int       `bun:"kind,notnull"`
+	ModifiedAt time.Time `bun:"modified_at,notnull"`
+}
+
 // Migration 20260101000000 (init): create the single key-value table backing
 // every logical storage key. bun derives the migration name and version
 // "20260101000000" from this file's name, so the file must keep its numeric
-// prefix. The table is created from the sqlBlob model so each dialect gets the
+// prefix. The table is created from a model so each dialect gets the
 // appropriate column types.
 func init() {
 	sqlMigrations.MustRegister(func(ctx context.Context, db *bun.DB) error {
-		if _, err := db.NewCreateTable().
-			Model((*sqlBlob)(nil)).
-			IfNotExists().
-			Exec(ctx); err != nil {
-			return err
-		}
-		// bun maps []byte to BLOB, which on MySQL/MariaDB caps at 64 KiB — too
-		// small for the append-only inventory. Widen it to LONGBLOB. SQLite and
-		// PostgreSQL store blobs without a practical size limit, so they need no
-		// adjustment.
-		if db.Dialect().Name() == dialect.MySQL {
-			if _, err := db.ExecContext(ctx, "ALTER TABLE puppet_ca_blobs MODIFY data LONGBLOB"); err != nil {
+		return migrationDDL(ctx, db, func(ctx context.Context, idb bun.IDB) error {
+			if _, err := idb.NewCreateTable().
+				Model((*sqlBlobV1)(nil)).
+				IfNotExists().
+				Exec(ctx); err != nil {
 				return err
 			}
-		}
-		return nil
+			// bun maps []byte to BLOB, which on MySQL/MariaDB caps at 64 KiB — too
+			// small for the append-only inventory. Widen it to LONGBLOB. SQLite and
+			// PostgreSQL store blobs without a practical size limit, so they need no
+			// adjustment.
+			if idb.Dialect().Name() == dialect.MySQL {
+				if _, err := idb.ExecContext(ctx, "ALTER TABLE puppet_ca_blobs MODIFY data LONGBLOB"); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
 	}, func(ctx context.Context, db *bun.DB) error {
-		_, err := db.NewDropTable().
-			Model((*sqlBlob)(nil)).
-			IfExists().
-			Exec(ctx)
-		return err
+		return migrationDDL(ctx, db, func(ctx context.Context, idb bun.IDB) error {
+			_, err := idb.NewDropTable().
+				Model((*sqlBlobV1)(nil)).
+				IfExists().
+				Exec(ctx)
+			return err
+		})
 	})
 }

--- a/internal/storage/20260201000000_inventory.go
+++ b/internal/storage/20260201000000_inventory.go
@@ -23,6 +23,21 @@ import (
 	"github.com/uptrace/bun"
 )
 
+// sqlInventoryRowV1 is the inventory table exactly as this migration created
+// it, frozen so later schema changes to the live sqlInventoryRow model cannot
+// leak into this migration's DDL. A fresh database must create this shape and
+// then replay the follow-up migrations (which ALTER it forward), identically
+// to a database that upgraded in place.
+type sqlInventoryRowV1 struct {
+	bun.BaseModel `bun:"table:puppet_ca_inventory,alias:inv"`
+
+	ID        int64  `bun:"id,pk,autoincrement"`
+	Serial    string `bun:"serial,notnull,type:varchar(128)"`
+	Subject   string `bun:"subject,notnull,type:varchar(512)"`
+	NotBefore string `bun:"not_before,notnull,type:varchar(64)"`
+	NotAfter  string `bun:"not_after,notnull,type:varchar(64)"`
+}
+
 // Migration 20260201000000 (inventory): create the structured inventory table
 // that backs the InventoryStore capability. Each issued certificate is one row,
 // ordered by the autoincrement id (issuance order); the subject index serves
@@ -33,7 +48,7 @@ import (
 func init() {
 	sqlMigrations.MustRegister(func(ctx context.Context, db *bun.DB) error {
 		if _, err := db.NewCreateTable().
-			Model((*sqlInventoryRow)(nil)).
+			Model((*sqlInventoryRowV1)(nil)).
 			IfNotExists().
 			Exec(ctx); err != nil {
 			return err
@@ -41,7 +56,7 @@ func init() {
 		// Index subject for LatestSerialForSubject. No IF NOT EXISTS: MySQL does
 		// not support it on CREATE INDEX, and bun applies each migration once.
 		if _, err := db.NewCreateIndex().
-			Model((*sqlInventoryRow)(nil)).
+			Model((*sqlInventoryRowV1)(nil)).
 			Index("idx_puppet_ca_inventory_subject").
 			Column("subject").
 			Exec(ctx); err != nil {
@@ -52,7 +67,7 @@ func init() {
 		// or a double insert, which AppendEntry should fail on rather than
 		// silently record two certs under one serial.
 		if _, err := db.NewCreateIndex().
-			Model((*sqlInventoryRow)(nil)).
+			Model((*sqlInventoryRowV1)(nil)).
 			Unique().
 			Index("idx_puppet_ca_inventory_serial").
 			Column("serial").
@@ -62,7 +77,7 @@ func init() {
 		return nil
 	}, func(ctx context.Context, db *bun.DB) error {
 		_, err := db.NewDropTable().
-			Model((*sqlInventoryRow)(nil)).
+			Model((*sqlInventoryRowV1)(nil)).
 			IfExists().
 			Exec(ctx)
 		return err

--- a/internal/storage/20260201000000_inventory.go
+++ b/internal/storage/20260201000000_inventory.go
@@ -23,6 +23,12 @@ import (
 	"github.com/uptrace/bun"
 )
 
+// inventoryTableV1 is the name this migration gave the inventory table. Later
+// migrations that ALTER the same table address it through this constant, so
+// they keep targeting the table as created here even if a future migration
+// renames it.
+const inventoryTableV1 = "puppet_ca_inventory"
+
 // sqlInventoryRowV1 is the inventory table exactly as this migration created
 // it, frozen so later schema changes to the live sqlInventoryRow model cannot
 // leak into this migration's DDL. A fresh database must create this shape and
@@ -47,39 +53,32 @@ type sqlInventoryRowV1 struct {
 // migrate it via the storage migrate command, which parses it into rows.
 func init() {
 	sqlMigrations.MustRegister(func(ctx context.Context, db *bun.DB) error {
-		if _, err := db.NewCreateTable().
-			Model((*sqlInventoryRowV1)(nil)).
-			IfNotExists().
-			Exec(ctx); err != nil {
-			return err
-		}
-		// Index subject for LatestSerialForSubject. No IF NOT EXISTS: MySQL does
-		// not support it on CREATE INDEX, and bun applies each migration once.
-		if _, err := db.NewCreateIndex().
-			Model((*sqlInventoryRowV1)(nil)).
-			Index("idx_puppet_ca_inventory_subject").
-			Column("subject").
-			Exec(ctx); err != nil {
-			return err
-		}
-		// Serials are unique per issuance (random 128-bit, fresh on every
-		// (re-)issuance), so enforce it: a duplicate signals a serial collision
-		// or a double insert, which AppendEntry should fail on rather than
-		// silently record two certs under one serial.
-		if _, err := db.NewCreateIndex().
-			Model((*sqlInventoryRowV1)(nil)).
-			Unique().
-			Index("idx_puppet_ca_inventory_serial").
-			Column("serial").
-			Exec(ctx); err != nil {
-			return err
-		}
-		return nil
+		return migrationDDL(ctx, db, func(ctx context.Context, idb bun.IDB) error {
+			if _, err := idb.NewCreateTable().
+				Model((*sqlInventoryRowV1)(nil)).
+				IfNotExists().
+				Exec(ctx); err != nil {
+				return err
+			}
+			// Index subject for LatestSerialForSubject.
+			if err := createIndexIfMissing(ctx, idb, inventoryTableV1,
+				"idx_puppet_ca_inventory_subject", false, "subject"); err != nil {
+				return err
+			}
+			// Serials are unique per issuance (random 128-bit, fresh on every
+			// (re-)issuance), so enforce it: a duplicate signals a serial collision
+			// or a double insert, which AppendEntry should fail on rather than
+			// silently record two certs under one serial.
+			return createIndexIfMissing(ctx, idb, inventoryTableV1,
+				"idx_puppet_ca_inventory_serial", true, "serial")
+		})
 	}, func(ctx context.Context, db *bun.DB) error {
-		_, err := db.NewDropTable().
-			Model((*sqlInventoryRowV1)(nil)).
-			IfExists().
-			Exec(ctx)
-		return err
+		return migrationDDL(ctx, db, func(ctx context.Context, idb bun.IDB) error {
+			_, err := idb.NewDropTable().
+				Model((*sqlInventoryRowV1)(nil)).
+				IfExists().
+				Exec(ctx)
+			return err
+		})
 	})
 }

--- a/internal/storage/20260725000000_certindex.go
+++ b/internal/storage/20260725000000_certindex.go
@@ -33,8 +33,14 @@ import (
 // and the signed CRL) by the CA's index repair pass at startup, so this
 // migration needs no data backfill of its own.
 //
-// The state and not_after indices serve the certificate_statuses state filter
-// and expiry-window queries respectively.
+// The state and not_after indices are provisioned ahead of their consumers,
+// deliberately: no shipped query filters on either column yet (the statuses
+// handler filters state in Go to keep its dedup set complete, and no
+// expiry-window query exists), but issue #137 fixes this schema before 1.0.0
+// precisely because changing it later means another migration on live
+// databases. Two low-cardinality index maintenances per issuance is the
+// price of not re-migrating when a state-filtered or expiry-window consumer
+// lands.
 func init() {
 	sqlMigrations.MustRegister(func(ctx context.Context, db *bun.DB) error {
 		// bun's dialects map time.Time to different column types; mirror the

--- a/internal/storage/20260725000000_certindex.go
+++ b/internal/storage/20260725000000_certindex.go
@@ -43,69 +43,54 @@ import (
 // lands.
 func init() {
 	sqlMigrations.MustRegister(func(ctx context.Context, db *bun.DB) error {
-		// bun's dialects map time.Time to different column types; mirror the
-		// type CreateTable-from-model would have produced so an upgraded table
-		// is indistinguishable from a freshly created one.
-		timeType := "TIMESTAMP"
-		switch db.Dialect().Name() {
-		case dialect.PG:
-			timeType = "TIMESTAMPTZ"
-		case dialect.MySQL:
-			timeType = "DATETIME"
-		}
-
-		columns := []string{
-			"fingerprint_sha256 VARCHAR(95)",
-			"dns_alt_names TEXT",
-			"auth_extensions TEXT",
-			"state VARCHAR(16) NOT NULL DEFAULT 'signed'",
-			"revoked_at " + timeType,
-		}
-		for _, col := range columns {
-			if _, err := db.NewAddColumn().
-				Model((*sqlInventoryRow)(nil)).
-				ColumnExpr(col).
-				Exec(ctx); err != nil {
-				return err
+		return migrationDDL(ctx, db, func(ctx context.Context, idb bun.IDB) error {
+			// bun's dialects map time.Time to different column types; mirror the
+			// type CreateTable-from-model would have produced so an upgraded table
+			// is indistinguishable from a freshly created one.
+			timeType := "TIMESTAMP"
+			switch idb.Dialect().Name() {
+			case dialect.PG:
+				timeType = "TIMESTAMPTZ"
+			case dialect.MySQL:
+				timeType = "DATETIME"
 			}
-		}
 
-		if _, err := db.NewCreateIndex().
-			Model((*sqlInventoryRow)(nil)).
-			Index("idx_puppet_ca_inventory_state").
-			Column("state").
-			Exec(ctx); err != nil {
-			return err
-		}
-		if _, err := db.NewCreateIndex().
-			Model((*sqlInventoryRow)(nil)).
-			Index("idx_puppet_ca_inventory_not_after").
-			Column("not_after").
-			Exec(ctx); err != nil {
-			return err
-		}
-		return nil
+			columns := []struct{ name, definition string }{
+				{"fingerprint_sha256", "VARCHAR(95)"},
+				{"dns_alt_names", "TEXT"},
+				{"auth_extensions", "TEXT"},
+				{"state", "VARCHAR(16) NOT NULL DEFAULT 'signed'"},
+				{"revoked_at", timeType},
+			}
+			for _, col := range columns {
+				if err := addColumnIfMissing(ctx, idb, inventoryTableV1, col.name, col.definition); err != nil {
+					return err
+				}
+			}
+
+			for _, idx := range []struct{ name, column string }{
+				{"idx_puppet_ca_inventory_state", "state"},
+				{"idx_puppet_ca_inventory_not_after", "not_after"},
+			} {
+				if err := createIndexIfMissing(ctx, idb, inventoryTableV1, idx.name, false, idx.column); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
 	}, func(ctx context.Context, db *bun.DB) error {
-		// bun's DropIndexQuery emits bare "DROP INDEX <name>", which MySQL
-		// rejects (it requires "... ON <table>"), so build the statement per
-		// dialect.
-		for _, idx := range []string{"idx_puppet_ca_inventory_not_after", "idx_puppet_ca_inventory_state"} {
-			stmt := "DROP INDEX " + idx
-			if db.Dialect().Name() == dialect.MySQL {
-				stmt += " ON puppet_ca_inventory"
+		return migrationDDL(ctx, db, func(ctx context.Context, idb bun.IDB) error {
+			for _, idx := range []string{"idx_puppet_ca_inventory_not_after", "idx_puppet_ca_inventory_state"} {
+				if err := dropIndexIfPresent(ctx, idb, inventoryTableV1, idx); err != nil {
+					return err
+				}
 			}
-			if _, err := db.ExecContext(ctx, stmt); err != nil {
-				return err
+			for _, col := range []string{"revoked_at", "state", "auth_extensions", "dns_alt_names", "fingerprint_sha256"} {
+				if err := dropColumnIfPresent(ctx, idb, inventoryTableV1, col); err != nil {
+					return err
+				}
 			}
-		}
-		for _, col := range []string{"revoked_at", "state", "auth_extensions", "dns_alt_names", "fingerprint_sha256"} {
-			if _, err := db.NewDropColumn().
-				Model((*sqlInventoryRow)(nil)).
-				ColumnExpr(col).
-				Exec(ctx); err != nil {
-				return err
-			}
-		}
-		return nil
+			return nil
+		})
 	})
 }

--- a/internal/storage/20260725000000_certindex.go
+++ b/internal/storage/20260725000000_certindex.go
@@ -1,0 +1,105 @@
+// Copyright (C) 2026 Chris Boot
+// Copyright (C) 2026 Vox Pupuli and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package storage
+
+import (
+	"context"
+
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect"
+)
+
+// Migration 20260725000000 (certindex): grow the inventory table into the
+// certificate index backing the CertIndex capability (see sqlInventoryRow for
+// the column semantics).
+//
+// Existing rows get state='signed' via the column default and NULL projection
+// columns; both are reconciled from the authoritative artefacts (stored PEMs
+// and the signed CRL) by the CA's index repair pass at startup, so this
+// migration needs no data backfill of its own.
+//
+// The state and not_after indices serve the certificate_statuses state filter
+// and expiry-window queries respectively.
+func init() {
+	sqlMigrations.MustRegister(func(ctx context.Context, db *bun.DB) error {
+		// bun's dialects map time.Time to different column types; mirror the
+		// type CreateTable-from-model would have produced so an upgraded table
+		// is indistinguishable from a freshly created one.
+		timeType := "TIMESTAMP"
+		switch db.Dialect().Name() {
+		case dialect.PG:
+			timeType = "TIMESTAMPTZ"
+		case dialect.MySQL:
+			timeType = "DATETIME"
+		}
+
+		columns := []string{
+			"fingerprint_sha256 VARCHAR(95)",
+			"dns_alt_names TEXT",
+			"auth_extensions TEXT",
+			"state VARCHAR(16) NOT NULL DEFAULT 'signed'",
+			"revoked_at " + timeType,
+		}
+		for _, col := range columns {
+			if _, err := db.NewAddColumn().
+				Model((*sqlInventoryRow)(nil)).
+				ColumnExpr(col).
+				Exec(ctx); err != nil {
+				return err
+			}
+		}
+
+		if _, err := db.NewCreateIndex().
+			Model((*sqlInventoryRow)(nil)).
+			Index("idx_puppet_ca_inventory_state").
+			Column("state").
+			Exec(ctx); err != nil {
+			return err
+		}
+		if _, err := db.NewCreateIndex().
+			Model((*sqlInventoryRow)(nil)).
+			Index("idx_puppet_ca_inventory_not_after").
+			Column("not_after").
+			Exec(ctx); err != nil {
+			return err
+		}
+		return nil
+	}, func(ctx context.Context, db *bun.DB) error {
+		// bun's DropIndexQuery emits bare "DROP INDEX <name>", which MySQL
+		// rejects (it requires "... ON <table>"), so build the statement per
+		// dialect.
+		for _, idx := range []string{"idx_puppet_ca_inventory_not_after", "idx_puppet_ca_inventory_state"} {
+			stmt := "DROP INDEX " + idx
+			if db.Dialect().Name() == dialect.MySQL {
+				stmt += " ON puppet_ca_inventory"
+			}
+			if _, err := db.ExecContext(ctx, stmt); err != nil {
+				return err
+			}
+		}
+		for _, col := range []string{"revoked_at", "state", "auth_extensions", "dns_alt_names", "fingerprint_sha256"} {
+			if _, err := db.NewDropColumn().
+				Model((*sqlInventoryRow)(nil)).
+				ColumnExpr(col).
+				Exec(ctx); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}

--- a/internal/storage/backend.go
+++ b/internal/storage/backend.go
@@ -229,6 +229,14 @@ type CertIndex interface {
 	// CertStateRevoked; "" returns all records. Records whose projection has
 	// never been populated are returned with an empty Fingerprint so the
 	// caller can fall back to the stored PEM for display fields.
+	//
+	// Note today's in-tree callers always pass "": the statuses handler must
+	// see every certified subject to keep its CSR-dedup set complete (it
+	// filters per record in Go), and the index repair pass reconciles all
+	// records. The filter is nevertheless part of the capability contract —
+	// it is the indexed query shape issue #137 fixes the schema for, it is
+	// dialect-tested, and direct consumers (CLI/report tooling) can use it
+	// without a schema change.
 	Statuses(ctx context.Context, stateFilter string) ([]CertRecord, error)
 
 	// SetRevoked marks every index row bearing serial as revoked at the given

--- a/internal/storage/backend.go
+++ b/internal/storage/backend.go
@@ -169,6 +169,101 @@ type InventoryEntry struct {
 	Subject   string
 }
 
+// Certificate index states recorded in CertRecord.State. Pending CSRs are not
+// issued certificates and never appear in the index; the API layer derives the
+// "requested" state from the csr/ namespace instead.
+const (
+	CertStateSigned  = "signed"
+	CertStateRevoked = "revoked"
+)
+
+// CertProjection carries the display fields denormalised from a signed
+// certificate into the certificate index. Every field is immutable for the
+// life of the certificate (they are fixed at signing), so the projection can
+// never drift from the stored PEM — the PEM remains the authoritative
+// artefact and the projection is rebuildable from it at any time.
+type CertProjection struct {
+	// Fingerprint is the SHA-256 digest of the certificate's DER encoding,
+	// rendered as colon-separated hex pairs exactly as the status API emits it.
+	// An empty Fingerprint marks a record whose projection has not been
+	// populated (e.g. rows imported from a legacy inventory blob); readers must
+	// fall back to parsing the stored PEM for such records.
+	Fingerprint string
+	// DNSAltNames holds the certificate's DNS subject alternative names.
+	DNSAltNames []string
+	// AuthExtensions holds Puppet auth-arc extension values keyed by short
+	// name (e.g. "pp_auth_role") or dotted OID when no short name is known.
+	AuthExtensions map[string]string
+}
+
+// CertRecord is one issued certificate as the certificate index sees it: the
+// canonical inventory fields, the denormalised display projection, and the one
+// mutable fact — revocation. State/RevokedAt are a projection of the signed
+// CRL (the source of truth), written alongside CRL updates and rebuildable
+// from it, exactly as the projection fields relate to the PEM.
+//
+// Note the integrity hash chain covers only the canonical InventoryEntry
+// fields (via canonicalInventoryLine); the projection columns are not chained.
+// That is deliberate: each projection field is independently verifiable
+// against a signed artefact (the certificate PEM or the CRL), so chaining
+// them would add nothing the artefacts do not already guarantee.
+type CertRecord struct {
+	InventoryEntry
+	CertProjection
+	State     string     // CertStateSigned or CertStateRevoked
+	RevokedAt *time.Time // nil unless revoked
+}
+
+// CertIndex is an optional capability of InventoryStore backends: the backend
+// that owns the structured inventory rows can answer certificate-status
+// queries from indexed columns instead of forcing the caller into a
+// list-certs → read-PEM → parse → CRL-check scan per subject.
+//
+// The certificate blobs stay authoritative. Statuses reflects the index rows
+// joined against blob existence, so a certificate removed by clean/cleanup
+// stops being reported even though its historical inventory rows remain.
+type CertIndex interface {
+	// Statuses returns one record per subject that currently holds a stored
+	// signed certificate — the latest issuance for that subject — in subject
+	// order. stateFilter narrows the result to CertStateSigned or
+	// CertStateRevoked; "" returns all records. Records whose projection has
+	// never been populated are returned with an empty Fingerprint so the
+	// caller can fall back to the stored PEM for display fields.
+	Statuses(ctx context.Context, stateFilter string) ([]CertRecord, error)
+
+	// SetRevoked marks every index row bearing serial as revoked at the given
+	// time. Idempotent: re-marking an already-revoked serial keeps the
+	// original revocation time. A serial with no matching row is a no-op, not
+	// an error (the CRL may legitimately reference certs the index no longer
+	// tracks).
+	SetRevoked(ctx context.Context, serial string, at time.Time) error
+
+	// ClearRevoked returns every index row bearing serial to the signed
+	// state. Used by index repair when a row claims a revocation the signed
+	// CRL does not corroborate.
+	ClearRevoked(ctx context.Context, serial string) error
+
+	// SetProjection fills the denormalised display fields for every index row
+	// bearing serial. Used to backfill rows created from projection-less
+	// sources (legacy inventory blobs, direct AppendLine writes).
+	SetProjection(ctx context.Context, serial string, proj CertProjection) error
+}
+
+// asCertIndex probes b for the CertIndex capability, unwrapping wrapper
+// backends the same way asInventoryStore does.
+func asCertIndex(b Backend) (CertIndex, bool) {
+	for {
+		if idx, ok := b.(CertIndex); ok {
+			return idx, true
+		}
+		unwrapper, ok := b.(interface{ Unwrap() Backend })
+		if !ok {
+			return nil, false
+		}
+		b = unwrapper.Unwrap()
+	}
+}
+
 // InventoryStore is an optional Backend capability for storing the certificate
 // inventory as structured records (e.g. a SQL table) rather than the single
 // append-only KeyInventory blob. Backends that implement it let StorageService
@@ -184,14 +279,16 @@ type InventoryEntry struct {
 // parsing text back to rows) so that Migrate and the OCSP index build remain
 // backend-agnostic.
 type InventoryStore interface {
-	// AppendEntry inserts e and advances the integrity head atomically. newHead
-	// computes the chained head MAC from the previous head (nil when the
-	// inventory is empty); the backend MUST invoke it inside the same
+	// AppendEntry inserts rec and advances the integrity head atomically.
+	// newHead computes the chained head MAC from the previous head (nil when
+	// the inventory is empty); the backend MUST invoke it inside the same
 	// transaction or lock that serialises appends so the chain cannot fork
 	// under concurrent appenders. A nil newHead means integrity is disabled
 	// (no HMAC key configured): the backend appends the entry and leaves the
-	// stored head untouched.
-	AppendEntry(ctx context.Context, e InventoryEntry, newHead func(prev []byte) []byte) error
+	// stored head untouched. Only rec's canonical InventoryEntry fields feed
+	// the chain; the projection/state columns are stored uncovered (see
+	// CertRecord).
+	AppendEntry(ctx context.Context, rec CertRecord, newHead func(prev []byte) []byte) error
 
 	// Entries returns every entry in issuance order, for the OCSP index build
 	// and for chain verification.

--- a/internal/storage/sql.go
+++ b/internal/storage/sql.go
@@ -66,6 +66,29 @@ const (
 	sqlBusyTimeoutMS = 10000
 
 	sqlDefaultTimeout = 10 * time.Second
+
+	// sqlMinOpenConns is the floor MaxOpenConns is held to on the networked
+	// dialects. Distributed locks are session-scoped (pg_advisory_lock and
+	// GET_LOCK both bind to their connection), so every lock held ties up a
+	// connection for its whole lifetime while the work done under it needs one
+	// of its own. The deepest nesting is a storage migration: the bootstrap
+	// lock, the migration lock inside it, and the migration's own statements —
+	// three at once, plus one spare. A smaller pool would not run slowly, it
+	// would deadlock, so an operator setting cannot lower it.
+	sqlMinOpenConns = 4
+
+	// sqlMigrationTimeout bounds a whole migration run, replacing the
+	// per-statement RequestTimeout for the duration of EnsureReady. It has to
+	// cover the slowest legitimate migration (an index build over a large
+	// inventory) plus any wait for a peer replica holding the migration lock,
+	// because a run cut short is exactly what leaves a schema half-migrated.
+	sqlMigrationTimeout = 10 * time.Minute
+
+	// lockNameSQLMigrate is the distributed-lock name held for a migration run.
+	// It is deliberately distinct from the CA's "bootstrap" lock: EnsureReady
+	// runs before (and, via MigrateService, inside) that one, so sharing a name
+	// would deadlock.
+	lockNameSQLMigrate = "sql-schema-migrate"
 )
 
 // SQLConfig configures an SQLBackend.
@@ -159,7 +182,7 @@ func NewSQLBackend(cfg SQLConfig) (*SQLBackend, error) {
 		sqldb.SetMaxOpenConns(1)
 	} else {
 		if cfg.MaxOpenConns > 0 {
-			sqldb.SetMaxOpenConns(cfg.MaxOpenConns)
+			sqldb.SetMaxOpenConns(max(cfg.MaxOpenConns, sqlMinOpenConns))
 		}
 		if cfg.MaxIdleConns > 0 {
 			sqldb.SetMaxIdleConns(cfg.MaxIdleConns)
@@ -263,16 +286,51 @@ func (b *SQLBackend) callCtx(parent context.Context) (context.Context, context.C
 }
 
 // EnsureReady verifies connectivity and brings the schema up to date by running
-// the bun migrations. Safe to call multiple times: the migrator records applied
-// versions and serialises concurrent runners with its lock table.
+// the bun migrations. Safe to call multiple times, and safe to call from several
+// processes at once: the run is serialised by the backend's distributed lock and
+// the migrator records applied versions.
 func (b *SQLBackend) EnsureReady(ctx context.Context) error {
-	ctx, cancel := b.callCtx(ctx)
-	defer cancel()
-	if err := b.db.PingContext(ctx); err != nil {
+	pingCtx, cancelPing := b.callCtx(ctx)
+	err := b.db.PingContext(pingCtx)
+	cancelPing()
+	if err != nil {
 		return fmt.Errorf("sql database not reachable: %w", err)
 	}
 
-	migrator := migrate.NewMigrator(b.db, sqlMigrations)
+	// Schema changes get their own budget. RequestTimeout bounds one ordinary
+	// statement; a migration run can legitimately take far longer (building an
+	// index over a large inventory) and must never be cut off part-way.
+	ctx, cancel := context.WithTimeout(ctx, sqlMigrationTimeout)
+	defer cancel()
+
+	// Serialise runners before any migration state is read. bun's Migrate does
+	// not lock — Migrator.Lock exists but Migrate never calls it — so without
+	// this two starters (replicas, or the signer and frontend of one replica)
+	// both read "unapplied", both record the version, and both run the DDL. The
+	// loser then fails on work the winner already did, and with bun's default of
+	// recording a migration before running it, the version stays recorded and is
+	// never retried. That is how a schema ends up permanently half-migrated.
+	unlock, lockErr := b.AcquireLock(ctx, lockNameSQLMigrate)
+	switch {
+	case lockErr == nil:
+		defer func() { _ = unlock.Unlock() }()
+	case errors.Is(lockErr, ErrDistributedLockingUnsupported):
+		// SQLite has no distributed lock. Two processes sharing one file can
+		// still race here; the migrations are transactional and idempotent, so
+		// the loser fails cleanly and succeeds on its next start rather than
+		// leaving the schema half-changed. The process-local mutex at least
+		// serialises goroutines within this process.
+		local := b.localLockFor(lockNameSQLMigrate)
+		local.Lock()
+		defer local.Unlock()
+	default:
+		return fmt.Errorf("acquiring migration lock: %w", lockErr)
+	}
+
+	// WithMarkAppliedOnSuccess reverses bun's default of recording a migration
+	// before running it, so a migration that fails is retried on the next start
+	// instead of being remembered as done.
+	migrator := migrate.NewMigrator(b.db, sqlMigrations, migrate.WithMarkAppliedOnSuccess(true))
 	if err := migrator.Init(ctx); err != nil {
 		return fmt.Errorf("initialising migrations: %w", err)
 	}

--- a/internal/storage/sql.go
+++ b/internal/storage/sql.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io/fs"
+	"log/slog"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -182,6 +183,10 @@ func NewSQLBackend(cfg SQLConfig) (*SQLBackend, error) {
 		sqldb.SetMaxOpenConns(1)
 	} else {
 		if cfg.MaxOpenConns > 0 {
+			if cfg.MaxOpenConns < sqlMinOpenConns {
+				slog.Warn("Raising SQL connection limit to the minimum the distributed locks require",
+					"requested", cfg.MaxOpenConns, "effective", sqlMinOpenConns)
+			}
 			sqldb.SetMaxOpenConns(max(cfg.MaxOpenConns, sqlMinOpenConns))
 		}
 		if cfg.MaxIdleConns > 0 {
@@ -313,7 +318,15 @@ func (b *SQLBackend) EnsureReady(ctx context.Context) error {
 	unlock, lockErr := b.AcquireLock(ctx, lockNameSQLMigrate)
 	switch {
 	case lockErr == nil:
-		defer func() { _ = unlock.Unlock() }()
+		defer func() {
+			// Same treatment StorageService.WithLock gives a failed release: a
+			// lost unlock is not worth failing a successful migration over, but
+			// it must not be silent — a session-scoped lock left held is what
+			// the next start would block on.
+			if err := unlock.Unlock(); err != nil {
+				slog.Warn("Failed to release migration lock", "name", lockNameSQLMigrate, "error", err)
+			}
+		}()
 	case errors.Is(lockErr, ErrDistributedLockingUnsupported):
 		// SQLite has no distributed lock. Two processes sharing one file can
 		// still race here; the migrations are transactional and idempotent, so

--- a/internal/storage/sql_certindex_test.go
+++ b/internal/storage/sql_certindex_test.go
@@ -1,0 +1,252 @@
+// Copyright (C) 2026 Chris Boot
+// Copyright (C) 2026 Vox Pupuli and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package storage
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/uptrace/bun/migrate"
+)
+
+// newCertIndexService returns a StorageService over a fresh SQLite backend
+// with the inventory touched and integrity initialised, plus the backend for
+// direct blob writes (stored certificates gate Statuses visibility).
+func newCertIndexService() (*StorageService, *SQLBackend) {
+	ctx := context.Background()
+	b := newSQLiteBackend()
+	svc := NewWithBackend(b, "")
+	Expect(svc.TouchInventory(ctx)).To(Succeed(), "TouchInventory")
+	Expect(svc.InitHMAC(ctx)).To(Succeed(), "InitHMAC")
+	return svc, b
+}
+
+func putCertBlob(b *SQLBackend, subject string) {
+	Expect(b.Put(context.Background(), CertKey(subject), []byte("pem-"+subject), BlobPublic)).
+		To(Succeed(), "Put cert blob for "+subject)
+}
+
+// certIndexRoundTrip exercises the CertIndex surface end to end against b:
+// projected append, latest-per-subject and blob-gated Statuses, the state
+// filter, the revocation round-trip, and projection backfill. It is shared
+// between the SQLite unit suite and the PostgreSQL/MySQL integration suites
+// so every supported dialect runs identical assertions over its real DDL.
+func certIndexRoundTrip(b *SQLBackend) {
+	ctx := context.Background()
+	svc := NewWithBackend(b, "")
+	Expect(svc.TouchInventory(ctx)).To(Succeed(), "TouchInventory")
+	Expect(svc.InitHMAC(ctx)).To(Succeed(), "InitHMAC")
+
+	proj := CertProjection{
+		Fingerprint:    "aa:bb:cc",
+		DNSAltNames:    []string{"node1", "node1.example.com"},
+		AuthExtensions: map[string]string{"pp_auth_role": "webserver"},
+	}
+	Expect(svc.AppendInventory(ctx, "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1")).To(Succeed())
+	Expect(svc.AppendInventoryRecord(ctx, "0003 2024-01-03T00:00:00UTC 2029-01-03T00:00:00UTC /node1", &proj)).To(Succeed())
+	Expect(svc.AppendInventory(ctx, "0002 2024-01-02T00:00:00UTC 2029-01-02T00:00:00UTC /node2")).To(Succeed())
+	for _, subject := range []string{"node1", "node2"} {
+		Expect(b.Put(ctx, CertKey(subject), []byte("pem-"+subject), BlobPublic)).To(Succeed())
+	}
+
+	recs, ok, err := svc.CertStatuses(ctx, "")
+	Expect(err).NotTo(HaveOccurred(), "CertStatuses")
+	Expect(ok).To(BeTrue())
+	Expect(recs).To(HaveLen(2), "one record per subject, latest issuance only")
+	Expect(recs[0].Subject).To(Equal("node1"))
+	Expect(recs[0].Serial).To(Equal("0003"), "node1's latest issuance wins")
+	Expect(recs[0].Fingerprint).To(Equal(proj.Fingerprint))
+	Expect(recs[0].DNSAltNames).To(Equal(proj.DNSAltNames))
+	Expect(recs[0].AuthExtensions).To(Equal(proj.AuthExtensions))
+	Expect(recs[1].Subject).To(Equal("node2"))
+	Expect(recs[1].Fingerprint).To(BeEmpty(), "appended without a projection")
+
+	// Revocation round-trip, including the state filter.
+	revokedAt := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+	Expect(svc.MarkCertRevoked(ctx, "0003", revokedAt)).To(Succeed())
+	revoked, _, err := svc.CertStatuses(ctx, CertStateRevoked)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(revoked).To(HaveLen(1))
+	Expect(revoked[0].Subject).To(Equal("node1"))
+	Expect(revoked[0].RevokedAt).NotTo(BeNil())
+	Expect(*revoked[0].RevokedAt).To(BeTemporally("~", revokedAt, time.Second))
+	Expect(svc.ClearCertRevoked(ctx, "0003")).To(Succeed())
+
+	// Projection backfill for the projection-less row.
+	Expect(svc.SetCertProjection(ctx, "0002", CertProjection{Fingerprint: "dd:ee:ff"})).To(Succeed())
+	recs, _, err = svc.CertStatuses(ctx, "")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(recs).To(HaveLen(2))
+	Expect(recs[0].State).To(Equal(CertStateSigned), "ClearCertRevoked restored node1")
+	Expect(recs[0].RevokedAt).To(BeNil())
+	Expect(recs[1].Fingerprint).To(Equal("dd:ee:ff"))
+}
+
+// certIndexMigrationRollback rolls every applied migration group back and
+// re-applies them, then re-runs the index round-trip. Nothing in the product
+// invokes the down migrations, so this is the only check that their DDL —
+// notably the certindex column and index drops — is valid for the backend's
+// dialect.
+func certIndexMigrationRollback(b *SQLBackend) {
+	ctx := context.Background()
+	migrator := migrate.NewMigrator(b.db, sqlMigrations)
+	for {
+		group, err := migrator.Rollback(ctx)
+		Expect(err).NotTo(HaveOccurred(), "Rollback")
+		if group.IsZero() {
+			break
+		}
+	}
+	_, err := migrator.Migrate(ctx)
+	Expect(err).NotTo(HaveOccurred(), "Migrate (re-apply)")
+	certIndexRoundTrip(b)
+}
+
+var _ = Describe("SQLiteCertIndex", func() {
+	It("round-trips the certificate index end to end", func() {
+		certIndexRoundTrip(newSQLiteBackend())
+	})
+
+	It("survives a migration rollback and re-apply", func() {
+		certIndexMigrationRollback(newSQLiteBackend())
+	})
+
+	It("persists the projection at append time and serves it back from Statuses", func() {
+		ctx := context.Background()
+		svc, b := newCertIndexService()
+
+		proj := CertProjection{
+			Fingerprint:    "aa:bb:cc",
+			DNSAltNames:    []string{"node1", "node1.example.com"},
+			AuthExtensions: map[string]string{"pp_auth_role": "webserver"},
+		}
+		line := "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1"
+		Expect(svc.AppendInventoryRecord(ctx, line, &proj)).To(Succeed(), "AppendInventoryRecord")
+		putCertBlob(b, "node1")
+
+		recs, ok, err := svc.CertStatuses(ctx, "")
+		Expect(err).NotTo(HaveOccurred(), "CertStatuses")
+		Expect(ok).To(BeTrue(), "SQL backend must advertise the CertIndex capability")
+		Expect(recs).To(HaveLen(1))
+		Expect(recs[0].Serial).To(Equal("0001"))
+		Expect(recs[0].Subject).To(Equal("node1"))
+		Expect(recs[0].NotBefore).To(Equal("2024-01-01T00:00:00UTC"))
+		Expect(recs[0].NotAfter).To(Equal("2029-01-01T00:00:00UTC"))
+		Expect(recs[0].State).To(Equal(CertStateSigned))
+		Expect(recs[0].RevokedAt).To(BeNil())
+		Expect(recs[0].Fingerprint).To(Equal(proj.Fingerprint))
+		Expect(recs[0].DNSAltNames).To(Equal(proj.DNSAltNames))
+		Expect(recs[0].AuthExtensions).To(Equal(proj.AuthExtensions))
+	})
+
+	It("returns only the latest issuance per subject, and only subjects with a stored certificate", func() {
+		ctx := context.Background()
+		svc, b := newCertIndexService()
+
+		for _, line := range []string{
+			"0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1",
+			"0002 2024-01-02T00:00:00UTC 2029-01-02T00:00:00UTC /node2",
+			"0003 2024-01-03T00:00:00UTC 2029-01-03T00:00:00UTC /node1",
+		} {
+			Expect(svc.AppendInventory(ctx, line)).To(Succeed(), "AppendInventory")
+		}
+		// node1 has a stored cert; node2 was cleaned (rows remain, blob gone).
+		putCertBlob(b, "node1")
+
+		recs, ok, err := svc.CertStatuses(ctx, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(BeTrue())
+		Expect(recs).To(HaveLen(1), "superseded and cleaned rows must not be listed")
+		Expect(recs[0].Serial).To(Equal("0003"), "the latest issuance for node1 wins")
+	})
+
+	It("projects revocation state, keeping the first revocation time, and clears it again", func() {
+		ctx := context.Background()
+		svc, b := newCertIndexService()
+
+		line := "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1"
+		Expect(svc.AppendInventory(ctx, line)).To(Succeed())
+		putCertBlob(b, "node1")
+
+		first := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+		Expect(svc.MarkCertRevoked(ctx, "0001", first)).To(Succeed(), "MarkCertRevoked")
+		// A retried revocation must not overwrite the original time.
+		Expect(svc.MarkCertRevoked(ctx, "0001", first.Add(24*time.Hour))).To(Succeed(), "MarkCertRevoked (retry)")
+
+		recs, _, err := svc.CertStatuses(ctx, CertStateRevoked)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(recs).To(HaveLen(1))
+		Expect(recs[0].State).To(Equal(CertStateRevoked))
+		Expect(recs[0].RevokedAt).NotTo(BeNil())
+		Expect(*recs[0].RevokedAt).To(BeTemporally("~", first, time.Second))
+
+		// The state filter must partition the records.
+		signed, _, err := svc.CertStatuses(ctx, CertStateSigned)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(signed).To(BeEmpty())
+
+		Expect(svc.ClearCertRevoked(ctx, "0001")).To(Succeed(), "ClearCertRevoked")
+		recs, _, err = svc.CertStatuses(ctx, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(recs).To(HaveLen(1))
+		Expect(recs[0].State).To(Equal(CertStateSigned))
+		Expect(recs[0].RevokedAt).To(BeNil())
+	})
+
+	It("marks rows imported from a legacy inventory blob as projection-less and backfills them", func() {
+		ctx := context.Background()
+		svc, b := newCertIndexService()
+
+		// Importing an inventory.txt blob (the Migrate path) replaces the rows
+		// with projection-less ones.
+		blob := "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1\n"
+		Expect(b.Put(ctx, KeyInventory, []byte(blob), BlobPrivate)).To(Succeed(), "Put inventory blob")
+		putCertBlob(b, "node1")
+
+		recs, _, err := svc.CertStatuses(ctx, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(recs).To(HaveLen(1))
+		Expect(recs[0].Fingerprint).To(BeEmpty(), "imported rows carry no projection")
+		Expect(recs[0].State).To(Equal(CertStateSigned), "imported rows default to signed")
+
+		proj := CertProjection{Fingerprint: "dd:ee:ff", DNSAltNames: []string{"node1"}}
+		Expect(svc.SetCertProjection(ctx, "0001", proj)).To(Succeed(), "SetCertProjection")
+
+		recs, _, err = svc.CertStatuses(ctx, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(recs[0].Fingerprint).To(Equal("dd:ee:ff"))
+		Expect(recs[0].DNSAltNames).To(Equal([]string{"node1"}))
+		Expect(recs[0].AuthExtensions).To(BeNil(), "no auth extensions were projected")
+	})
+
+	It("degrades gracefully on backends without the capability", func() {
+		ctx := context.Background()
+		svc := New(GinkgoT().TempDir())
+
+		_, ok, err := svc.CertStatuses(ctx, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(BeFalse(), "filesystem backend has no certificate index")
+
+		// Index writes are silent no-ops so shared CA paths need no probing.
+		Expect(svc.MarkCertRevoked(ctx, "0001", time.Now())).To(Succeed())
+		Expect(svc.ClearCertRevoked(ctx, "0001")).To(Succeed())
+		Expect(svc.SetCertProjection(ctx, "0001", CertProjection{Fingerprint: "aa"})).To(Succeed())
+	})
+})

--- a/internal/storage/sql_certindex_test.go
+++ b/internal/storage/sql_certindex_test.go
@@ -236,6 +236,30 @@ var _ = Describe("SQLiteCertIndex", func() {
 		Expect(recs[0].AuthExtensions).To(BeNil(), "no auth extensions were projected")
 	})
 
+	It("degrades a corrupt projection to a missing one instead of failing the record", func() {
+		// record() promises undecodable projection JSON reads as "projection
+		// missing" (empty Fingerprint) so listings keep working and readers
+		// fall back to the authoritative PEM.
+		row := sqlInventoryRow{
+			Serial: "0001", Subject: "node1",
+			NotBefore: "2024-01-01T00:00:00UTC", NotAfter: "2029-01-01T00:00:00UTC",
+			State:       CertStateSigned,
+			Fingerprint: "aa:bb:cc",
+			DNSAltNames: "{not-json",
+		}
+		rec := row.record()
+		Expect(rec.CertProjection).To(Equal(CertProjection{}), "bad dns_alt_names discards the projection")
+		Expect(rec.State).To(Equal(CertStateSigned), "state is not part of the projection and survives")
+
+		// Bad auth_extensions JSON discards the whole projection, including
+		// the DNS names that decoded successfully — the record is either
+		// fully projected or not projected at all.
+		row.DNSAltNames = `["node1"]`
+		row.AuthExts = "{not-json"
+		rec = row.record()
+		Expect(rec.CertProjection).To(Equal(CertProjection{}))
+	})
+
 	It("degrades gracefully on backends without the capability", func() {
 		ctx := context.Background()
 		svc := New(GinkgoT().TempDir())

--- a/internal/storage/sql_certindex_test.go
+++ b/internal/storage/sql_certindex_test.go
@@ -114,8 +114,26 @@ func certIndexMigrationRollback(b *SQLBackend) {
 			break
 		}
 	}
+
+	// Assert the rollback actually removed something before re-applying. Every
+	// down step is guarded by dropColumnIfPresent/dropIndexIfPresent, so a
+	// catalogue query mis-scoped for this dialect would make the rollback a
+	// silent no-op, the re-apply a no-op too, and the round-trip below would
+	// still pass against a schema nothing ever touched.
+	for _, col := range certIndexColumns {
+		exists, err := columnExists(ctx, b.db, inventoryTableV1, col)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(exists).To(BeFalse(), "column %s should have been dropped by the rollback", col)
+	}
+	for _, idx := range certIndexIndices {
+		exists, err := indexExists(ctx, b.db, inventoryTableV1, idx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(exists).To(BeFalse(), "index %s should have been dropped by the rollback", idx)
+	}
+
 	_, err := migrator.Migrate(ctx)
 	Expect(err).NotTo(HaveOccurred(), "Migrate (re-apply)")
+	expectCertIndexSchema(ctx, b)
 	certIndexRoundTrip(b)
 }
 

--- a/internal/storage/sql_inventory.go
+++ b/internal/storage/sql_inventory.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -36,6 +37,12 @@ import (
 // which drives both the rendered inventory.txt ordering and the integrity hash
 // chain. NotBefore/NotAfter are stored verbatim as the formatted strings the
 // signing path produces so that rendering is byte-identical to the legacy blob.
+//
+// The table doubles as the certificate index (see CertIndex): the projection
+// columns denormalise immutable display fields filled at signing time, and
+// state/revoked_at project the CRL's one mutable fact. Rows created from
+// projection-less sources (legacy blob imports) leave fingerprint_sha256 NULL,
+// which readers treat as "projection missing, fall back to the PEM".
 type sqlInventoryRow struct {
 	bun.BaseModel `bun:"table:puppet_ca_inventory,alias:inv"`
 
@@ -44,6 +51,17 @@ type sqlInventoryRow struct {
 	Subject   string `bun:"subject,notnull,type:varchar(512)"`
 	NotBefore string `bun:"not_before,notnull,type:varchar(64)"`
 	NotAfter  string `bun:"not_after,notnull,type:varchar(64)"`
+
+	// Denormalised display projection (immutable, filled at signing).
+	// DNSAltNames is a JSON array, AuthExts a JSON object; both NULL when
+	// empty. See CertProjection for the field semantics.
+	Fingerprint string `bun:"fingerprint_sha256,nullzero,type:varchar(95)"`
+	DNSAltNames string `bun:"dns_alt_names,nullzero,type:text"`
+	AuthExts    string `bun:"auth_extensions,nullzero,type:text"`
+
+	// The one mutable fact, projected from the signed CRL.
+	State     string     `bun:"state,notnull,type:varchar(16)"`
+	RevokedAt *time.Time `bun:"revoked_at,nullzero"`
 }
 
 func inventoryRowFromEntry(e InventoryEntry) *sqlInventoryRow {
@@ -52,7 +70,32 @@ func inventoryRowFromEntry(e InventoryEntry) *sqlInventoryRow {
 		Subject:   e.Subject,
 		NotBefore: e.NotBefore,
 		NotAfter:  e.NotAfter,
+		State:     CertStateSigned,
 	}
+}
+
+func inventoryRowFromRecord(rec CertRecord) (*sqlInventoryRow, error) {
+	row := inventoryRowFromEntry(rec.InventoryEntry)
+	if rec.State != "" {
+		row.State = rec.State
+	}
+	row.RevokedAt = rec.RevokedAt
+	row.Fingerprint = rec.Fingerprint
+	if len(rec.DNSAltNames) > 0 {
+		data, err := json.Marshal(rec.DNSAltNames)
+		if err != nil {
+			return nil, fmt.Errorf("encoding dns_alt_names: %w", err)
+		}
+		row.DNSAltNames = string(data)
+	}
+	if len(rec.AuthExtensions) > 0 {
+		data, err := json.Marshal(rec.AuthExtensions)
+		if err != nil {
+			return nil, fmt.Errorf("encoding auth_extensions: %w", err)
+		}
+		row.AuthExts = string(data)
+	}
+	return row, nil
 }
 
 func (r sqlInventoryRow) entry() InventoryEntry {
@@ -64,6 +107,35 @@ func (r sqlInventoryRow) entry() InventoryEntry {
 	}
 }
 
+// record decodes the row into a CertRecord. Undecodable projection JSON is
+// treated as a missing projection (empty Fingerprint) rather than an error:
+// the projection is a rebuildable cache of the PEM, so readers fall back to
+// the authoritative artefact instead of failing the whole listing.
+func (r sqlInventoryRow) record() CertRecord {
+	rec := CertRecord{
+		InventoryEntry: r.entry(),
+		State:          r.State,
+		RevokedAt:      r.RevokedAt,
+	}
+	if rec.State == "" {
+		rec.State = CertStateSigned
+	}
+	rec.Fingerprint = r.Fingerprint
+	if r.DNSAltNames != "" {
+		if err := json.Unmarshal([]byte(r.DNSAltNames), &rec.DNSAltNames); err != nil {
+			rec.CertProjection = CertProjection{}
+			return rec
+		}
+	}
+	if r.AuthExts != "" {
+		if err := json.Unmarshal([]byte(r.AuthExts), &rec.AuthExtensions); err != nil {
+			rec.CertProjection = CertProjection{}
+			return rec
+		}
+	}
+	return rec
+}
+
 // SQLBackend implements InventoryStore: the certificate inventory lives in the
 // puppet_ca_inventory table rather than a single KeyInventory blob. The
 // KeyInventory row in puppet_ca_blobs is kept only as an empty presence marker
@@ -73,13 +145,13 @@ func (r sqlInventoryRow) entry() InventoryEntry {
 // chain (see StorageService.AppendInventory).
 var _ InventoryStore = (*SQLBackend)(nil)
 
-// AppendEntry inserts e and advances the integrity head atomically. The whole
-// operation runs in one transaction that locks the presence-marker row, so
-// concurrent appenders — including separate replicas — serialise and the hash
-// chain cannot fork. newHead is invoked inside that transaction with the
+// AppendEntry inserts rec and advances the integrity head atomically. The
+// whole operation runs in one transaction that locks the presence-marker row,
+// so concurrent appenders — including separate replicas — serialise and the
+// hash chain cannot fork. newHead is invoked inside that transaction with the
 // current head (nil when none); a nil newHead means integrity is disabled and
 // the stored head is left untouched.
-func (b *SQLBackend) AppendEntry(ctx context.Context, e InventoryEntry, newHead func(prev []byte) []byte) error {
+func (b *SQLBackend) AppendEntry(ctx context.Context, rec CertRecord, newHead func(prev []byte) []byte) error {
 	b.appendMu.Lock()
 	defer b.appendMu.Unlock()
 
@@ -88,7 +160,7 @@ func (b *SQLBackend) AppendEntry(ctx context.Context, e InventoryEntry, newHead 
 
 	const maxAttempts = 10
 	for attempt := 0; ; attempt++ {
-		err := b.appendEntryOnce(ctx, e, newHead)
+		err := b.appendEntryOnce(ctx, rec, newHead)
 		if err == nil {
 			return nil
 		}
@@ -103,7 +175,11 @@ func (b *SQLBackend) AppendEntry(ctx context.Context, e InventoryEntry, newHead 
 	}
 }
 
-func (b *SQLBackend) appendEntryOnce(ctx context.Context, e InventoryEntry, newHead func(prev []byte) []byte) error {
+func (b *SQLBackend) appendEntryOnce(ctx context.Context, rec CertRecord, newHead func(prev []byte) []byte) error {
+	row, err := inventoryRowFromRecord(rec)
+	if err != nil {
+		return err
+	}
 	return b.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
 		// Lock the presence marker (created by TouchInventory during bootstrap)
 		// to serialise appends across replicas before reading the head. On the
@@ -114,7 +190,7 @@ func (b *SQLBackend) appendEntryOnce(ctx context.Context, e InventoryEntry, newH
 			return err
 		}
 
-		if _, err := tx.NewInsert().Model(inventoryRowFromEntry(e)).Exec(ctx); err != nil {
+		if _, err := tx.NewInsert().Model(row).Exec(ctx); err != nil {
 			return err
 		}
 
@@ -260,6 +336,122 @@ func (b *SQLBackend) pruneEntriesOnce(ctx context.Context, keep func(InventoryEn
 		return nil, err
 	}
 	return removed, nil
+}
+
+// --- CertIndex ---
+
+// SQLBackend implements CertIndex: certificate-status queries are answered
+// from the indexed inventory columns instead of reading and parsing every
+// stored certificate PEM. See CertIndex for the capability contract.
+var _ CertIndex = (*SQLBackend)(nil)
+
+// Statuses returns one record per subject that currently holds a stored
+// signed certificate (the subject's latest issuance), in subject order,
+// optionally narrowed to stateFilter. Blob existence is resolved with a
+// single indexed key listing rather than a cross-table SQL join so the query
+// stays dialect-free; historical rows for cleaned or superseded certificates
+// are never returned.
+func (b *SQLBackend) Statuses(ctx context.Context, stateFilter string) ([]CertRecord, error) {
+	certKeys, err := b.List(ctx, certPrefix)
+	if err != nil {
+		return nil, err
+	}
+	if len(certKeys) == 0 {
+		return nil, nil
+	}
+	stored := make(map[string]bool, len(certKeys))
+	for _, key := range certKeys {
+		stored[strings.TrimPrefix(key, certPrefix)] = true
+	}
+
+	ctx, cancel := b.callCtx(ctx)
+	defer cancel()
+
+	var rows []sqlInventoryRow
+	latest := b.db.NewSelect().
+		Model((*sqlInventoryRow)(nil)).
+		ColumnExpr("MAX(id)").
+		GroupExpr("subject")
+	q := b.db.NewSelect().Model(&rows).Where("id IN (?)", latest)
+	if stateFilter != "" {
+		q = q.Where("state = ?", stateFilter)
+	}
+	if err := q.Order("subject ASC").Scan(ctx); err != nil {
+		return nil, err
+	}
+
+	records := make([]CertRecord, 0, len(rows))
+	for _, r := range rows {
+		if !stored[r.Subject] {
+			continue
+		}
+		records = append(records, r.record())
+	}
+	return records, nil
+}
+
+// SetRevoked marks every row bearing serial as revoked at the given time. The
+// state guard keeps the first recorded revocation time on repeat calls, and a
+// serial with no rows is a no-op.
+func (b *SQLBackend) SetRevoked(ctx context.Context, serial string, at time.Time) error {
+	ctx, cancel := b.callCtx(ctx)
+	defer cancel()
+
+	_, err := b.db.NewUpdate().
+		Model((*sqlInventoryRow)(nil)).
+		Set("state = ?", CertStateRevoked).
+		Set("revoked_at = ?", at.UTC()).
+		Where("serial = ?", serial).
+		Where("state <> ?", CertStateRevoked).
+		Exec(ctx)
+	return err
+}
+
+// ClearRevoked returns every row bearing serial to the signed state.
+func (b *SQLBackend) ClearRevoked(ctx context.Context, serial string) error {
+	ctx, cancel := b.callCtx(ctx)
+	defer cancel()
+
+	_, err := b.db.NewUpdate().
+		Model((*sqlInventoryRow)(nil)).
+		Set("state = ?", CertStateSigned).
+		Set("revoked_at = NULL").
+		Where("serial = ?", serial).
+		Exec(ctx)
+	return err
+}
+
+// SetProjection fills the denormalised display columns for every row bearing
+// serial. Empty DNS names / auth extensions are stored as NULL, matching what
+// AppendEntry writes for a fresh issuance.
+func (b *SQLBackend) SetProjection(ctx context.Context, serial string, proj CertProjection) error {
+	var dnsNames, authExts any
+	if len(proj.DNSAltNames) > 0 {
+		data, err := json.Marshal(proj.DNSAltNames)
+		if err != nil {
+			return fmt.Errorf("encoding dns_alt_names: %w", err)
+		}
+		dnsNames = string(data)
+	}
+	if len(proj.AuthExtensions) > 0 {
+		data, err := json.Marshal(proj.AuthExtensions)
+		if err != nil {
+			return fmt.Errorf("encoding auth_extensions: %w", err)
+		}
+		authExts = string(data)
+	}
+
+	ctx, cancel := b.callCtx(ctx)
+	defer cancel()
+
+	_, err := b.db.NewUpdate().
+		Model((*sqlInventoryRow)(nil)).
+		Set("fingerprint_sha256 = ?", proj.Fingerprint).
+		Set("dns_alt_names = ?", dnsNames).
+		Set("auth_extensions = ?", authExts).
+		Where("serial = ?", serial).
+		Exec(ctx)
+	return err
 }
 
 // --- KeyInventory blob shim ---

--- a/internal/storage/sql_inventory.go
+++ b/internal/storage/sql_inventory.go
@@ -98,6 +98,14 @@ func inventoryRowFromRecord(rec CertRecord) (*sqlInventoryRow, error) {
 	return row, nil
 }
 
+// inventoryEntryColumns are the columns needed to build an InventoryEntry (plus
+// the id that orders and identifies rows). Queries that only render inventory
+// entries name these explicitly instead of selecting the whole model: the
+// integrity check reads the inventory before anything else at startup, so a
+// select naming columns it does not need turns any unrelated schema drift into
+// a fatal — and thoroughly misleading — "inventory integrity check failed".
+var inventoryEntryColumns = []string{"id", "serial", "subject", "not_before", "not_after"}
+
 func (r sqlInventoryRow) entry() InventoryEntry {
 	return InventoryEntry{
 		Serial:    r.Serial,
@@ -225,7 +233,10 @@ func (b *SQLBackend) Entries(ctx context.Context) ([]InventoryEntry, error) {
 	defer cancel()
 
 	var rows []sqlInventoryRow
-	if err := b.db.NewSelect().Model(&rows).Order("id ASC").Scan(ctx); err != nil {
+	if err := b.db.NewSelect().Model(&rows).
+		Column(inventoryEntryColumns...).
+		Order("id ASC").
+		Scan(ctx); err != nil {
 		return nil, err
 	}
 	entries := make([]InventoryEntry, len(rows))
@@ -299,7 +310,10 @@ func (b *SQLBackend) pruneEntriesOnce(ctx context.Context, keep func(InventoryEn
 		}
 
 		var rows []sqlInventoryRow
-		if err := tx.NewSelect().Model(&rows).Order("id ASC").Scan(ctx); err != nil {
+		if err := tx.NewSelect().Model(&rows).
+			Column(inventoryEntryColumns...).
+			Order("id ASC").
+			Scan(ctx); err != nil {
 			return err
 		}
 
@@ -478,7 +492,10 @@ func (b *SQLBackend) getInventory(ctx context.Context) ([]byte, error) {
 	}
 
 	var rows []sqlInventoryRow
-	if err := b.db.NewSelect().Model(&rows).Order("id ASC").Scan(ctx); err != nil {
+	if err := b.db.NewSelect().Model(&rows).
+		Column(inventoryEntryColumns...).
+		Order("id ASC").
+		Scan(ctx); err != nil {
 		return nil, err
 	}
 	var buf bytes.Buffer

--- a/internal/storage/sql_migrations.go
+++ b/internal/storage/sql_migrations.go
@@ -17,15 +17,184 @@
 
 package storage
 
-import "github.com/uptrace/bun/migrate"
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect"
+	"github.com/uptrace/bun/migrate"
+)
 
 // sqlMigrations is the ordered set of schema migrations applied by every
 // SQLBackend on EnsureReady. bun records applied versions in its own
-// bun_migrations table and serialises concurrent runners with a lock table, so
-// it is safe for multiple CA replicas to start against the same database.
+// bun_migrations table, but it does NOT serialise concurrent runners: Migrator
+// exposes Lock/Unlock and Migrate never calls them. EnsureReady therefore takes
+// the backend's own distributed lock around the whole run, which is what makes
+// it safe for multiple CA replicas — and for the signer and frontend processes
+// of a single replica — to start against the same database at once.
 //
 // Each migration is registered from a file whose name carries the version (a
 // numeric prefix); see the 2026..._init.go file in this package. Migrations are
 // Go functions rather than static .sql so a single definition emits
 // dialect-correct DDL for SQLite, PostgreSQL, and MySQL/MariaDB.
+//
+// Migrations must be written to two rules, both enforced by convention rather
+// than by the compiler:
+//
+//   - Run the DDL through migrationDDL, so it is atomic wherever the dialect
+//     allows it.
+//   - Address tables by a pinned name (or a frozen model, as
+//     sqlInventoryRowV1 does) rather than the live model, so a later rename
+//     cannot retarget an already-shipped migration.
 var sqlMigrations = migrate.NewMigrations()
+
+// migrationDDL runs one migration's statements as a unit. On PostgreSQL and
+// SQLite, whose DDL is transactional, that unit is a transaction: the migration
+// either applies whole or not at all, and a cancelled context can no longer
+// leave the schema half-changed. MySQL/MariaDB commit implicitly on every DDL
+// statement, so a transaction there would be a comforting lie — its migrations
+// stay recoverable by being idempotent instead (addColumnIfMissing and friends),
+// so a re-run completes a partial application rather than failing on the work
+// already done.
+//
+// Idempotence is applied on every dialect, not just MySQL: it is what lets an
+// operator whose schema drifted (see the concurrent-runner history above) clear
+// the stale bun_migrations rows and have the migration finish the job.
+func migrationDDL(ctx context.Context, db *bun.DB, fn func(ctx context.Context, idb bun.IDB) error) error {
+	if db.Dialect().Name() == dialect.MySQL {
+		return fn(ctx, db)
+	}
+	return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+		return fn(ctx, tx)
+	})
+}
+
+// addColumnIfMissing adds column to table with the given type/constraint
+// definition, unless the column is already present. bun's AddColumnQuery has
+// IfNotExists, but it errors on every dialect without native ADD COLUMN IF NOT
+// EXISTS support (SQLite and MySQL both lack it), so the check is made against
+// the catalogue instead.
+func addColumnIfMissing(ctx context.Context, idb bun.IDB, table, column, definition string) error {
+	exists, err := columnExists(ctx, idb, table, column)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+	_, err = idb.NewAddColumn().
+		Table(table).
+		ColumnExpr(column + " " + definition).
+		Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("adding column %s.%s: %w", table, column, err)
+	}
+	return nil
+}
+
+// createIndexIfMissing creates a (optionally unique) index over columns unless
+// an index of that name already exists. CREATE INDEX IF NOT EXISTS is not
+// available on MySQL, so this too goes via the catalogue.
+func createIndexIfMissing(ctx context.Context, idb bun.IDB, table, index string, unique bool, columns ...string) error {
+	exists, err := indexExists(ctx, idb, table, index)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+	q := idb.NewCreateIndex().Table(table).Index(index).Column(columns...)
+	if unique {
+		q = q.Unique()
+	}
+	if _, err := q.Exec(ctx); err != nil {
+		return fmt.Errorf("creating index %s on %s: %w", index, table, err)
+	}
+	return nil
+}
+
+// dropIndexIfPresent drops index when it exists. bun's DropIndexQuery emits a
+// bare "DROP INDEX <name>", which MySQL rejects (it requires "... ON <table>"),
+// so the statement is built per dialect.
+func dropIndexIfPresent(ctx context.Context, idb bun.IDB, table, index string) error {
+	exists, err := indexExists(ctx, idb, table, index)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+	stmt := "DROP INDEX " + index
+	if idb.Dialect().Name() == dialect.MySQL {
+		stmt += " ON " + table
+	}
+	if _, err := idb.ExecContext(ctx, stmt); err != nil {
+		return fmt.Errorf("dropping index %s on %s: %w", index, table, err)
+	}
+	return nil
+}
+
+// dropColumnIfPresent drops column when it exists.
+func dropColumnIfPresent(ctx context.Context, idb bun.IDB, table, column string) error {
+	exists, err := columnExists(ctx, idb, table, column)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+	if _, err := idb.NewDropColumn().Table(table).ColumnExpr(column).Exec(ctx); err != nil {
+		return fmt.Errorf("dropping column %s.%s: %w", table, column, err)
+	}
+	return nil
+}
+
+// columnExists reports whether table has a column named column. PostgreSQL and
+// MySQL both expose the standard information_schema; each scopes the lookup to
+// the connection's own schema so a same-named table elsewhere in the instance
+// cannot answer for ours. SQLite has no information_schema and answers from the
+// table-valued pragma instead.
+func columnExists(ctx context.Context, idb bun.IDB, table, column string) (bool, error) {
+	var query string
+	switch idb.Dialect().Name() {
+	case dialect.PG:
+		query = `SELECT COUNT(*) FROM information_schema.columns
+		         WHERE table_schema = CURRENT_SCHEMA() AND table_name = ? AND column_name = ?`
+	case dialect.MySQL:
+		query = `SELECT COUNT(*) FROM information_schema.columns
+		         WHERE table_schema = DATABASE() AND table_name = ? AND column_name = ?`
+	default: // SQLite
+		query = `SELECT COUNT(*) FROM pragma_table_info(?) WHERE name = ?`
+	}
+
+	var n int
+	if err := idb.NewRaw(query, table, column).Scan(ctx, &n); err != nil {
+		return false, fmt.Errorf("checking for column %s.%s: %w", table, column, err)
+	}
+	return n > 0, nil
+}
+
+// indexExists reports whether an index named index exists on table. Index names
+// are schema-scoped on PostgreSQL and table-scoped on MySQL/SQLite; each lookup
+// is scoped the way its dialect names things.
+func indexExists(ctx context.Context, idb bun.IDB, table, index string) (bool, error) {
+	var query string
+	switch idb.Dialect().Name() {
+	case dialect.PG:
+		query = `SELECT COUNT(*) FROM pg_indexes
+		         WHERE schemaname = CURRENT_SCHEMA() AND tablename = ? AND indexname = ?`
+	case dialect.MySQL:
+		query = `SELECT COUNT(*) FROM information_schema.statistics
+		         WHERE table_schema = DATABASE() AND table_name = ? AND index_name = ?`
+	default: // SQLite
+		query = `SELECT COUNT(*) FROM sqlite_master
+		         WHERE type = 'index' AND tbl_name = ? AND name = ?`
+	}
+
+	var n int
+	if err := idb.NewRaw(query, table, index).Scan(ctx, &n); err != nil {
+		return false, fmt.Errorf("checking for index %s on %s: %w", index, table, err)
+	}
+	return n > 0, nil
+}

--- a/internal/storage/sql_migrations_integration_test.go
+++ b/internal/storage/sql_migrations_integration_test.go
@@ -1,0 +1,67 @@
+// Copyright (C) 2026 Chris Boot
+// Copyright (C) 2026 Vox Pupuli and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+//go:build postgres_integration || mysql_integration
+
+package storage
+
+import (
+	"context"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// sqlMigrationsConcurrentRunners drives two independent backends through the
+// same pending migration at once, standing in for the signer and frontend
+// processes of one replica (or two replicas) starting together. Both must
+// succeed, and the migration must end up recorded exactly once: the incident
+// this guards against left two rows for one version and a schema stuck
+// part-way.
+//
+// This lives behind the integration tags because only PostgreSQL and MySQL have
+// a distributed lock to exercise. SQLite reports
+// ErrDistributedLockingUnsupported, so two backends on one file remain a real
+// race there — one that the transactional, idempotent migrations make
+// recoverable on the next start rather than one this test could assert on.
+func sqlMigrationsConcurrentRunners(newBackend func() *SQLBackend) {
+	ctx := context.Background()
+	runners := []*SQLBackend{newBackend(), newBackend()}
+
+	dropCertIndexSchema(ctx, runners[0], certIndexColumns)
+	_, err := runners[0].db.ExecContext(ctx, "DELETE FROM bun_migrations WHERE name = ?", certIndexVersion)
+	Expect(err).NotTo(HaveOccurred())
+
+	errs := make([]error, len(runners))
+	var wg sync.WaitGroup
+	wg.Add(len(runners))
+	for i, backend := range runners {
+		go func() {
+			defer GinkgoRecover()
+			defer wg.Done()
+			errs[i] = backend.EnsureReady(ctx)
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		Expect(err).NotTo(HaveOccurred(), "runner %d", i)
+	}
+	expectCertIndexSchema(ctx, runners[0])
+	expectOneRowPerMigration(ctx, runners[0])
+}

--- a/internal/storage/sql_migrations_test.go
+++ b/internal/storage/sql_migrations_test.go
@@ -133,6 +133,44 @@ var _ = Describe("SQL schema migrations", func() {
 		})
 	})
 
+	// The floor is the only thing between a small sql_max_open_conns and a
+	// startup deadlock: the distributed locks are session-scoped, so each one
+	// held occupies a connection while the work under it needs another. A
+	// deadlock is the worst failure to find in production, and no other spec
+	// would notice the clamp disappearing — the concurrency specs run with the
+	// default pool. Both networked dialects open lazily, so these construct a
+	// backend against an unreachable DSN and never connect.
+	Describe("the connection pool floor", func() {
+		DescribeTable("raises a pool too small for the locks to hold",
+			func(d SQLDialect, dsn string) {
+				b, err := NewSQLBackend(SQLConfig{Dialect: d, DSN: dsn, MaxOpenConns: 1})
+				Expect(err).NotTo(HaveOccurred())
+				DeferCleanup(func() { _ = b.Close() })
+				Expect(b.db.Stats().MaxOpenConnections).To(Equal(sqlMinOpenConns))
+			},
+			Entry("postgres", SQLPostgres, "postgres://u:p@127.0.0.1:1/db?sslmode=disable"),
+			Entry("mysql", SQLMySQL, "u:p@tcp(127.0.0.1:1)/db"),
+		)
+
+		It("leaves a pool above the floor as configured", func() {
+			b, err := NewSQLBackend(SQLConfig{
+				Dialect:      SQLPostgres,
+				DSN:          "postgres://u:p@127.0.0.1:1/db?sslmode=disable",
+				MaxOpenConns: 25,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(func() { _ = b.Close() })
+			Expect(b.db.Stats().MaxOpenConnections).To(Equal(25))
+		})
+
+		It("does not apply to SQLite, which is pinned to one connection", func() {
+			// SQLite reports ErrDistributedLockingUnsupported, so no connection
+			// is ever tied up by a lock and the single-writer pin still holds.
+			b := newSQLiteBackend()
+			Expect(b.db.Stats().MaxOpenConnections).To(Equal(1))
+		})
+	})
+
 	Describe("the inventory integrity read", func() {
 		// The startup integrity check reads the inventory before anything else
 		// touches the table. It must not depend on columns it has no use for, or

--- a/internal/storage/sql_migrations_test.go
+++ b/internal/storage/sql_migrations_test.go
@@ -1,0 +1,219 @@
+// Copyright (C) 2026 Chris Boot
+// Copyright (C) 2026 Vox Pupuli and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package storage
+
+import (
+	"context"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// certIndexVersion is the migration whose half-application these tests
+// reproduce; it is the name bun derives from 20260725000000_certindex.go.
+const certIndexVersion = "20260725000000"
+
+// certIndexColumns are the columns the certindex migration adds, in the order
+// it adds them.
+var certIndexColumns = []string{
+	"fingerprint_sha256", "dns_alt_names", "auth_extensions", "state", "revoked_at",
+}
+
+var certIndexIndices = []string{
+	"idx_puppet_ca_inventory_state", "idx_puppet_ca_inventory_not_after",
+}
+
+var _ = Describe("SQL schema migrations", func() {
+	ctx := context.Background()
+
+	Describe("catalogue lookups", func() {
+		It("reports columns and indices that do and do not exist", func() {
+			b := newSQLiteBackend()
+
+			for _, col := range certIndexColumns {
+				exists, err := columnExists(ctx, b.db, inventoryTableV1, col)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(exists).To(BeTrue(), "column %s should exist after migrating", col)
+			}
+			exists, err := columnExists(ctx, b.db, inventoryTableV1, "no_such_column")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeFalse())
+
+			for _, idx := range certIndexIndices {
+				exists, err := indexExists(ctx, b.db, inventoryTableV1, idx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(exists).To(BeTrue(), "index %s should exist after migrating", idx)
+			}
+			exists, err = indexExists(ctx, b.db, inventoryTableV1, "no_such_index")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeFalse())
+		})
+
+		It("does not confuse a column for an index of the same name", func() {
+			b := newSQLiteBackend()
+
+			exists, err := indexExists(ctx, b.db, inventoryTableV1, "state")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeFalse(), "state is a column, not an index")
+		})
+	})
+
+	Describe("recovering a half-applied migration", func() {
+		// Reproduces the schema drift seen in the field: the certindex migration
+		// was recorded as applied but only its first two ALTERs ran, so every
+		// later start failed reading the inventory and nothing ever retried the
+		// migration. Re-running it must finish the job rather than fail on the
+		// columns already there.
+		It("completes the remaining DDL when re-run", func() {
+			b := newSQLiteBackend()
+
+			// Rewind to the broken state: drop both indices and the last three
+			// columns (indices first, since SQLite will not drop a column one
+			// depends on), then forget the migration was ever applied.
+			dropCertIndexSchema(ctx, b, certIndexColumns[2:])
+			_, err := b.db.ExecContext(ctx, "DELETE FROM bun_migrations WHERE name = ?", certIndexVersion)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(b.EnsureReady(ctx)).To(Succeed())
+			expectCertIndexSchema(ctx, b)
+		})
+
+		It("leaves an already-complete schema alone", func() {
+			b := newSQLiteBackend()
+
+			_, err := b.db.ExecContext(ctx, "DELETE FROM bun_migrations")
+			Expect(err).NotTo(HaveOccurred())
+
+			// Every migration re-runs against the schema it already produced;
+			// each must be a no-op rather than an "already exists" failure.
+			Expect(b.EnsureReady(ctx)).To(Succeed())
+		})
+	})
+
+	Describe("concurrent runners", func() {
+		It("serialises callers sharing a backend", func() {
+			b := newSQLiteBackend()
+
+			_, err := b.db.ExecContext(ctx, "DELETE FROM bun_migrations")
+			Expect(err).NotTo(HaveOccurred())
+
+			const runners = 4
+			errs := make([]error, runners)
+			var wg sync.WaitGroup
+			wg.Add(runners)
+			for i := range runners {
+				go func() {
+					defer GinkgoRecover()
+					defer wg.Done()
+					errs[i] = b.EnsureReady(ctx)
+				}()
+			}
+			wg.Wait()
+
+			for i, err := range errs {
+				Expect(err).NotTo(HaveOccurred(), "runner %d", i)
+			}
+			expectOneRowPerMigration(ctx, b)
+		})
+	})
+
+	Describe("the inventory integrity read", func() {
+		// The startup integrity check reads the inventory before anything else
+		// touches the table. It must not depend on columns it has no use for, or
+		// unrelated schema drift surfaces as a bogus tampering error.
+		It("does not select the certificate index columns", func() {
+			b := newSQLiteBackend()
+
+			Expect(b.AppendEntry(ctx, CertRecord{
+				InventoryEntry: InventoryEntry{
+					Serial:    "0x1",
+					Subject:   "/CN=node.example.com",
+					NotBefore: "2026-01-01T00:00:00UTC",
+					NotAfter:  "2031-01-01T00:00:00UTC",
+				},
+				State: CertStateSigned,
+			}, nil)).To(Succeed())
+
+			dropCertIndexSchema(ctx, b, certIndexColumns)
+
+			entries, err := b.Entries(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(entries).To(HaveLen(1))
+			Expect(entries[0].Serial).To(Equal("0x1"))
+			Expect(entries[0].Subject).To(Equal("/CN=node.example.com"))
+		})
+	})
+})
+
+// dropCertIndexSchema removes the certindex indices and the named columns,
+// undoing part or all of that migration so a re-run has something to do. Indices
+// go first: SQLite refuses to drop a column an index is built on. The drops go
+// through the migrations' own dialect-aware helpers, then are verified, so a
+// helper that quietly did nothing cannot leave the caller asserting against a
+// schema that was never disturbed.
+func dropCertIndexSchema(ctx context.Context, b *SQLBackend, columns []string) {
+	GinkgoHelper()
+
+	for _, idx := range certIndexIndices {
+		Expect(dropIndexIfPresent(ctx, b.db, inventoryTableV1, idx)).To(Succeed(), "dropping index %s", idx)
+	}
+	for _, col := range columns {
+		Expect(dropColumnIfPresent(ctx, b.db, inventoryTableV1, col)).To(Succeed(), "dropping column %s", col)
+
+		exists, err := columnExists(ctx, b.db, inventoryTableV1, col)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(exists).To(BeFalse(), "column %s should be gone", col)
+	}
+}
+
+// expectCertIndexSchema asserts the certindex migration has fully applied.
+func expectCertIndexSchema(ctx context.Context, b *SQLBackend) {
+	GinkgoHelper()
+
+	for _, col := range certIndexColumns {
+		exists, err := columnExists(ctx, b.db, inventoryTableV1, col)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(exists).To(BeTrue(), "column %s missing", col)
+	}
+	for _, idx := range certIndexIndices {
+		exists, err := indexExists(ctx, b.db, inventoryTableV1, idx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(exists).To(BeTrue(), "index %s missing", idx)
+	}
+}
+
+// expectOneRowPerMigration asserts that every applied migration is recorded
+// exactly once. Duplicate rows are the fingerprint of two runners having read
+// the migration state at the same time.
+func expectOneRowPerMigration(ctx context.Context, b *SQLBackend) {
+	GinkgoHelper()
+
+	var names []string
+	err := b.db.NewRaw("SELECT name FROM bun_migrations ORDER BY name").Scan(ctx, &names)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(names).NotTo(BeEmpty())
+
+	seen := make(map[string]int, len(names))
+	for _, n := range names {
+		seen[n]++
+	}
+	for name, count := range seen {
+		Expect(count).To(Equal(1), "migration %s recorded %d times", name, count)
+	}
+}

--- a/internal/storage/sql_mysql_integration_test.go
+++ b/internal/storage/sql_mysql_integration_test.go
@@ -270,3 +270,9 @@ var _ = Describe("MySQL CertIndex", func() {
 		certIndexMigrationRollback(newMySQLBackend())
 	})
 })
+
+var _ = Describe("MySQL schema migrations", func() {
+	It("survives two backends migrating the same database at once", func() {
+		sqlMigrationsConcurrentRunners(newMySQLBackend)
+	})
+})

--- a/internal/storage/sql_mysql_integration_test.go
+++ b/internal/storage/sql_mysql_integration_test.go
@@ -260,3 +260,13 @@ var _ = Describe("MySQL EndToEndViaStorageService", func() {
 		Expect(csrs[0]).To(Equal("node1"), "ListCSRs = %v, want [node1]", csrs)
 	})
 })
+
+var _ = Describe("MySQL CertIndex", func() {
+	It("round-trips the certificate index end to end", func() {
+		certIndexRoundTrip(newMySQLBackend())
+	})
+
+	It("survives a migration rollback and re-apply", func() {
+		certIndexMigrationRollback(newMySQLBackend())
+	})
+})

--- a/internal/storage/sql_postgres_integration_test.go
+++ b/internal/storage/sql_postgres_integration_test.go
@@ -243,3 +243,13 @@ var _ = Describe("Postgres EndToEndViaStorageService", func() {
 		Expect(csrs[0]).To(Equal("node1"), "ListCSRs = %v, want [node1]", csrs)
 	})
 })
+
+var _ = Describe("Postgres CertIndex", func() {
+	It("round-trips the certificate index end to end", func() {
+		certIndexRoundTrip(newPostgresBackend())
+	})
+
+	It("survives a migration rollback and re-apply", func() {
+		certIndexMigrationRollback(newPostgresBackend())
+	})
+})

--- a/internal/storage/sql_postgres_integration_test.go
+++ b/internal/storage/sql_postgres_integration_test.go
@@ -253,3 +253,9 @@ var _ = Describe("Postgres CertIndex", func() {
 		certIndexMigrationRollback(newPostgresBackend())
 	})
 })
+
+var _ = Describe("Postgres schema migrations", func() {
+	It("survives two backends migrating the same database at once", func() {
+		sqlMigrationsConcurrentRunners(newPostgresBackend)
+	})
+})

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -191,6 +191,16 @@ var ErrDuplicateSerial = errors.New("serial number already exists in inventory")
 // and the whole-blob HMAC is recomputed. Returns ErrDuplicateSerial (wrapped)
 // if the entry's serial is already present anywhere in the inventory.
 func (s *StorageService) AppendInventory(ctx context.Context, entry string) error {
+	return s.AppendInventoryRecord(ctx, entry, nil)
+}
+
+// AppendInventoryRecord is AppendInventory with an optional certificate-index
+// projection. Issuance paths (signing, import) pass the display fields
+// denormalised from the certificate they just stored; backends with the
+// CertIndex capability persist them on the new row (state "signed"), all
+// others ignore them. A nil proj records the entry without a projection,
+// which index readers treat as "fall back to the stored PEM".
+func (s *StorageService) AppendInventoryRecord(ctx context.Context, entry string, proj *CertProjection) error {
 	s.inventoryMu.Lock()
 	defer s.inventoryMu.Unlock()
 
@@ -200,12 +210,16 @@ func (s *StorageService) AppendInventory(ctx context.Context, entry string) erro
 	}
 
 	if store, ok := asInventoryStore(s.backend); ok {
+		rec := CertRecord{InventoryEntry: parsed, State: CertStateSigned}
+		if proj != nil {
+			rec.CertProjection = *proj
+		}
 		var newHead func(prev []byte) []byte
 		if s.hmacKey != nil {
 			key := s.hmacKey
 			newHead = func(prev []byte) []byte { return chainInventoryMAC(key, prev, entry) }
 		}
-		if err := store.AppendEntry(ctx, parsed, newHead); err != nil {
+		if err := store.AppendEntry(ctx, rec, newHead); err != nil {
 			if isUniqueSerialViolation(err) {
 				return fmt.Errorf("%w: %s", ErrDuplicateSerial, parsed.Serial)
 			}
@@ -425,6 +439,59 @@ func (s *StorageService) PruneInventory(ctx context.Context, keep func(Inventory
 		}
 	}
 	return removed, nil
+}
+
+// --- Certificate index ---
+//
+// The methods below expose the optional CertIndex backend capability. On
+// backends without it they degrade gracefully: reads report ok=false so the
+// caller keeps its list-and-parse path, writes are silent no-ops. The index is
+// a projection of authoritative artefacts (certificate PEMs, the signed CRL),
+// so a lost index write is at worst a stale display value that the CA's index
+// repair pass reconciles at the next startup.
+
+// CertStatuses answers the certificate-status listing from the certificate
+// index. ok reports whether the backend has the capability at all; when false
+// the caller must fall back to enumerating and parsing the stored PEMs.
+// stateFilter narrows the records to CertStateSigned or CertStateRevoked; ""
+// returns everything the index tracks.
+func (s *StorageService) CertStatuses(ctx context.Context, stateFilter string) (records []CertRecord, ok bool, err error) {
+	idx, ok := asCertIndex(s.backend)
+	if !ok {
+		return nil, false, nil
+	}
+	records, err = idx.Statuses(ctx, stateFilter)
+	return records, true, err
+}
+
+// MarkCertRevoked projects a revocation into the certificate index; no-op
+// when the backend has no index.
+func (s *StorageService) MarkCertRevoked(ctx context.Context, serial string, at time.Time) error {
+	idx, ok := asCertIndex(s.backend)
+	if !ok {
+		return nil
+	}
+	return idx.SetRevoked(ctx, serial, at)
+}
+
+// ClearCertRevoked removes a revocation projection from the certificate
+// index; no-op when the backend has no index.
+func (s *StorageService) ClearCertRevoked(ctx context.Context, serial string) error {
+	idx, ok := asCertIndex(s.backend)
+	if !ok {
+		return nil
+	}
+	return idx.ClearRevoked(ctx, serial)
+}
+
+// SetCertProjection backfills the denormalised display fields for serial in
+// the certificate index; no-op when the backend has no index.
+func (s *StorageService) SetCertProjection(ctx context.Context, serial string, proj CertProjection) error {
+	idx, ok := asCertIndex(s.backend)
+	if !ok {
+		return nil
+	}
+	return idx.SetProjection(ctx, serial, proj)
 }
 
 // TouchInventory creates an empty inventory blob if one does not already


### PR DESCRIPTION
Implements #137: the structured inventory table (`puppet_ca_inventory`) now doubles as a certificate index, and SQL backends advertise a new optional `CertIndex` capability that lets `GET /certificate_statuses` collapse from an O(N) *list-certs → read-PEM → parse → CRL-check* scan into indexed queries. Blob backends (filesystem, etcd, Redis) keep the existing scan path verbatim via the same capability-probe pattern as `InventoryStore`/`Locker` — no REST contract changes anywhere.

Following the leanings in the issue's open questions:

1. **Display fields are denormalised** (`fingerprint_sha256`, `dns_alt_names`, `auth_extensions`, filled at signing). They are immutable for the life of the cert, so they cannot drift from the PEM; the PEM stays the authoritative artefact.
2. **`state`/`revoked_at` are a projection of the signed CRL**, written by the revoke path right after the CRL is re-signed (log-and-continue on failure, including the already-revoked retry branch). The CRL remains the source of truth.
3. **Rebuildability is enforced, not just claimed**: CA startup runs an index repair pass that backfills projections from stored PEMs (refusing serial mismatches) and reconciles revocation state against the CRL in both directions. This is also what converges an index populated by `storage migrate` from a blob backend, whose imported rows arrive projection-less; until repair runs, the handler falls back to the PEM per projection-less record.

Design points worth reviewer attention:

- **Integrity chain coverage is unchanged.** The hash chain still covers only the canonical inventory line. Chaining the new columns would add nothing: each one is independently verifiable against a signed artefact (PEM or CRL).
- **`Statuses` is gated on blob existence and returns only the latest issuance per subject**, so cleaned or superseded historical rows are never listed and the output matches what the scan path would have produced. The API suite pins the index path to values derived from the stored PEM — the exact artefact the fallback would have parsed.
- **Migration hygiene:** the 20260201 migration is frozen onto a v1 copy of the row model so fresh databases create the original shape and replay the new ALTERs, identically to databases upgraded in place. The down migration avoids bun's `DropIndexQuery`, which emits bare `DROP INDEX` (invalid on MySQL). Both directions plus a full index round-trip run against SQLite, PostgreSQL and MySQL in the unit/integration suites.
- **Shared field producers:** the colon-separated SHA-256 fingerprint and the auth-extension display map now have single producers (`ca.SHA256ColonFingerprint`, `ca.AuthExtensionMap`) used by both the status API and the index projection, so the two cannot disagree on format.
- **`CertRecord` is the shared struct** the etcd/Redis decompositions (#138/#139) would project into, per the issue's note to settle it once.

**FIPS/crypto note:** no new dependencies; the only crypto touched is `crypto/sha256` and `crypto/x509` from the standard library, on paths that already used them (fingerprinting and cert parsing), so the boringcrypto contract is unaffected.

Closes #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)