### PR TITLE
Decompose the etcd inventory into per-entry keys (InventoryStore/CertIndex)

### DIFF
--- a/cmd/openvox-ca/cert_cleanup.go
+++ b/cmd/openvox-ca/cert_cleanup.go
@@ -65,7 +65,10 @@ func cleanupExpiredOnce(ctx context.Context, c *ca.CA, retain time.Duration) {
 	removed, err := c.CleanupExpiredCerts(ctx, retain)
 	switch {
 	case err != nil:
-		slog.Warn("Expired-certificate cleanup failed", "error", err)
+		// removed can be non-zero here: a batched backend (etcd) may have
+		// durably pruned entries before failing, and the operator needs to
+		// know state changed permanently despite the error.
+		slog.Warn("Expired-certificate cleanup failed", "removed", removed, "error", err)
 	case removed > 0:
 		slog.Info("Expired certificates cleaned up", "removed", removed)
 	default:

--- a/docs/development/inventory-store.md
+++ b/docs/development/inventory-store.md
@@ -215,39 +215,56 @@ Rules that keep the decomposed structure coherent:
 - **Appends are O(1)** — six puts guarded on the fence plus
   `CreateRevision(by-serial/<serial>) == 0`, which makes duplicate-serial
   rejection atomic cluster-wide (previously a SQL-only guarantee).
-- **Bulk rewrites are batched but every commit is consistent.** Prunes and
-  imports larger than one transaction (bounded well under etcd's default
-  `--max-txn-ops` of 128) are split into batches, and each batch writes a head
-  covering exactly the entries that remain after it. A concurrent verifier
-  never sees entries and head out of sync, and a crash mid-prune leaves a
-  valid, partially-pruned inventory rather than a spurious tamper alarm.
-  Because a batched prune can partially complete, `PruneEntries` returns every
-  entry actually removed — accumulated across batches and retries, even
-  alongside an error — so `CleanupExpiredCerts` can always finish the CRL and
-  blob cleanup for what was deleted (see the contract in `backend.go`). Prune
-  batches run newest-first, which keeps the intermediate heads cheap: each is
-  a cached prefix fold over the untouched older entries resumed across the
-  survivor tail, rather than a full refold per batch.
+- **Bulk rewrites are batched; prune commits are individually consistent.**
+  Prunes and imports larger than one transaction (bounded well under etcd's
+  default `--max-txn-ops` of 128) are split into batches. Each *prune* batch
+  writes a head covering exactly the entries that remain after it, so a
+  concurrent verifier never sees entries and head out of sync and a crash
+  mid-prune leaves a valid, partially-pruned inventory rather than a spurious
+  tamper alarm. *Import* batches carry no head at all — the head is left for
+  `RebuildInventoryHMAC` (migration) or dropped in the final commit (legacy
+  conversion) — which is exactly why the legacy blob stays authoritative
+  until the import's final commit and why the marker-guard/resume machinery
+  exists. Because a batched prune can partially complete, `PruneEntries`
+  returns every entry actually removed — accumulated across batches and
+  retries, even alongside an error — so `CleanupExpiredCerts` can always
+  finish the CRL and blob cleanup for what was deleted (see the contract in
+  `backend.go`). Prune batches run newest-first, which keeps the intermediate
+  heads cheap (each is a cached prefix fold over the untouched older entries
+  resumed across the survivor tail), and one call removes at most a bounded
+  number of batches so a huge backlog cannot blow the caller's lock budget —
+  deferred matches stay present and consistent for later runs.
 - **Legacy blobs are decomposed in place.** `EnsureReady` detects a non-empty
   pre-decomposition `inventory/data` blob, takes a distributed lock
   (`inventory-decompose`), verifies the blob against its stored whole-blob
-  HMAC (the key is a backend blob, so it is available; a mismatch fails
-  startup with `ErrInventoryTampered` exactly as the old code would have),
-  imports the lines into entry keys, and empties the marker only in the final
-  commit. The verified HMAC is deleted in the same import — it is not a chain
-  head, so it cannot carry over — and the next verification re-baselines from
-  the imported entries; only the import window itself is uncovered. Because
-  the blob stays authoritative until that final commit, an interrupted import
-  is detected on the next start (the partial entries are the import-written
-  prefix of the blob) and redone from the intact blob; entries that are *not*
-  such a prefix mean a mixed-version cluster wrote both forms, which is
-  refused with an explicit error rather than guessed at. Duplicate serials in
-  the legacy blob — possible, since blob backends never had a cluster-wide
-  uniqueness guarantee — are imported verbatim with a warning, with the
-  by-serial index pointing at each serial's newest bearer. All replicas must
-  still upgrade together: an old-version writer appending to the blob
-  mid-import is detected via the marker guard and the import restarts, but
-  the race only closes once the old writers are gone.
+  HMAC (the key is a backend blob, so it is available), imports the lines
+  into entry keys, and empties the marker only in the final commit.
+  Verification is fail-closed: a mismatch — or a stored HMAC that cannot be
+  verified because the key is missing or malformed — fails startup with
+  `ErrInventoryTampered`, exactly as the pre-decomposition code would have;
+  the operator acknowledges a lost baseline by deleting the stored
+  `inventory/hmac` key. The verified HMAC is deleted in the same import — it
+  is not a chain head, so it cannot carry over — and the next verification
+  re-baselines from the imported entries; only the import window itself is
+  uncovered. A CA upgraded while its inventory is *empty* has no import to
+  drop the head as part of, so `EnsureReady` handles that case separately:
+  when zero entries exist and the stored head verifies as the whole-blob MAC
+  of an empty inventory, it is deleted so the first verification re-baselines
+  cleanly (any other head over zero entries is left for verification to
+  flag). Because the blob stays authoritative until the import's final
+  commit, an interrupted import is detected on the next start (the partial
+  entries are the import-written prefix of the blob) and redone from the
+  intact blob; entries that are *not* such a prefix mean a mixed-version
+  cluster wrote both forms, which is refused with an explicit error rather
+  than guessed at. Duplicate serials in the legacy blob — possible, since
+  blob backends never had a cluster-wide uniqueness guarantee — are imported
+  verbatim with a warning; their by-serial keys carry an ambiguity sentinel
+  that keeps the serial reserved against reissue but makes certificate-index
+  writes for it explicit no-ops, since a one-to-one index cannot say which
+  bearer such a write is meant for. All replicas must still upgrade together:
+  an old-version writer appending to the blob mid-import is detected via the
+  marker guard and the import restarts, but the race only closes once the old
+  writers are gone.
 - **Certificate-index writes stay off the chain.** `SetRevoked` /
   `ClearRevoked` / `SetProjection` rewrite a single entry key guarded on its
   own ModRevision (the mutable fields are not chain input), so index repair

--- a/docs/development/inventory-store.md
+++ b/docs/development/inventory-store.md
@@ -261,7 +261,10 @@ Rules that keep the decomposed structure coherent:
   verbatim with a warning; their by-serial keys carry an ambiguity sentinel
   that keeps the serial reserved against reissue but makes certificate-index
   writes for it explicit no-ops, since a one-to-one index cannot say which
-  bearer such a write is meant for. All replicas must still upgrade together:
+  bearer such a write is meant for. `Statuses` reports those records with
+  `CertStateUnknown`, the statuses handler derives their real state from the
+  signed CRL, and the startup repair pass skips them (they can never
+  converge). All replicas must still upgrade together:
   an old-version writer appending to the blob mid-import is detected via the
   marker guard and the import restarts, but the race only closes once the old
   writers are gone.

--- a/docs/development/inventory-store.md
+++ b/docs/development/inventory-store.md
@@ -221,15 +221,33 @@ Rules that keep the decomposed structure coherent:
   covering exactly the entries that remain after it. A concurrent verifier
   never sees entries and head out of sync, and a crash mid-prune leaves a
   valid, partially-pruned inventory rather than a spurious tamper alarm.
+  Because a batched prune can partially complete, `PruneEntries` returns every
+  entry actually removed — accumulated across batches and retries, even
+  alongside an error — so `CleanupExpiredCerts` can always finish the CRL and
+  blob cleanup for what was deleted (see the contract in `backend.go`). Prune
+  batches run newest-first, which keeps the intermediate heads cheap: each is
+  a cached prefix fold over the untouched older entries resumed across the
+  survivor tail, rather than a full refold per batch.
 - **Legacy blobs are decomposed in place.** `EnsureReady` detects a non-empty
-  pre-decomposition `inventory/data` blob, takes a distributed lock, imports
-  the lines into entry keys, and empties the marker. The stored whole-blob
-  HMAC is deleted in the same import: it is not a chain head and the backend
-  does not hold the key to translate it, so the next verification re-baselines
-  from the imported entries. Tamper detection therefore does not cover the
-  decomposition window itself — and all replicas must upgrade together, since
-  an old-version writer appending to the blob mid-import is detected and
-  retried, but the race only closes once the old writers are gone.
+  pre-decomposition `inventory/data` blob, takes a distributed lock
+  (`inventory-decompose`), verifies the blob against its stored whole-blob
+  HMAC (the key is a backend blob, so it is available; a mismatch fails
+  startup with `ErrInventoryTampered` exactly as the old code would have),
+  imports the lines into entry keys, and empties the marker only in the final
+  commit. The verified HMAC is deleted in the same import — it is not a chain
+  head, so it cannot carry over — and the next verification re-baselines from
+  the imported entries; only the import window itself is uncovered. Because
+  the blob stays authoritative until that final commit, an interrupted import
+  is detected on the next start (the partial entries are the import-written
+  prefix of the blob) and redone from the intact blob; entries that are *not*
+  such a prefix mean a mixed-version cluster wrote both forms, which is
+  refused with an explicit error rather than guessed at. Duplicate serials in
+  the legacy blob — possible, since blob backends never had a cluster-wide
+  uniqueness guarantee — are imported verbatim with a warning, with the
+  by-serial index pointing at each serial's newest bearer. All replicas must
+  still upgrade together: an old-version writer appending to the blob
+  mid-import is detected via the marker guard and the import restarts, but
+  the race only closes once the old writers are gone.
 - **Certificate-index writes stay off the chain.** `SetRevoked` /
   `ClearRevoked` / `SetProjection` rewrite a single entry key guarded on its
   own ModRevision (the mutable fields are not chain input), so index repair
@@ -274,3 +292,9 @@ Each phase is a separate commit.
    backends: latest-wins lookups, chain tamper detection (modify / insert /
    delete), byte-identical render, and a filesystem ⇄ sqlite migration
    round-trip that verifies integrity on both sides.
+5. **Certificate index** (issue #137, a later extension). Extend the SQL
+   inventory table with the projection/state columns, define `CertIndex`,
+   serve `certificate_statuses` from it, and add the startup repair pass.
+6. **etcd decomposition** (issue #138, a later extension). Implement
+   `InventoryStore` and `CertIndex` on the etcd backend with per-entry keys,
+   including the in-place legacy blob conversion described above.

--- a/docs/development/inventory-store.md
+++ b/docs/development/inventory-store.md
@@ -35,8 +35,9 @@ an internal and on-disk-compatibility concern only.
 ## Goal
 
 Let backends that can do better store the inventory as **structured records**
-(e.g. a SQL table) while preserving exact behaviour for backends that keep the
-blob (filesystem, etcd, redis/valkey). This is opt-in per backend.
+(e.g. a SQL table, or one etcd key per entry) while preserving exact behaviour
+for backends that keep the blob (filesystem, redis/valkey). This is opt-in per
+backend.
 
 ## Design
 
@@ -183,15 +184,69 @@ Design rules that keep the index honest:
   `cert/<subject>` blob still exists, and only their latest issuance —
   matching what the scan path would have listed.
 
+### The etcd decomposition
+
+The etcd backend implements both capabilities too (issue #138), with a key
+layout that plays to etcd's strengths — a sorted keyspace and multi-key
+compare-then-op transactions:
+
+```text
+<prefix>/inventory/entries/<seq>       one JSON CertRecord per issuance;
+                                       <seq> is zero-padded so a range scan
+                                       returns issuance order
+<prefix>/inventory/seq                 last allocated sequence number; doubles
+                                       as the mutation fence (below)
+<prefix>/inventory/by-serial/<serial>  serial → seq; existence is the atomic
+                                       duplicate-serial guard
+<prefix>/inventory/by-subject/<subj>   subject → latest serial (O(1) lookup)
+<prefix>/inventory/data                presence marker for the KeyInventory
+                                       logical key (empty payload)
+<prefix>/inventory/hmac                chain head, unchanged logical key
+```
+
+Rules that keep the decomposed structure coherent:
+
+- **One fence, guarded everywhere.** etcd transactions cannot read-compute-
+  write, so `chainInventoryMAC` runs in Go between a read and a guarded
+  commit. Every mutating transaction — append, prune batch, import batch —
+  both *guards on* and *re-puts* `inventory/seq`, so any interleaved writer
+  (same or another replica) invalidates the guard and forces a re-read. This
+  is the same optimistic ModRevision-retry shape the blob append already used.
+- **Appends are O(1)** — six puts guarded on the fence plus
+  `CreateRevision(by-serial/<serial>) == 0`, which makes duplicate-serial
+  rejection atomic cluster-wide (previously a SQL-only guarantee).
+- **Bulk rewrites are batched but every commit is consistent.** Prunes and
+  imports larger than one transaction (bounded well under etcd's default
+  `--max-txn-ops` of 128) are split into batches, and each batch writes a head
+  covering exactly the entries that remain after it. A concurrent verifier
+  never sees entries and head out of sync, and a crash mid-prune leaves a
+  valid, partially-pruned inventory rather than a spurious tamper alarm.
+- **Legacy blobs are decomposed in place.** `EnsureReady` detects a non-empty
+  pre-decomposition `inventory/data` blob, takes a distributed lock, imports
+  the lines into entry keys, and empties the marker. The stored whole-blob
+  HMAC is deleted in the same import: it is not a chain head and the backend
+  does not hold the key to translate it, so the next verification re-baselines
+  from the imported entries. Tamper detection therefore does not cover the
+  decomposition window itself — and all replicas must upgrade together, since
+  an old-version writer appending to the blob mid-import is detected and
+  retried, but the race only closes once the old writers are gone.
+- **Certificate-index writes stay off the chain.** `SetRevoked` /
+  `ClearRevoked` / `SetProjection` rewrite a single entry key guarded on its
+  own ModRevision (the mutable fields are not chain input), so index repair
+  cannot fork the integrity head.
+
 ## Scope
 
 - **SQL backend** (sqlite/postgres/mysql) implements `InventoryStore` with a
   dedicated `puppet_ca_inventory` table indexed on `subject` (and a unique index
   on `serial`, since serials never repeat), plus the render/parse shim. This is
   where decomposition pays off.
-- **Filesystem, etcd, redis/valkey keep the blob.** They do not implement the
+- **etcd** implements `InventoryStore` and `CertIndex` with per-entry keys —
+  see [The etcd decomposition](#the-etcd-decomposition) above.
+- **Filesystem and redis/valkey keep the blob.** They do not implement the
   interface; the type assertion fails and they behave exactly as before. Adding
-  the capability to etcd/redis later is possible but not currently motivated.
+  the capability to redis later is possible (issue #139) but not currently
+  motivated.
 - **Wrapper backends unwrap to their base.** The probe is `asInventoryStore`,
   not a bare `s.backend.(InventoryStore)`: it sees through wrappers such as
   `OverlayBackend` (the `ca_cert_file`/`ca_key_file` local-override wrapper) via

--- a/docs/development/storage-internals.md
+++ b/docs/development/storage-internals.md
@@ -59,7 +59,7 @@ With the default prefix `/puppet-ca`:
 | `ca_key` | `/puppet-ca/ca/key` |
 | `crl` | `/puppet-ca/ca/crl` |
 | `serial` | `/puppet-ca/serial` |
-| `inventory` | `/puppet-ca/inventory/data` |
+| `inventory` | `/puppet-ca/inventory/data` (presence marker only; see below) |
 | `inventory_hmac` | `/puppet-ca/inventory/hmac` |
 | `hmac_key` | `/puppet-ca/private/hmac_key` |
 | `csr/<subject>` | `/puppet-ca/requests/<subject>` |
@@ -69,11 +69,19 @@ Stored values carry an 8-byte big-endian `time.UnixNano` mtime prefix so
 `GET /puppet-ca/v1/certificate_revocation_list/ca` still answers
 `If-Modified-Since` without a second round-trip.
 
-Inventory appends use an etcd transaction guarded on the key's `ModRevision`
-with bounded retry, so concurrent appends across replicas don't lose lines.
-When two replicas race to bootstrap, etcd's compare-and-swap semantics prevent
-double-writes of `ca/cert` and `ca/key`; the loser observes the winner's cert
-and continues.
+The certificate inventory is not stored at `inventory/data` — that key is only
+a presence marker (and the location pre-decomposition versions kept the blob).
+The inventory itself is decomposed into one key per issued certificate under
+`inventory/entries/<seq>`, with `inventory/seq` acting as sequence allocator
+and mutation fence and `inventory/by-serial/<serial>` /
+`inventory/by-subject/<subject>` as index keys. Appends are transactions
+guarded on the fence's `ModRevision` with bounded retry, so concurrent
+appends across replicas lose nothing and duplicate serials are rejected
+cluster-wide. See
+[the inventory store](inventory-store.md#the-etcd-decomposition) for the full
+key family and the rules that keep it coherent. When two replicas race to
+bootstrap, etcd's compare-and-swap semantics prevent double-writes of
+`ca/cert` and `ca/key`; the loser observes the winner's cert and continues.
 
 ### Cross-node coordination
 
@@ -88,6 +96,7 @@ grabs per-name mutexes under `<prefix>/locks/<name>`:
 | `bootstrap` | First-run CA generation (winner writes, loser loads) |
 | `crl` | `Revoke` (read CRL, append entry, write CRL) |
 | `subject:<subject>` | `SaveRequest` and `Sign` for that one subject |
+| `inventory-decompose` | One-time legacy inventory blob conversion on the first start after upgrading |
 
 If a replica holding a lock crashes without calling Unlock, the etcd lease
 expires after 30s and the lock is released automatically. For the filesystem

--- a/docs/development/storage-internals.md
+++ b/docs/development/storage-internals.md
@@ -18,7 +18,7 @@ interface. Every backend serves the following logical keys:
 | `crl` | Current Certificate Revocation List (PEM) | bootstrap, revoke, rotate |
 | `serial` | Next leaf certificate serial counter | sign |
 | `inventory` | Append-only log of issued/revoked certificates | sign / revoke |
-| `inventory_hmac` | Inventory integrity head (blob HMAC or hash chain on SQL) | sign / revoke |
+| `inventory_hmac` | Inventory integrity head (blob HMAC, or hash chain on the structured backends: SQL, etcd) | sign / revoke |
 | `hmac_key` | Integrity key for `inventory_hmac` | first run |
 | `csr/<subject>` | Pending certificate signing request (PEM), per subject | CSR submission |
 | `cert/<subject>` | Issued certificate (PEM), per subject | sign |

--- a/docs/storage-backends.md
+++ b/docs/storage-backends.md
@@ -166,10 +166,23 @@ etcd_tls_key_file:  /etc/puppet-ca/etcd-client-key.pem
   etcd transaction are split into multiple transactions; batch sizes stay
   well under etcd's default `--max-txn-ops` (128), so no cluster tuning is
   needed. Every *prune* transaction leaves the inventory and its integrity
-  head consistent, and a single cleanup pass bounds how many entries it
-  removes so a large backlog drains over several runs rather than stalling
-  signing; an in-progress *conversion* is instead covered by the
-  blob-stays-authoritative resume behaviour described above.
+  head consistent, and a single expired-certificate cleanup pass removes at
+  most 900 entries so a large backlog drains over several runs rather than
+  stalling signing. At the default daily cleanup interval that is 900
+  entries/day: enabling cleanup for the first time on a large backlog, or
+  running a fleet whose expiry churn exceeds it, calls for a shorter
+  `expired_cert_cleanup_interval_sec` — the server logs a warning when a
+  single pass cannot keep up. An in-progress *conversion* is instead covered
+  by the blob-stays-authoritative resume behaviour described above.
+- **Legacy inventories with duplicate serial numbers** (possible, because the
+  pre-conversion blob had no cluster-wide uniqueness guarantee) are imported
+  verbatim with a startup warning naming the serials. The certificate index
+  cannot track per-serial state for them, so their status in
+  `certificate_statuses` output is derived from the signed CRL on each
+  request (always correct, slightly slower) and their display fields come
+  from the stored certificate. This resolves itself once the affected
+  certificates expire and are cleaned up, or when they are revoked and
+  reissued under fresh serials.
 
 ---
 

--- a/docs/storage-backends.md
+++ b/docs/storage-backends.md
@@ -138,6 +138,19 @@ etcd_tls_key_file:  /etc/puppet-ca/etcd-client-key.pem
 - **`openvox-ca-ctl setup` / `import` work on the local filesystem only.** To
   import a CA into an etcd-backed cluster, run them against a scratch directory
   first, then point `openvox-ca` at a cadir containing the output.
+- **The certificate inventory is stored as one etcd key per issued
+  certificate**, not as a single ever-growing text blob, so signing cost does
+  not grow with the size of the inventory and duplicate serial numbers are
+  rejected atomically across all replicas (see
+  [the inventory internals](development/inventory-store.md)). On first start
+  after upgrading from a version that stored the inventory as a blob, the
+  backend converts it in place automatically. **Upgrade all replicas
+  together**: a not-yet-upgraded replica writing the old blob format while an
+  upgraded one serves the converted inventory is not supported.
+- **Bulk inventory rewrites are batched.** Imports and prunes larger than one
+  etcd transaction are split into multiple transactions, each of which leaves
+  the inventory and its integrity head consistent; batch sizes stay well under
+  etcd's default `--max-txn-ops` (128), so no cluster tuning is needed.
 
 ---
 

--- a/docs/storage-backends.md
+++ b/docs/storage-backends.md
@@ -144,9 +144,21 @@ etcd_tls_key_file:  /etc/puppet-ca/etcd-client-key.pem
   rejected atomically across all replicas (see
   [the inventory internals](development/inventory-store.md)). On first start
   after upgrading from a version that stored the inventory as a blob, the
-  backend converts it in place automatically. **Upgrade all replicas
-  together**: a not-yet-upgraded replica writing the old blob format while an
-  upgraded one serves the converted inventory is not supported.
+  backend converts it in place automatically: the blob is first verified
+  against its stored HMAC (a mismatch fails startup, exactly as it would have
+  before the upgrade), and after the conversion the integrity value is
+  re-established over the converted entries — the conversion window itself is
+  the one moment tamper detection does not cover. An interrupted conversion
+  resumes safely on the next start. **Upgrade all replicas together**: a
+  not-yet-upgraded replica writing the old blob format while an upgraded one
+  serves the converted inventory is not supported and is refused with an
+  explicit error when detected.
+- **The etcd backend also maintains the certificate index**: `GET
+  /certificate_statuses` (`puppetserver ca list`) is answered from the
+  decomposed inventory entries instead of reading and parsing every stored
+  certificate, with the same rebuildable-projection semantics as the SQL
+  backends — after migrating from another backend the display fields are
+  backfilled automatically on the next server start.
 - **Bulk inventory rewrites are batched.** Imports and prunes larger than one
   etcd transaction are split into multiple transactions, each of which leaves
   the inventory and its integrity head consistent; batch sizes stay well under
@@ -276,12 +288,12 @@ backend creates and upgrades its own tables automatically on startup, so
 multiple replicas can start against the same database safely. `cadir` is still
 required for per-subject keys and ancillary local state.
 
-SQL backends additionally maintain a certificate index: `GET
-/certificate_statuses` (`puppetserver ca list`) is answered from indexed
-columns instead of reading and parsing every stored certificate, which matters
-for large fleets. The index is a rebuildable projection of the stored
-certificates and the CRL — after migrating from another backend it is
-backfilled automatically on the next server start.
+SQL backends additionally maintain a certificate index (as does
+[etcd](#etcd-backend)): `GET /certificate_statuses` (`puppetserver ca list`)
+is answered from indexed columns instead of reading and parsing every stored
+certificate, which matters for large fleets. The index is a rebuildable
+projection of the stored certificates and the CRL — after migrating from
+another backend it is backfilled automatically on the next server start.
 
 ### SQLite backend
 

--- a/docs/storage-backends.md
+++ b/docs/storage-backends.md
@@ -158,11 +158,18 @@ etcd_tls_key_file:  /etc/puppet-ca/etcd-client-key.pem
   decomposed inventory entries instead of reading and parsing every stored
   certificate, with the same rebuildable-projection semantics as the SQL
   backends — after migrating from another backend the display fields are
-  backfilled automatically on the next server start.
+  backfilled automatically on the next server start. Note the first start
+  after an upgrade or migration therefore performs both the inventory
+  conversion and a per-certificate projection backfill before serving; on a
+  large fleet expect it to take a while (progress is logged).
 - **Bulk inventory rewrites are batched.** Imports and prunes larger than one
-  etcd transaction are split into multiple transactions, each of which leaves
-  the inventory and its integrity head consistent; batch sizes stay well under
-  etcd's default `--max-txn-ops` (128), so no cluster tuning is needed.
+  etcd transaction are split into multiple transactions; batch sizes stay
+  well under etcd's default `--max-txn-ops` (128), so no cluster tuning is
+  needed. Every *prune* transaction leaves the inventory and its integrity
+  head consistent, and a single cleanup pass bounds how many entries it
+  removes so a large backlog drains over several runs rather than stalling
+  signing; an in-progress *conversion* is instead covered by the
+  blob-stays-authoritative resume behaviour described above.
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/uptrace/bun/dialect/sqlitedialect v1.2.18
 	github.com/uptrace/bun/driver/pgdriver v1.2.18
 	github.com/uptrace/bun/driver/sqliteshim v1.2.18
+	go.etcd.io/etcd/api/v3 v3.7.1
 	go.etcd.io/etcd/client/v3 v3.7.1
 	go.etcd.io/etcd/server/v3 v3.7.1
 	go.yaml.in/yaml/v3 v3.0.5
@@ -125,7 +126,6 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yuin/gopher-lua v1.1.2 // indirect
 	go.etcd.io/bbolt v1.5.0 // indirect
-	go.etcd.io/etcd/api/v3 v3.7.1 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.7.1 // indirect
 	go.etcd.io/etcd/pkg/v3 v3.7.1 // indirect
 	go.etcd.io/raft/v3 v3.7.0 // indirect

--- a/internal/api/certindex_statuses_test.go
+++ b/internal/api/certindex_statuses_test.go
@@ -39,6 +39,27 @@ import (
 	"github.com/voxpupuli/openvox-ca/internal/testutil"
 )
 
+// unknownStateBackend wraps a real structured backend, rewriting one
+// subject's Statuses record to CertStateUnknown — the value the etcd backend
+// reports for serials its one-to-one by-serial index cannot address
+// (duplicates imported from a legacy blob). Everything else delegates
+// unchanged.
+type unknownStateBackend struct {
+	*storage.SQLBackend
+	subject string
+}
+
+func (b *unknownStateBackend) Statuses(ctx context.Context, stateFilter string) ([]storage.CertRecord, error) {
+	recs, err := b.SQLBackend.Statuses(ctx, stateFilter)
+	for i := range recs {
+		if recs[i].Subject == b.subject {
+			recs[i].State = storage.CertStateUnknown
+			recs[i].RevokedAt = nil
+		}
+	}
+	return recs, err
+}
+
 // generateCSRWithSANs builds a CSR carrying explicit DNS subject alternative
 // names, which the signing path copies onto the issued certificate and the
 // certificate index projects into dns_alt_names.
@@ -254,6 +275,54 @@ var _ = Describe("Certificate statuses via the certificate index", func() {
 		requested := getStatuses("?state=requested")
 		Expect(requested).To(HaveLen(1))
 		Expect(requested[0].Name).To(Equal("idx-pending"))
+	})
+
+	It("derives an unknown-state record's state from the CRL", func() {
+		// The etcd backend reports CertStateUnknown for serials it cannot
+		// address one-to-one (duplicated legacy serials): index writes for
+		// them are refused, so the record's stored state is meaningless and
+		// the handler must consult the signed CRL instead. Simulate that with
+		// a backend whose Statuses rewrites one subject's state to unknown.
+		dir := GinkgoT().TempDir()
+		inner, err := storage.NewSQLBackend(storage.SQLConfig{
+			Dialect: storage.SQLitePure,
+			DSN:     "file:" + filepath.Join(dir, "unknown.db"),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = inner.Close() })
+		store = storage.NewWithBackend(&unknownStateBackend{SQLBackend: inner, subject: "idx-ambig"}, dir)
+		myCA = ca.New(store, ca.AutosignConfig{Mode: "off"}, "puppet.test")
+		Expect(store.EnsureDirs(ctx)).To(Succeed())
+		Expect(store.SaveCAKey(ctx, cachedKeyPEM)).To(Succeed())
+		Expect(store.SaveCACert(ctx, cachedCrtPEM)).To(Succeed())
+		Expect(store.UpdateCRL(ctx, cachedCrlPEM)).To(Succeed())
+		Expect(store.WriteSerial(ctx, "0001")).To(Succeed())
+		Expect(store.TouchInventory(ctx)).To(Succeed())
+		Expect(myCA.Init(ctx)).To(Succeed())
+		mux = api.New(myCA).Routes()
+
+		submitAndSign("idx-ambig", generateCSRWithSANs("idx-ambig", []string{"idx-ambig"}))
+		submitAndSign("idx-plainly-signed", generateCSRWithSANs("idx-plainly-signed", []string{"idx-plainly-signed"}))
+		Expect(myCA.Revoke(ctx, "idx-ambig")).To(Succeed())
+
+		// The record for idx-ambig reads as unknown from the index, but the
+		// CRL says revoked — and the CRL must win.
+		all := getStatuses("")
+		states := map[string]string{}
+		for _, s := range all {
+			states[s.Name] = s.State
+		}
+		Expect(states).To(Equal(map[string]string{
+			"idx-ambig":          "revoked",
+			"idx-plainly-signed": "signed",
+		}), "unknown must resolve against the CRL, never leak through as a state")
+
+		revoked := getStatuses("?state=revoked")
+		Expect(revoked).To(HaveLen(1))
+		Expect(revoked[0].Name).To(Equal("idx-ambig"))
+		signed := getStatuses("?state=signed")
+		Expect(signed).To(HaveLen(1))
+		Expect(signed[0].Name).To(Equal("idx-plainly-signed"))
 	})
 
 	It("serialises an empty index as [] and projects a promoted CN SAN", func() {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -819,6 +819,18 @@ func (s *Server) handleGetStatuses(w http.ResponseWriter, r *http.Request) {
 	if indexed {
 		for _, rec := range records {
 			seen[rec.Subject] = true
+			if rec.State == storage.CertStateUnknown {
+				// The backend cannot maintain this record's state (duplicated
+				// legacy serial on etcd); derive it from the signed CRL, the
+				// authoritative artefact, exactly as the non-indexed path
+				// does. The revocation timestamp is unknowable here, matching
+				// that path.
+				rec.State = storage.CertStateSigned
+				rec.RevokedAt = nil
+				if s.CA.IsRevoked(r.Context(), rec.Subject) {
+					rec.State = storage.CertStateRevoked
+				}
+			}
 			if stateFilter != "" && rec.State != stateFilter {
 				continue
 			}

--- a/internal/ca/certindex.go
+++ b/internal/ca/certindex.go
@@ -102,7 +102,7 @@ func (c *CA) rebuildCertIndex(ctx context.Context) {
 	// apparent hang between "Loaded existing CA" and the listener coming up.
 	var missing int
 	for _, rec := range records {
-		if rec.Fingerprint == "" {
+		if rec.Fingerprint == "" && rec.State != storage.CertStateUnknown {
 			missing++
 		}
 	}
@@ -114,6 +114,14 @@ func (c *CA) rebuildCertIndex(ctx context.Context) {
 	const progressEvery = 1000
 	var projected, restated int
 	for _, rec := range records {
+		if rec.State == storage.CertStateUnknown {
+			// The backend cannot address this record's serial one-to-one
+			// (duplicated legacy serial on etcd): index writes for it are
+			// refused, so backfill and reconciliation can never converge.
+			// Readers derive its state from the CRL instead; skip it rather
+			// than re-attempt and warn on every start.
+			continue
+		}
 		if rec.Fingerprint == "" && c.backfillCertProjection(ctx, rec) {
 			projected++
 			if projected%progressEvery == 0 {

--- a/internal/ca/cleanup.go
+++ b/internal/ca/cleanup.go
@@ -81,6 +81,19 @@ func (c *CA) CleanupExpiredCerts(ctx context.Context, retain time.Duration) (int
 		if len(dropped) == 0 {
 			return pruneErr
 		}
+		// The entries below are durably gone whatever else happens, so report
+		// them even if a later cleanup step (or the prune itself) failed —
+		// otherwise a partial run logs "failed" with no hint that state
+		// changed permanently.
+		removed = len(dropped)
+
+		// The prune may have consumed most (or, on a deadline error, all) of
+		// ctx's budget, and the deadline case is exactly when a partial prune
+		// is most likely. The cleanup below must still run for the durably
+		// removed entries, so give it its own bounded context that survives
+		// the prune's. The CRL lock is still held throughout.
+		cleanupCtx, cancelCleanup := context.WithTimeout(context.WithoutCancel(ctx), lockTimeout)
+		defer cancelCleanup()
 
 		// Collect the removed serials (normalised) and refresh in-memory caches.
 		removedSerials := make(map[string]*big.Int, len(dropped))
@@ -97,7 +110,7 @@ func (c *CA) CleanupExpiredCerts(ctx context.Context, retain time.Duration) (int
 			delete(c.ocspCache, key)
 		}
 
-		if err := c.dropCRLEntriesLocked(ctx, removedSerials); err != nil {
+		if err := c.dropCRLEntriesLocked(cleanupCtx, removedSerials); err != nil {
 			return errors.Join(pruneErr, err)
 		}
 
@@ -105,10 +118,9 @@ func (c *CA) CleanupExpiredCerts(ctx context.Context, retain time.Duration) (int
 		// the cert still on file carries the expired serial (otherwise the
 		// subject has been renewed and the current cert must be preserved).
 		for _, e := range dropped {
-			c.deleteStoredCertIfSerialMatches(ctx, e.Subject, e.Serial)
+			c.deleteStoredCertIfSerialMatches(cleanupCtx, e.Subject, e.Serial)
 		}
 
-		removed = len(dropped)
 		return pruneErr
 	})
 	return removed, err

--- a/internal/ca/cleanup.go
+++ b/internal/ca/cleanup.go
@@ -46,8 +46,10 @@ import (
 // observable point, but on backends that prune in batches (etcd) it may
 // partially complete on error; the entries PruneInventory returns are always
 // exactly the ones removed, so the CRL/blob cleanup below runs even when the
-// prune itself reports an error. An entry that cannot be time-parsed is
-// conservatively kept, never dropped.
+// prune itself reports an error — on its own small context, so in the worst
+// case (a prune that exhausted its deadline) the CRL lock is held for up to
+// lockTimeout plus that cleanup budget. An entry that cannot be time-parsed
+// is conservatively kept, never dropped.
 func (c *CA) CleanupExpiredCerts(ctx context.Context, retain time.Duration) (int, error) {
 	if retain < 0 {
 		retain = 0
@@ -91,8 +93,12 @@ func (c *CA) CleanupExpiredCerts(ctx context.Context, retain time.Duration) (int
 		// ctx's budget, and the deadline case is exactly when a partial prune
 		// is most likely. The cleanup below must still run for the durably
 		// removed entries, so give it its own bounded context that survives
-		// the prune's. The CRL lock is still held throughout.
-		cleanupCtx, cancelCleanup := context.WithTimeout(context.WithoutCancel(ctx), lockTimeout)
+		// the prune's. The CRL lock (and c.mu) is still held throughout, so
+		// keep the extra budget modest — one CRL re-sign plus at most a
+		// bounded batch of blob deletions — rather than granting a second
+		// full lockTimeout: a concurrent Revoke waits on the same lock with a
+		// lockTimeout budget of its own.
+		cleanupCtx, cancelCleanup := context.WithTimeout(context.WithoutCancel(ctx), lockTimeout/2)
 		defer cancelCleanup()
 
 		// Collect the removed serials (normalised) and refresh in-memory caches.
@@ -110,9 +116,10 @@ func (c *CA) CleanupExpiredCerts(ctx context.Context, retain time.Duration) (int
 			delete(c.ocspCache, key)
 		}
 
-		if err := c.dropCRLEntriesLocked(cleanupCtx, removedSerials); err != nil {
-			return errors.Join(pruneErr, err)
-		}
+		// A CRL failure must not abort the rest: the "clean up NOW" rule above
+		// applies to the cert blobs just as much, and the deletion loop
+		// already logs-and-swallows its own per-subject failures.
+		crlErr := c.dropCRLEntriesLocked(cleanupCtx, removedSerials)
 
 		// Delete the stored signed cert for each removed subject, but only when
 		// the cert still on file carries the expired serial (otherwise the
@@ -121,7 +128,7 @@ func (c *CA) CleanupExpiredCerts(ctx context.Context, retain time.Duration) (int
 			c.deleteStoredCertIfSerialMatches(cleanupCtx, e.Subject, e.Serial)
 		}
 
-		return pruneErr
+		return errors.Join(pruneErr, crlErr)
 	})
 	return removed, err
 }

--- a/internal/ca/cleanup.go
+++ b/internal/ca/cleanup.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"log/slog"
 	"math/big"
 	"time"
@@ -40,9 +41,13 @@ import (
 // as soon as expired); negative values are treated as zero.
 //
 // Replica safety: the whole operation runs under the cluster-wide CRL lock, so
-// it serialises with Revoke and the CRL refresher across replicas. The inventory
-// rewrite itself is atomic per backend (see StorageService.PruneInventory). An
-// entry that cannot be time-parsed is conservatively kept, never dropped.
+// it serialises with Revoke and the CRL refresher across replicas. The
+// inventory rewrite keeps entries and integrity head consistent at every
+// observable point, but on backends that prune in batches (etcd) it may
+// partially complete on error; the entries PruneInventory returns are always
+// exactly the ones removed, so the CRL/blob cleanup below runs even when the
+// prune itself reports an error. An entry that cannot be time-parsed is
+// conservatively kept, never dropped.
 func (c *CA) CleanupExpiredCerts(ctx context.Context, retain time.Duration) (int, error) {
 	if retain < 0 {
 		retain = 0
@@ -58,8 +63,13 @@ func (c *CA) CleanupExpiredCerts(ctx context.Context, retain time.Duration) (int
 		defer c.mu.Unlock()
 
 		// Prune the inventory first; the returned entries tell us exactly which
-		// serials to drop from the CRL and which caches/blobs to clean up.
-		dropped, err := c.Storage.PruneInventory(ctx, func(e storage.InventoryEntry) bool {
+		// serials to drop from the CRL and which caches/blobs to clean up. A
+		// batched backend (etcd) may error mid-prune with some entries already
+		// durably removed — those are still returned, and they must be cleaned
+		// up NOW: the inventory no longer names them, so a later run could
+		// never rediscover them and their CRL entries and cert blobs would be
+		// orphaned forever. Hold the prune error and surface it at the end.
+		dropped, pruneErr := c.Storage.PruneInventory(ctx, func(e storage.InventoryEntry) bool {
 			notAfter, perr := time.Parse(storage.InventoryTimeFormat, e.NotAfter)
 			if perr != nil {
 				slog.Warn("Cleanup: keeping inventory entry with unparseable NotAfter",
@@ -68,11 +78,8 @@ func (c *CA) CleanupExpiredCerts(ctx context.Context, retain time.Duration) (int
 			}
 			return !notAfter.Before(cutoff)
 		})
-		if err != nil {
-			return err
-		}
 		if len(dropped) == 0 {
-			return nil
+			return pruneErr
 		}
 
 		// Collect the removed serials (normalised) and refresh in-memory caches.
@@ -91,7 +98,7 @@ func (c *CA) CleanupExpiredCerts(ctx context.Context, retain time.Duration) (int
 		}
 
 		if err := c.dropCRLEntriesLocked(ctx, removedSerials); err != nil {
-			return err
+			return errors.Join(pruneErr, err)
 		}
 
 		// Delete the stored signed cert for each removed subject, but only when
@@ -102,7 +109,7 @@ func (c *CA) CleanupExpiredCerts(ctx context.Context, retain time.Duration) (int
 		}
 
 		removed = len(dropped)
-		return nil
+		return pruneErr
 	})
 	return removed, err
 }

--- a/internal/ca/cleanup_test.go
+++ b/internal/ca/cleanup_test.go
@@ -45,16 +45,23 @@ const cleanupInventoryFormat = "2006-01-02T15:04:05UTC"
 // and injecting an error after a successful prune — modelling a batched
 // backend (etcd) that durably removed entries and then failed. Per the
 // PruneEntries contract the removed entries are still returned with the
-// error.
+// error. With blockUntilDeadline set it instead parks until the caller's
+// context expires and returns its error, modelling a prune that consumed the
+// whole time budget — the case the post-prune cleanup context exists for.
 type partialPruneBackend struct {
 	*storage.SQLBackend
-	pruneErr error
+	pruneErr           error
+	blockUntilDeadline bool
 }
 
 func (b *partialPruneBackend) PruneEntries(ctx context.Context, keep func(storage.InventoryEntry) bool, advanceHead func(prev []byte, e storage.InventoryEntry) []byte) ([]storage.InventoryEntry, error) {
 	removed, err := b.SQLBackend.PruneEntries(ctx, keep, advanceHead)
 	if err != nil || len(removed) == 0 {
 		return removed, err
+	}
+	if b.blockUntilDeadline {
+		<-ctx.Done()
+		return removed, ctx.Err()
 	}
 	return removed, b.pruneErr
 }
@@ -240,6 +247,45 @@ var _ = Describe("CA CleanupExpiredCerts", func() {
 			"the CRL entry must be dropped despite the prune error")
 		Expect(store.HasCert(ctx, "expired-node")).To(BeFalse(),
 			"the stored cert must be deleted despite the prune error")
+	})
+
+	It("still cleans up when the prune exhausts the context deadline", func() {
+		// The deadline case is when a partial prune is most likely, and it is
+		// exactly when the cleanup would be skipped if it shared the prune's
+		// context: this spec fails if the post-prune steps run on the original
+		// (expired) ctx instead of their own surviving one.
+		inner, err := storage.NewSQLBackend(storage.SQLConfig{
+			Dialect: storage.SQLitePure,
+			DSN:     "file:" + filepath.Join(tmpDir, "deadline-prune.db"),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = inner.Close() })
+		Expect(inner.EnsureReady(ctx)).To(Succeed())
+		store = storage.NewWithBackend(&partialPruneBackend{SQLBackend: inner, blockUntilDeadline: true},
+			filepath.Join(tmpDir, "deadline-private"))
+		myCA = ca.New(store, ca.AutosignConfig{Mode: "off"}, "puppet.test")
+		Expect(store.EnsureDirs(ctx)).To(Succeed())
+		Expect(store.SaveCAKey(ctx, cachedKeyPEM)).To(Succeed())
+		Expect(store.SaveCACert(ctx, cachedCrtPEM)).To(Succeed())
+		Expect(store.UpdateCRL(ctx, cachedCrlPEM)).To(Succeed())
+		Expect(store.WriteSerial(ctx, "0001")).To(Succeed())
+		Expect(store.TouchInventory(ctx)).To(Succeed())
+		Expect(myCA.Init(ctx)).To(Succeed())
+
+		seedCert("expired-node", big.NewInt(0xEE02), time.Now().Add(-3*365*24*time.Hour))
+		Expect(parseStoredCRL(store).RevokedCertificateEntries).To(HaveLen(1))
+
+		shortCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+		defer cancel()
+		removed, err := myCA.CleanupExpiredCerts(shortCtx, time.Hour)
+		Expect(err).To(MatchError(context.DeadlineExceeded), "the prune's deadline error must surface")
+		Expect(removed).To(Equal(1))
+
+		Expect(inventoryString()).NotTo(ContainSubstring("/expired-node"))
+		Expect(parseStoredCRL(store).RevokedCertificateEntries).To(BeEmpty(),
+			"the CRL entry must be dropped even though the prune consumed the deadline")
+		Expect(store.HasCert(ctx, "expired-node")).To(BeFalse(),
+			"the stored cert must be deleted even though the prune consumed the deadline")
 	})
 
 	It("preserves a renewed cert under the same subject when an old serial expires", func() {

--- a/internal/ca/cleanup_test.go
+++ b/internal/ca/cleanup_test.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -39,6 +40,24 @@ import (
 // cleanupInventoryFormat matches the layout the signing path writes and
 // CleanupExpiredCerts parses.
 const cleanupInventoryFormat = "2006-01-02T15:04:05UTC"
+
+// partialPruneBackend wraps a real structured backend, delegating everything
+// and injecting an error after a successful prune — modelling a batched
+// backend (etcd) that durably removed entries and then failed. Per the
+// PruneEntries contract the removed entries are still returned with the
+// error.
+type partialPruneBackend struct {
+	*storage.SQLBackend
+	pruneErr error
+}
+
+func (b *partialPruneBackend) PruneEntries(ctx context.Context, keep func(storage.InventoryEntry) bool, advanceHead func(prev []byte, e storage.InventoryEntry) []byte) ([]storage.InventoryEntry, error) {
+	removed, err := b.SQLBackend.PruneEntries(ctx, keep, advanceHead)
+	if err != nil || len(removed) == 0 {
+		return removed, err
+	}
+	return removed, b.pruneErr
+}
 
 var _ = Describe("CA CleanupExpiredCerts", func() {
 	var (
@@ -180,6 +199,47 @@ var _ = Describe("CA CleanupExpiredCerts", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(removed).To(Equal(0))
 		Expect(inventoryString()).To(ContainSubstring("/weird-node"))
+	})
+
+	It("cleans up returned entries and reports the count even when the prune errors", func() {
+		// Batched backends (etcd) can durably remove entries and then fail;
+		// PruneInventory returns those entries alongside the error, and the
+		// cleanup must still drop their CRL entries and stored certs — the
+		// inventory no longer names them, so no later run could. Model that
+		// with a backend whose prune succeeds and then reports an error.
+		injected := fmt.Errorf("simulated mid-prune failure")
+		inner, err := storage.NewSQLBackend(storage.SQLConfig{
+			Dialect: storage.SQLitePure,
+			DSN:     "file:" + filepath.Join(tmpDir, "partial-prune.db"),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = inner.Close() })
+		Expect(inner.EnsureReady(ctx)).To(Succeed())
+		store = storage.NewWithBackend(&partialPruneBackend{SQLBackend: inner, pruneErr: injected},
+			filepath.Join(tmpDir, "partial-private"))
+		myCA = ca.New(store, ca.AutosignConfig{Mode: "off"}, "puppet.test")
+		Expect(store.EnsureDirs(ctx)).To(Succeed())
+		Expect(store.SaveCAKey(ctx, cachedKeyPEM)).To(Succeed())
+		Expect(store.SaveCACert(ctx, cachedCrtPEM)).To(Succeed())
+		Expect(store.UpdateCRL(ctx, cachedCrlPEM)).To(Succeed())
+		Expect(store.WriteSerial(ctx, "0001")).To(Succeed())
+		Expect(store.TouchInventory(ctx)).To(Succeed())
+		Expect(myCA.Init(ctx)).To(Succeed())
+
+		seedCert("expired-node", big.NewInt(0xEE01), time.Now().Add(-3*365*24*time.Hour))
+		Expect(parseStoredCRL(store).RevokedCertificateEntries).To(HaveLen(1))
+
+		removed, err := myCA.CleanupExpiredCerts(ctx, time.Hour)
+		Expect(err).To(MatchError(injected), "the prune error must surface to the caller")
+		Expect(removed).To(Equal(1), "the durably removed entry must still be counted")
+
+		// The cleanup for the returned entry ran despite the error: nothing
+		// is orphaned.
+		Expect(inventoryString()).NotTo(ContainSubstring("/expired-node"))
+		Expect(parseStoredCRL(store).RevokedCertificateEntries).To(BeEmpty(),
+			"the CRL entry must be dropped despite the prune error")
+		Expect(store.HasCert(ctx, "expired-node")).To(BeFalse(),
+			"the stored cert must be deleted despite the prune error")
 	})
 
 	It("preserves a renewed cert under the same subject when an old serial expires", func() {

--- a/internal/storage/backend.go
+++ b/internal/storage/backend.go
@@ -172,9 +172,17 @@ type InventoryEntry struct {
 // Certificate index states recorded in CertRecord.State. Pending CSRs are not
 // issued certificates and never appear in the index; the API layer derives the
 // "requested" state from the csr/ namespace instead.
+//
+// CertStateUnknown is reported (never stored as a target state) by a backend
+// that cannot maintain per-serial state for a record — today only the etcd
+// backend for serials that appeared more than once in a converted legacy
+// blob, which its one-to-one by-serial index cannot address. Readers must
+// derive such a record's real state from the signed CRL (the authoritative
+// artefact) rather than trust the index.
 const (
 	CertStateSigned  = "signed"
 	CertStateRevoked = "revoked"
+	CertStateUnknown = "unknown"
 )
 
 // CertProjection carries the display fields denormalised from a signed
@@ -200,7 +208,10 @@ type CertProjection struct {
 // canonical inventory fields, the denormalised display projection, and the one
 // mutable fact — revocation. State/RevokedAt are a projection of the signed
 // CRL (the source of truth), written alongside CRL updates and rebuildable
-// from it, exactly as the projection fields relate to the PEM.
+// from it, exactly as the projection fields relate to the PEM. The
+// rebuildability guarantee is conditional on the backend being able to
+// address the record's serial one-to-one; when it cannot, State is reported
+// as CertStateUnknown and the reader consults the CRL directly.
 //
 // Note the integrity hash chain covers only the canonical InventoryEntry
 // fields (via canonicalInventoryLine); the projection columns are not chained.
@@ -244,6 +255,13 @@ type CertIndex interface {
 	// original revocation time. A serial with no matching row is a no-op, not
 	// an error (the CRL may legitimately reference certs the index no longer
 	// tracks).
+	//
+	// SetRevoked, ClearRevoked, and SetProjection may also decline a write —
+	// as a logged no-op, not an error — when the implementation cannot
+	// unambiguously identify the bearing rows (the etcd backend's one-to-one
+	// by-serial index cannot address a serial duplicated in a converted
+	// legacy blob). Statuses reports such records with CertStateUnknown so
+	// callers know to derive their state from the CRL instead.
 	SetRevoked(ctx context.Context, serial string, at time.Time) error
 
 	// ClearRevoked returns every index row bearing serial to the signed

--- a/internal/storage/backend.go
+++ b/internal/storage/backend.go
@@ -307,13 +307,22 @@ type InventoryStore interface {
 	LatestSerialForSubject(ctx context.Context, subject string) (string, error)
 
 	// PruneEntries removes every entry for which keep returns false and
-	// recomputes the integrity head over the survivors, atomically in one
-	// transaction so the rows and the chained head can never be observed out of
-	// sync by another replica. recomputeHead folds the hash chain over the
-	// surviving entries in issuance order; a nil recomputeHead means integrity is
-	// disabled and the stored head is left untouched. It returns the removed
-	// entries in issuance order, or an empty slice when nothing matched.
-	PruneEntries(ctx context.Context, keep func(InventoryEntry) bool, recomputeHead func(survivors []InventoryEntry) []byte) ([]InventoryEntry, error)
+	// rewrites the integrity head over the survivors. advanceHead advances the
+	// hash chain by one entry from the previous head (nil for the first
+	// entry); a nil advanceHead means integrity is disabled and the stored
+	// head is left untouched.
+	//
+	// Consistency contract: the stored entries and the stored head must never
+	// be observable out of sync by another replica. Implementations need not
+	// perform the whole prune in one transaction — the etcd backend commits
+	// it in batches, each of which writes a head covering exactly the entries
+	// that remain after it — so a prune may partially complete on conflict or
+	// error. Whatever happens, the returned slice must contain every entry
+	// actually removed (in issuance order), including alongside a non-nil
+	// error: callers drive CRL entry removal and blob cleanup from it, and an
+	// entry that was durably removed but not returned can never be
+	// rediscovered. An empty slice with a nil error means nothing matched.
+	PruneEntries(ctx context.Context, keep func(InventoryEntry) bool, advanceHead func(prev []byte, e InventoryEntry) []byte) ([]InventoryEntry, error)
 }
 
 // asInventoryStore probes b for the InventoryStore capability, unwrapping

--- a/internal/storage/backend.go
+++ b/internal/storage/backend.go
@@ -317,10 +317,13 @@ type InventoryStore interface {
 	// perform the whole prune in one transaction — the etcd backend commits
 	// it in batches, each of which writes a head covering exactly the entries
 	// that remain after it — so a prune may partially complete on conflict or
-	// error. Whatever happens, the returned slice must contain every entry
-	// actually removed (in issuance order), including alongside a non-nil
-	// error: callers drive CRL entry removal and blob cleanup from it, and an
-	// entry that was durably removed but not returned can never be
+	// error, and an implementation may deliberately bound how much one call
+	// removes (etcd caps a call's batches so a huge backlog cannot blow the
+	// caller's time budget; deferred matches stay present and consistent for
+	// later calls). Whatever happens, the returned slice must contain every
+	// entry actually removed (in issuance order), including alongside a
+	// non-nil error: callers drive CRL entry removal and blob cleanup from
+	// it, and an entry that was durably removed but not returned can never be
 	// rediscovered. An empty slice with a nil error means nothing matched.
 	PruneEntries(ctx context.Context, keep func(InventoryEntry) bool, advanceHead func(prev []byte, e InventoryEntry) []byte) ([]InventoryEntry, error)
 }

--- a/internal/storage/etcd.go
+++ b/internal/storage/etcd.go
@@ -83,10 +83,12 @@ type EtcdBackend struct {
 	timeout  time.Duration
 	appendMu sync.Mutex // serialises inventory mutations within this process
 
-	// pruneBatchHook, when non-nil, runs after each committed prune batch.
-	// Test seam only: it lets the suite interleave a conflicting write
-	// between batches to exercise the partial-prune paths deterministically.
-	pruneBatchHook func()
+	// pruneBatchHook and importBatchHook, when non-nil, run after each
+	// committed prune/import transaction. Test seams only: they let the
+	// suite interleave conflicting writes between batches to exercise the
+	// partial-completion and guard-retry paths deterministically.
+	pruneBatchHook  func()
+	importBatchHook func()
 
 	// session is the lease-backed concurrency session used for distributed
 	// mutexes. It is created lazily on the first AcquireLock call and

--- a/internal/storage/etcd.go
+++ b/internal/storage/etcd.go
@@ -69,17 +69,19 @@ func (c *EtcdConfig) applyDefaults() {
 // EtcdBackend is a Backend implementation backed by an etcd v3 cluster.
 //
 // Blob contents are wrapped with an 8-byte big-endian nanosecond mtime prefix
-// so ModTime can be answered without a second key. Appends use an etcd Txn
-// with a ModRevision guard to remain atomic across concurrent writers,
-// including those in different processes. Distributed locks are provided
-// via AcquireLock using etcd's concurrency.Mutex on a lazily-created
-// lease session.
+// so ModTime can be answered without a second key. The certificate inventory
+// is not stored as a blob: it is decomposed into per-entry keys (see
+// etcd_inventory.go), and the backend implements InventoryStore and
+// CertIndex. Mutations use etcd Txns with ModRevision guards to remain atomic
+// across concurrent writers, including those in different processes.
+// Distributed locks are provided via AcquireLock using etcd's
+// concurrency.Mutex on a lazily-created lease session.
 type EtcdBackend struct {
 	client   *clientv3.Client
 	owned    bool // true when Close should close the client
 	prefix   string
 	timeout  time.Duration
-	appendMu sync.Mutex // serialises AppendLine within this process
+	appendMu sync.Mutex // serialises inventory mutations within this process
 
 	// session is the lease-backed concurrency session used for distributed
 	// mutexes. It is created lazily on the first AcquireLock call and
@@ -102,15 +104,17 @@ type EtcdBackend struct {
 const etcdLockTTLSeconds = 30
 
 // etcdLayout maps logical keys to their physical etcd sub-paths. CSR and
-// signed-cert keys are handled directly in physicalKey.
+// signed-cert keys are handled directly in physicalKey. KeyInventory's
+// physical key holds only a presence marker: the inventory itself is
+// decomposed into per-entry keys (see etcd_inventory.go).
 var etcdLayout = map[string]string{
 	KeyCACert:        "ca/cert",
 	KeyCAPubKey:      "ca/pubkey",
 	KeyCAKey:         "ca/key",
 	KeyCRL:           "ca/crl",
 	KeySerial:        "serial",
-	KeyInventory:     "inventory/data",
-	KeyInventoryHMAC: "inventory/hmac",
+	KeyInventory:     etcdInvDataSub,
+	KeyInventoryHMAC: etcdInvHMACSub,
 	KeyHMACKey:       "private/hmac_key",
 }
 
@@ -177,26 +181,33 @@ func (b *EtcdBackend) callCtx(parent context.Context) (context.Context, context.
 	return context.WithTimeout(parent, b.timeout)
 }
 
-// EnsureReady verifies connectivity by listing the cluster status. Etcd has
-// no directory concept so there is nothing else to prepare.
+// EnsureReady verifies connectivity by listing the cluster status (etcd has
+// no directory concept so there is nothing to create), then decomposes a
+// legacy inventory blob left by a pre-decomposition version of this backend
+// into the per-entry structure. Decomposition must run before the inventory
+// is used: the structured paths assume the blob key is only a presence marker.
 func (b *EtcdBackend) EnsureReady(ctx context.Context) error {
 	if len(b.client.Endpoints()) == 0 {
 		return fmt.Errorf("etcd backend has no endpoints configured")
 	}
-	ctx, cancel := b.callCtx(ctx)
+	statusCtx, cancel := b.callCtx(ctx)
 	defer cancel()
-	_, err := b.client.Status(ctx, b.client.Endpoints()[0])
-	if err != nil {
+	if _, err := b.client.Status(statusCtx, b.client.Endpoints()[0]); err != nil {
 		return fmt.Errorf("etcd not reachable: %w", err)
 	}
-	return nil
+	return b.decomposeLegacyInventory(ctx)
 }
 
-// Get returns the (unwrapped) blob at key, wrapping fs.ErrNotExist when absent.
+// Get returns the (unwrapped) blob at key, wrapping fs.ErrNotExist when
+// absent. The KeyInventory key is served from the decomposed entry keys
+// (rendered to inventory.txt text) rather than a stored blob.
 func (b *EtcdBackend) Get(ctx context.Context, key string) ([]byte, error) {
 	phys, err := b.physicalKey(key)
 	if err != nil {
 		return nil, err
+	}
+	if key == KeyInventory {
+		return b.getInventory(ctx)
 	}
 	ctx, cancel := b.callCtx(ctx)
 	defer cancel()
@@ -216,10 +227,14 @@ func (b *EtcdBackend) Get(ctx context.Context, key string) ([]byte, error) {
 
 // Put writes the blob at key. The BlobKind hint is recorded but has no
 // effect on the stored form: etcd access control is managed by the cluster.
+// Putting KeyInventory parses the text and replaces the decomposed entries.
 func (b *EtcdBackend) Put(ctx context.Context, key string, data []byte, _ BlobKind) error {
 	phys, err := b.physicalKey(key)
 	if err != nil {
 		return err
+	}
+	if key == KeyInventory {
+		return b.putInventory(ctx, data)
 	}
 	ctx, cancel := b.callCtx(ctx)
 	defer cancel()
@@ -228,10 +243,14 @@ func (b *EtcdBackend) Put(ctx context.Context, key string, data []byte, _ BlobKi
 }
 
 // Delete removes key, wrapping fs.ErrNotExist when the key is absent.
+// Deleting KeyInventory removes the marker and the decomposed structure.
 func (b *EtcdBackend) Delete(ctx context.Context, key string) error {
 	phys, err := b.physicalKey(key)
 	if err != nil {
 		return err
+	}
+	if key == KeyInventory {
+		return b.deleteInventory(ctx)
 	}
 	ctx, cancel := b.callCtx(ctx)
 	defer cancel()
@@ -298,16 +317,22 @@ func (b *EtcdBackend) List(ctx context.Context, prefix string) ([]string, error)
 // are resolved by an etcd Txn guarded on the key's ModRevision with bounded
 // retry on conflict.
 func (b *EtcdBackend) AppendLine(ctx context.Context, key string, data []byte, _ BlobKind) error {
-	b.appendMu.Lock()
-	defer b.appendMu.Unlock()
-
 	phys, err := b.physicalKey(key)
 	if err != nil {
 		return err
 	}
+	if key == KeyInventory {
+		// Inventory is decomposed: parse the lines and append them as entry
+		// keys. StorageService routes inventory appends through AppendEntry,
+		// so this only runs if a caller uses AppendLine(KeyInventory, ...)
+		// directly.
+		return b.appendInventoryLines(ctx, data)
+	}
 
-	const maxRetries = 16
-	for attempt := range maxRetries {
+	b.appendMu.Lock()
+	defer b.appendMu.Unlock()
+
+	for attempt := range etcdMaxTxnRetries {
 		getCtx, cancel := b.callCtx(ctx)
 		resp, err := b.client.Get(getCtx, phys)
 		cancel()
@@ -342,21 +367,28 @@ func (b *EtcdBackend) AppendLine(ctx context.Context, key string, data []byte, _
 		if txnResp.Succeeded {
 			return nil
 		}
-		// Another writer won the race; back off and retry. The sleep is a
-		// growing window with full jitter: jitter decorrelates two writers
-		// that would otherwise retry in lock-step on the same schedule and
-		// keep colliding (the cause of spurious "too many concurrent writers"
-		// under load). Honour the caller's cancellation rather than spinning
-		// past it.
-		window := time.Duration(attempt+1) * 10 * time.Millisecond
-		backoff := time.Duration(rand.Int64N(int64(window))) //nolint:gosec // jitter, not security-sensitive
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(backoff):
+		// Another writer won the race; back off and retry.
+		if err := b.txnBackoff(ctx, attempt); err != nil {
+			return err
 		}
 	}
 	return fmt.Errorf("append to %q failed: too many concurrent writers", key)
+}
+
+// txnBackoff sleeps between optimistic-transaction retries. The sleep is a
+// growing window with full jitter: jitter decorrelates two writers that would
+// otherwise retry in lock-step on the same schedule and keep colliding (the
+// cause of spurious "too many concurrent writers" under load). Honours the
+// caller's cancellation rather than spinning past it.
+func (b *EtcdBackend) txnBackoff(ctx context.Context, attempt int) error {
+	window := time.Duration(attempt+1) * 10 * time.Millisecond
+	backoff := time.Duration(rand.Int64N(int64(window))) //nolint:gosec // jitter, not security-sensitive
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(backoff):
+		return nil
+	}
 }
 
 // ModTime returns the wall-clock timestamp recorded when the blob was last

--- a/internal/storage/etcd.go
+++ b/internal/storage/etcd.go
@@ -83,6 +83,11 @@ type EtcdBackend struct {
 	timeout  time.Duration
 	appendMu sync.Mutex // serialises inventory mutations within this process
 
+	// pruneBatchHook, when non-nil, runs after each committed prune batch.
+	// Test seam only: it lets the suite interleave a conflicting write
+	// between batches to exercise the partial-prune paths deterministically.
+	pruneBatchHook func()
+
 	// session is the lease-backed concurrency session used for distributed
 	// mutexes. It is created lazily on the first AcquireLock call and
 	// re-created when its lease has expired. Protected by sessionMu.

--- a/internal/storage/etcd_certindex.go
+++ b/internal/storage/etcd_certindex.go
@@ -1,0 +1,187 @@
+// Copyright (C) 2026 Chris Boot
+// Copyright (C) 2026 Vox Pupuli and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package storage
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+// EtcdBackend implements CertIndex: certificate-status queries are answered
+// from the decomposed inventory entries (one range read) instead of reading
+// and parsing every stored certificate PEM. See CertIndex for the contract.
+var _ CertIndex = (*EtcdBackend)(nil)
+
+// Statuses returns one record per subject that currently holds a stored
+// signed certificate (the subject's latest issuance), in subject order,
+// optionally narrowed to stateFilter. Unlike SQL there is no indexed query to
+// push the latest-per-subject fold into, so the whole entry range is read and
+// folded in Go — still a single round-trip against the entries, compared with
+// the per-subject PEM read-and-parse the fallback path costs.
+func (b *EtcdBackend) Statuses(ctx context.Context, stateFilter string) ([]CertRecord, error) {
+	certKeys, err := b.List(ctx, certPrefix)
+	if err != nil {
+		return nil, err
+	}
+	if len(certKeys) == 0 {
+		return nil, nil
+	}
+	stored := make(map[string]bool, len(certKeys))
+	for _, key := range certKeys {
+		stored[strings.TrimPrefix(key, certPrefix)] = true
+	}
+
+	recs, _, err := b.readIndexedRecords(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// Ascending issuance order: a later record for the same subject wins.
+	latest := make(map[string]CertRecord, len(recs))
+	for _, r := range recs {
+		latest[r.rec.Subject] = r.rec
+	}
+
+	subjects := make([]string, 0, len(latest))
+	for subject := range latest {
+		if stored[subject] {
+			subjects = append(subjects, subject)
+		}
+	}
+	sort.Strings(subjects)
+
+	records := make([]CertRecord, 0, len(subjects))
+	for _, subject := range subjects {
+		rec := latest[subject]
+		if stateFilter != "" && rec.State != stateFilter {
+			continue
+		}
+		records = append(records, rec)
+	}
+	return records, nil
+}
+
+// SetRevoked marks the entry bearing serial as revoked at the given time.
+// Idempotent: an already-revoked entry keeps its original revocation time. A
+// serial with no entry is a no-op, not an error.
+func (b *EtcdBackend) SetRevoked(ctx context.Context, serial string, at time.Time) error {
+	return b.mutateRecordBySerial(ctx, serial, func(rec *CertRecord) bool {
+		if rec.State == CertStateRevoked {
+			return false
+		}
+		rec.State = CertStateRevoked
+		utc := at.UTC()
+		rec.RevokedAt = &utc
+		return true
+	})
+}
+
+// ClearRevoked returns the entry bearing serial to the signed state.
+func (b *EtcdBackend) ClearRevoked(ctx context.Context, serial string) error {
+	return b.mutateRecordBySerial(ctx, serial, func(rec *CertRecord) bool {
+		if rec.State == CertStateSigned && rec.RevokedAt == nil {
+			return false
+		}
+		rec.State = CertStateSigned
+		rec.RevokedAt = nil
+		return true
+	})
+}
+
+// SetProjection fills the denormalised display fields for the entry bearing
+// serial. Used to backfill records created from projection-less sources
+// (legacy blob imports, direct AppendLine writes).
+func (b *EtcdBackend) SetProjection(ctx context.Context, serial string, proj CertProjection) error {
+	return b.mutateRecordBySerial(ctx, serial, func(rec *CertRecord) bool {
+		rec.CertProjection = proj
+		return true
+	})
+}
+
+// mutateRecordBySerial applies mutate to the entry the by-serial index points
+// at, writing it back guarded on the entry's ModRevision so a concurrent
+// mutation (e.g. SetRevoked racing SetProjection during index repair) is
+// re-read rather than clobbered. mutate returns false to signal a no-op. An
+// unknown serial — or a dangling by-serial key — is a no-op, matching the SQL
+// backend's zero-rows-updated behaviour.
+//
+// The entry keys are not part of the integrity chain input (only the
+// canonical fields are, and mutate must not touch them), so no fence or head
+// update is involved.
+func (b *EtcdBackend) mutateRecordBySerial(ctx context.Context, serial string, mutate func(rec *CertRecord) bool) error {
+	serialPhys := b.invPhys(etcdInvSerialSub + serial)
+	for attempt := range etcdMaxTxnRetries {
+		readCtx, cancel := b.callCtx(ctx)
+		resp, err := b.client.Get(readCtx, serialPhys)
+		cancel()
+		if err != nil {
+			return err
+		}
+		if len(resp.Kvs) == 0 {
+			return nil
+		}
+		seq, err := strconv.ParseUint(string(resp.Kvs[0].Value), 10, 64)
+		if err != nil {
+			return fmt.Errorf("parsing by-serial index for %q: %w", serial, err)
+		}
+
+		entryPhys := b.entryPhys(seq)
+		entryCtx, cancel2 := b.callCtx(ctx)
+		entryResp, err := b.client.Get(entryCtx, entryPhys)
+		cancel2()
+		if err != nil {
+			return err
+		}
+		if len(entryResp.Kvs) == 0 {
+			return nil
+		}
+		rec, err := decodeInventoryRecord(entryResp.Kvs[0].Value)
+		if err != nil {
+			return err
+		}
+		if !mutate(&rec) {
+			return nil
+		}
+		val, err := encodeInventoryRecord(rec)
+		if err != nil {
+			return err
+		}
+
+		txnCtx, cancel3 := b.callCtx(ctx)
+		txnResp, err := b.client.Txn(txnCtx).
+			If(clientv3.Compare(clientv3.ModRevision(entryPhys), "=", entryResp.Kvs[0].ModRevision)).
+			Then(clientv3.OpPut(entryPhys, string(val))).
+			Commit()
+		cancel3()
+		if err != nil {
+			return err
+		}
+		if txnResp.Succeeded {
+			return nil
+		}
+		if err := b.txnBackoff(ctx, attempt); err != nil {
+			return err
+		}
+	}
+	return fmt.Errorf("updating inventory record for serial %q: too many concurrent writers", serial)
+}

--- a/internal/storage/etcd_certindex.go
+++ b/internal/storage/etcd_certindex.go
@@ -58,9 +58,23 @@ func (b *EtcdBackend) Statuses(ctx context.Context, stateFilter string) ([]CertR
 		return nil, err
 	}
 	// Ascending issuance order: a later record for the same subject wins.
+	// Serials borne by more than one record (imported legacy duplicates)
+	// cannot have index-maintained state — mutateRecordBySerial refuses
+	// writes for them — so report those records as CertStateUnknown, which
+	// tells the reader to derive state from the signed CRL instead of
+	// trusting a value that revocation writes were never able to update.
+	serialCount := make(map[string]int, len(recs))
+	for _, r := range recs {
+		serialCount[r.rec.Serial]++
+	}
 	latest := make(map[string]CertRecord, len(recs))
 	for _, r := range recs {
-		latest[r.rec.Subject] = r.rec
+		rec := r.rec
+		if serialCount[rec.Serial] > 1 {
+			rec.State = CertStateUnknown
+			rec.RevokedAt = nil
+		}
+		latest[rec.Subject] = rec
 	}
 
 	subjects := make([]string, 0, len(latest))

--- a/internal/storage/etcd_certindex.go
+++ b/internal/storage/etcd_certindex.go
@@ -20,6 +20,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"sort"
 	"strconv"
 	"strings"
@@ -138,6 +139,15 @@ func (b *EtcdBackend) mutateRecordBySerial(ctx context.Context, serial string, m
 			return err
 		}
 		if len(resp.Kvs) == 0 {
+			return nil
+		}
+		if string(resp.Kvs[0].Value) == etcdSerialAmbiguous {
+			// The serial appears on several imported legacy records; applying
+			// the write through the one-to-one index would land it on an
+			// arbitrary bearer (e.g. another subject's record receiving this
+			// certificate's fingerprint). Refuse rather than alias.
+			slog.Warn("Certificate-index write skipped: serial is duplicated in the imported legacy inventory",
+				"serial", serial)
 			return nil
 		}
 		seq, err := strconv.ParseUint(string(resp.Kvs[0].Value), 10, 64)

--- a/internal/storage/etcd_integration_test.go
+++ b/internal/storage/etcd_integration_test.go
@@ -803,6 +803,54 @@ var _ = Describe("EtcdInventoryPrune", func() {
 		Expect(bytes.Split(bytes.TrimRight(inv, "\n"), []byte{'\n'})).To(HaveLen(total - 65))
 	})
 
+	It("bounds one call to the per-call batch budget, deferring the oldest matches", func() {
+		// Beyond etcdPruneMaxBatchesPerCall batches, a call removes only the
+		// newest matches and defers the rest to later runs. The slicing here
+		// decides exactly what CleanupExpiredCerts deletes CRL entries and
+		// blobs for, so pin it: the returned set, the deferred set, and
+		// convergence on a second call.
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		b := newBackend(cli, "/test-inv-prune-bound")
+		ctx := context.Background()
+
+		// Seed 950 entries through the import shim (appending one-by-one is
+		// needlessly slow at this size), then initialise integrity over them.
+		const total = 950
+		blob := ""
+		for i := 1; i <= total; i++ {
+			blob += fmt.Sprintf("%04d 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node%d\n", i, i%8)
+		}
+		Expect(b.Put(ctx, KeyInventory, []byte(blob), BlobPrivate)).To(Succeed(), "Put inventory")
+		svc := NewWithBackend(b, filepath.Join(GinkgoT().TempDir(), "private"))
+		Expect(svc.InitHMAC(ctx)).To(Succeed(), "InitHMAC")
+
+		// 930 matches (serials 0001–0930) exceed the 900-entry budget: the
+		// call must remove the newest 900 (0031–0930) and defer 0001–0030.
+		bound := etcdPruneMaxBatchesPerCall * etcdPruneBatch
+		keep := func(e InventoryEntry) bool { return e.Serial > "0930" }
+		removed, err := svc.PruneInventory(ctx, keep)
+		Expect(err).NotTo(HaveOccurred(), "PruneInventory (bounded call)")
+		Expect(removed).To(HaveLen(bound))
+		Expect(removed[0].Serial).To(Equal("0031"), "the NEWEST matches are removed; older ones are deferred")
+		Expect(removed[len(removed)-1].Serial).To(Equal("0930"))
+
+		inv, err := svc.ReadInventory(ctx)
+		Expect(err).NotTo(HaveOccurred(), "chain must verify after a bounded prune")
+		lines := bytes.Split(bytes.TrimRight(inv, "\n"), []byte{'\n'})
+		Expect(lines).To(HaveLen(total-bound), "deferred matches and survivors must all still be present")
+		Expect(string(bytes.Fields(lines[0])[0])).To(Equal("0001"), "deferred matches remain")
+
+		// The next run drains the deferred remainder.
+		removed, err = svc.PruneInventory(ctx, keep)
+		Expect(err).NotTo(HaveOccurred(), "PruneInventory (second call)")
+		Expect(removed).To(HaveLen(930 - bound))
+		Expect(removed[0].Serial).To(Equal("0001"))
+		inv, err = svc.ReadInventory(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(bytes.Split(bytes.TrimRight(inv, "\n"), []byte{'\n'})).To(HaveLen(20), "only true survivors remain after convergence")
+	})
+
 	It("returns the durably removed entries alongside the error when retries are exhausted", func() {
 		// The contract's hardest case: every attempt commits one batch and
 		// then conflicts, until the retry budget runs out. The error must
@@ -1120,7 +1168,9 @@ var _ = Describe("EtcdLegacyInventoryDecompose", func() {
 		// A one-to-one index cannot say which bearer an index write is meant
 		// for, so writes for a duplicated serial must be refused outright —
 		// applying them to the newest bearer would hand one subject the other
-		// subject's fingerprint or revocation state.
+		// subject's fingerprint or revocation state. Statuses reports such
+		// records as CertStateUnknown, telling readers to derive the real
+		// state from the signed CRL.
 		for _, subject := range []string{"node1", "node2"} {
 			Expect(b.Put(ctx, CertKey(subject), []byte("pem-"+subject), BlobPublic)).To(Succeed())
 		}
@@ -1131,7 +1181,8 @@ var _ = Describe("EtcdLegacyInventoryDecompose", func() {
 		Expect(recs).To(HaveLen(2))
 		for _, rec := range recs {
 			Expect(rec.Fingerprint).To(BeEmpty(), "no bearer may receive the projection for an ambiguous serial")
-			Expect(rec.State).To(Equal(CertStateSigned), "no bearer may receive the revocation for an ambiguous serial")
+			Expect(rec.State).To(Equal(CertStateUnknown), "ambiguous serials must not masquerade as signed or revoked")
+			Expect(rec.RevokedAt).To(BeNil())
 		}
 	})
 
@@ -1185,6 +1236,85 @@ var _ = Describe("EtcdLegacyInventoryDecompose", func() {
 
 		svc := NewWithBackend(b, filepath.Join(GinkgoT().TempDir(), "private"))
 		Expect(svc.InitHMAC(ctx)).To(MatchError(ErrInventoryTampered), "verification must stay fail-closed")
+	})
+
+	It("leaves the empty-inventory head alone when the HMAC key is missing or malformed", func() {
+		// Like the mismatch arm, the two cannot-verify arms must not delete
+		// the tamper baseline: deleting entries AND the key must not buy a
+		// clean re-baseline.
+		for name, corrupt := range map[string]func(cli *clientv3.Client, prefix string){
+			"missing key": func(cli *clientv3.Client, prefix string) {
+				_, err := cli.Delete(context.Background(), prefix+"/private/hmac_key")
+				Expect(err).NotTo(HaveOccurred())
+			},
+			"malformed key": func(cli *clientv3.Client, prefix string) {
+				_, err := cli.Put(context.Background(), prefix+"/private/hmac_key",
+					string(encodeBlob(time.Now(), []byte("short"))))
+				Expect(err).NotTo(HaveOccurred())
+			},
+		} {
+			cli, stop := startEmbeddedEtcd()
+			ctx := context.Background()
+			const prefix = "/test-inv-legacy-empty-nokey"
+
+			seedLegacyInventory(cli, prefix, "")
+			corrupt(cli, prefix)
+
+			b := NewEtcdBackendFromClient(cli, prefix, 5*time.Second)
+			Expect(b.EnsureReady(ctx)).To(Succeed(), "%s: EnsureReady itself succeeds", name)
+			headResp, err := cli.Get(ctx, prefix+"/inventory/hmac")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(headResp.Kvs).To(HaveLen(1), "%s: the unverifiable head must be left in place", name)
+
+			svc := NewWithBackend(b, filepath.Join(GinkgoT().TempDir(), "private"))
+			Expect(svc.InitHMAC(ctx)).To(MatchError(ErrInventoryTampered),
+				"%s: verification must stay fail-closed", name)
+			b.Close()
+			stop()
+		}
+	})
+
+	It("lets two replicas decompose concurrently without double-importing", func() {
+		// The mainline cluster upgrade: every replica starts together against
+		// the same legacy blob. The inventory-decompose lock plus the
+		// post-lock re-read make the loser a cheap no-op.
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		ctx := context.Background()
+		const prefix = "/test-inv-legacy-concurrent"
+
+		const total = 40
+		blob := ""
+		for i := 1; i <= total; i++ {
+			blob += fmt.Sprintf("%04d 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node%d\n", i, i%4)
+		}
+		seedLegacyInventory(cli, prefix, blob)
+
+		a := NewEtcdBackendFromClient(cli, prefix, 5*time.Second)
+		b := NewEtcdBackendFromClient(cli, prefix, 5*time.Second)
+		defer a.Close()
+		defer b.Close()
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		for _, backend := range []*EtcdBackend{a, b} {
+			go func() {
+				defer GinkgoRecover()
+				defer wg.Done()
+				Expect(backend.EnsureReady(ctx)).To(Succeed(), "concurrent EnsureReady")
+			}()
+		}
+		wg.Wait()
+
+		resp, err := cli.Get(ctx, prefix+"/inventory/entries/", clientv3.WithPrefix(), clientv3.WithCountOnly())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Count).To(Equal(int64(total)), "exactly one import's worth of entry keys")
+
+		svc := NewWithBackend(a, filepath.Join(GinkgoT().TempDir(), "private"))
+		Expect(svc.InitHMAC(ctx)).To(Succeed())
+		inv, err := svc.ReadInventory(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(inv)).To(Equal(blob), "the converged inventory must render the original blob")
 	})
 
 	It("fails startup when the stored head cannot be verified because the HMAC key is missing", func() {

--- a/internal/storage/etcd_integration_test.go
+++ b/internal/storage/etcd_integration_test.go
@@ -539,9 +539,52 @@ var _ = Describe("EtcdInventoryStore", func() {
 		Expect(b.AppendLine(ctx, KeyInventory, []byte("0001 nb na /node3\n"), BlobPrivate)).
 			To(MatchError(ErrDuplicateSerial), "stored serials must be rejected")
 
+		// This path appends in one transaction, so it is explicitly bounded
+		// rather than left to trip the server's --max-txn-ops opaquely.
+		big := ""
+		for i := 100; i < 100+etcdImportBatch+1; i++ {
+			big += fmt.Sprintf("%04d nb na /bulk%d\n", i, i)
+		}
+		err = b.AppendLine(ctx, KeyInventory, []byte(big), BlobPrivate)
+		Expect(err).To(HaveOccurred(), "oversized direct appends must be refused")
+		Expect(err.Error()).To(ContainSubstring("max-txn-ops"), "the error must name the limit")
+
 		entries, err = b.Entries(ctx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(entries).To(HaveLen(2), "rejected appends must not add entries")
+	})
+
+	It("serves a not-yet-decomposed legacy blob verbatim before EnsureReady has run", func() {
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		ctx := context.Background()
+		const prefix = "/test-inv-pre-ensure"
+
+		blob := "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1\n"
+		_, err := cli.Put(ctx, prefix+"/inventory/data", string(encodeBlob(time.Now(), []byte(blob))))
+		Expect(err).NotTo(HaveOccurred())
+
+		// Deliberately no EnsureReady: reads must stay correct regardless.
+		b := NewEtcdBackendFromClient(cli, prefix, 5*time.Second)
+		defer b.Close()
+		got, err := b.Get(ctx, KeyInventory)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(got)).To(Equal(blob), "the legacy blob must be passed through verbatim")
+	})
+
+	It("reads a touched-but-empty inventory as present and empty, not absent", func() {
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		b := newBackend(cli, "/test-inv-empty")
+		ctx := context.Background()
+
+		svc := NewWithBackend(b, "")
+		Expect(svc.TouchInventory(ctx)).To(Succeed(), "TouchInventory")
+
+		got, err := b.Get(ctx, KeyInventory)
+		Expect(err).NotTo(HaveOccurred(), "Get after TouchInventory")
+		Expect(got).NotTo(BeNil(), "present-but-empty must be a non-nil slice, matching the other backends")
+		Expect(got).To(BeEmpty())
 	})
 
 	It("replaces and serves the inventory through the Put/Get shim", func() {
@@ -628,6 +671,35 @@ var _ = Describe("EtcdInventoryPrune", func() {
 		Expect(removed).To(BeEmpty())
 	})
 
+	It("drops the by-subject key when a subject's every entry is pruned", func() {
+		// The mainline cleanup case: a decommissioned node whose issuances
+		// have all expired. etcd is the only backend where the subject index
+		// is hand-maintained, so the delete arm needs its own spec.
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		svc, _ := newEtcdInventoryService(cli, "/test-inv-prune-subject")
+		ctx := context.Background()
+
+		for _, line := range sampleInventoryLines {
+			Expect(svc.AppendInventory(ctx, line)).To(Succeed())
+		}
+
+		// node2's only issuance is 0002; pruning it must remove the subject
+		// from the index entirely, not leave a dangling pointer.
+		removed, err := svc.PruneInventory(ctx, keepNotSerial("0002"))
+		Expect(err).NotTo(HaveOccurred(), "PruneInventory")
+		Expect(removed).To(HaveLen(1))
+
+		_, err = svc.LatestSerialForSubject(ctx, "node2")
+		Expect(err).To(MatchError(fs.ErrNotExist), "fully-pruned subject must vanish from the index")
+		serial, err := svc.LatestSerialForSubject(ctx, "node1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(serial).To(Equal("0003"), "unaffected subjects keep their pointer")
+
+		_, err = svc.ReadInventory(ctx)
+		Expect(err).NotTo(HaveOccurred(), "chain must verify after the prune")
+	})
+
 	It("prunes more entries than one transaction batch holds, staying consistent throughout", func() {
 		cli, stop := startEmbeddedEtcd()
 		defer stop()
@@ -640,31 +712,160 @@ var _ = Describe("EtcdInventoryPrune", func() {
 			Expect(svc.AppendInventory(ctx, line)).To(Succeed())
 		}
 
-		// Remove the first 65 serials: spans three etcdPruneBatch (30)
-		// transactions, so the batched path with intermediate heads runs.
-		keep := func(e InventoryEntry) bool { return e.Serial > "0065" }
+		// Remove the first 65 serials plus all of node3's later issuances
+		// (0067, 0075): spans three etcdPruneBatch (30) transactions, so the
+		// batched path with intermediate heads runs, and node3 loses every
+		// entry so the multi-batch subject-index delete arm runs too.
+		keep := func(e InventoryEntry) bool { return e.Serial > "0065" && e.Subject != "node3" }
 		removed, err := svc.PruneInventory(ctx, keep)
 		Expect(err).NotTo(HaveOccurred(), "PruneInventory")
-		Expect(removed).To(HaveLen(65))
+		Expect(removed).To(HaveLen(67))
 
 		inv, err := svc.ReadInventory(ctx)
 		Expect(err).NotTo(HaveOccurred(), "ReadInventory after batched prune (head inconsistent?)")
 		lines := bytes.Split(bytes.TrimRight(inv, "\n"), []byte{'\n'})
-		Expect(lines).To(HaveLen(total - 65))
+		Expect(lines).To(HaveLen(total - 67))
 		Expect(string(bytes.Fields(lines[0])[0])).To(Equal("0066"), "survivors keep issuance order")
 
-		// node7's newest surviving serial is 0079 (79 mod 8 == 7).
+		// node7's newest surviving serial is 0079 (79 mod 8 == 7); node3 has
+		// no survivors at all.
 		serial, err := svc.LatestSerialForSubject(ctx, "node7")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(serial).To(Equal("0079"))
+		_, err = svc.LatestSerialForSubject(ctx, "node3")
+		Expect(err).To(MatchError(fs.ErrNotExist), "node3 lost every entry across batches")
 
 		Expect(svc.AppendInventory(ctx, "9999 2024-06-01T00:00:00UTC 2029-06-01T00:00:00UTC /fresh")).To(Succeed(), "append after batched prune")
 		_, err = svc.ReadInventory(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	})
+
+	It("returns every removed entry even when a fence conflict interrupts the batches", func() {
+		// A concurrent writer between batches conflicts the fence; the prune
+		// restarts from a fresh read. Entries deleted by the already-committed
+		// batches no longer appear in that re-read, so they must be carried
+		// over into the final result — CleanupExpiredCerts drives CRL entry
+		// removal and cert-blob deletion from exactly this list.
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		svc, b := newEtcdInventoryService(cli, "/test-inv-prune-conflict")
+		ctx := context.Background()
+
+		const total = 80
+		for i := 1; i <= total; i++ {
+			line := fmt.Sprintf("%04d 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node%d", i, i%8)
+			Expect(svc.AppendInventory(ctx, line)).To(Succeed())
+		}
+
+		// After the first committed batch, bump the fence exactly once, as a
+		// concurrent append from another replica would.
+		fired := false
+		b.pruneBatchHook = func() {
+			if fired {
+				return
+			}
+			fired = true
+			_, err := cli.Put(ctx, "/test-inv-prune-conflict/inventory/seq", fmt.Sprintf("%d", total))
+			Expect(err).NotTo(HaveOccurred(), "hook: bump fence")
+		}
+		defer func() { b.pruneBatchHook = nil }()
+
+		removed, err := svc.PruneInventory(ctx, func(e InventoryEntry) bool { return e.Serial > "0065" })
+		Expect(err).NotTo(HaveOccurred(), "PruneInventory")
+		Expect(fired).To(BeTrue(), "the conflict must actually have been injected")
+		Expect(removed).To(HaveLen(65), "removals committed before the conflict must be included")
+		serials := make(map[string]bool, len(removed))
+		for i, e := range removed {
+			serials[e.Serial] = true
+			Expect(e.Serial).To(Equal(fmt.Sprintf("%04d", i+1)), "issuance order restored across attempts")
+		}
+		Expect(serials).To(HaveLen(65), "no entry reported twice")
+
+		inv, err := svc.ReadInventory(ctx)
+		Expect(err).NotTo(HaveOccurred(), "chain must verify after the conflicted prune")
+		Expect(bytes.Split(bytes.TrimRight(inv, "\n"), []byte{'\n'})).To(HaveLen(total - 65))
+	})
+})
+
+// EtcdInventoryChainTamperDetection mirrors the SQL backend's tamper specs:
+// the chain head is etcd's only inventory tamper signal, and per-entry keys
+// are individually writable by anything with etcd access, so each mutation
+// class needs an explicit negative control proving verification can fail.
+var _ = Describe("EtcdInventoryChainTamperDetection", func() {
+	seed := func(cli *clientv3.Client, prefix string) *StorageService {
+		svc, _ := newEtcdInventoryService(cli, prefix)
+		for _, line := range sampleInventoryLines {
+			Expect(svc.AppendInventory(context.Background(), line)).To(Succeed())
+		}
+		return svc
+	}
+
+	It("detects a modified entry", func() {
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		ctx := context.Background()
+		svc := seed(cli, "/test-tamper-modify")
+
+		forged, err := encodeInventoryRecord(CertRecord{InventoryEntry: InventoryEntry{
+			Serial: "BEEF", NotBefore: "2024-01-01T00:00:00UTC", NotAfter: "2029-01-01T00:00:00UTC", Subject: "node1",
+		}})
+		Expect(err).NotTo(HaveOccurred())
+		_, err = cli.Put(ctx, fmt.Sprintf("/test-tamper-modify/inventory/entries/%020d", 1), string(forged))
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = svc.ReadInventory(ctx)
+		Expect(err).To(MatchError(ErrInventoryTampered), "a rewritten entry must fail verification")
+	})
+
+	It("detects an inserted entry", func() {
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		ctx := context.Background()
+		svc := seed(cli, "/test-tamper-insert")
+
+		forged, err := encodeInventoryRecord(CertRecord{InventoryEntry: InventoryEntry{
+			Serial: "BEEF", NotBefore: "2024-01-01T00:00:00UTC", NotAfter: "2029-01-01T00:00:00UTC", Subject: "intruder",
+		}})
+		Expect(err).NotTo(HaveOccurred())
+		_, err = cli.Put(ctx, fmt.Sprintf("/test-tamper-insert/inventory/entries/%020d", 99), string(forged))
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = svc.ReadInventory(ctx)
+		Expect(err).To(MatchError(ErrInventoryTampered), "an out-of-band entry must fail verification")
+	})
+
+	It("detects a deleted entry", func() {
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		ctx := context.Background()
+		svc := seed(cli, "/test-tamper-delete")
+
+		_, err := cli.Delete(ctx, fmt.Sprintf("/test-tamper-delete/inventory/entries/%020d", 2))
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = svc.ReadInventory(ctx)
+		Expect(err).To(MatchError(ErrInventoryTampered), "a removed entry must fail verification")
+	})
 })
 
 // --- Legacy blob decomposition ---
+
+// legacyHMACKey is the fixture HMAC key used to seed pre-decomposition state.
+var legacyHMACKey = bytes.Repeat([]byte{0x42}, 32)
+
+// seedLegacyInventory writes the exact state a pre-decomposition version
+// leaves behind: the inventory text at inventory/data, its whole-blob HMAC at
+// inventory/hmac, and the HMAC key.
+func seedLegacyInventory(cli *clientv3.Client, prefix, blob string) {
+	ctx := context.Background()
+	now := time.Now()
+	_, err := cli.Put(ctx, prefix+"/private/hmac_key", string(encodeBlob(now, legacyHMACKey)))
+	Expect(err).NotTo(HaveOccurred())
+	_, err = cli.Put(ctx, prefix+"/inventory/data", string(encodeBlob(now, []byte(blob))))
+	Expect(err).NotTo(HaveOccurred())
+	_, err = cli.Put(ctx, prefix+"/inventory/hmac", string(encodeBlob(now, wholeBlobInventoryMAC(legacyHMACKey, []byte(blob)))))
+	Expect(err).NotTo(HaveOccurred())
+}
 
 var _ = Describe("EtcdLegacyInventoryDecompose", func() {
 	It("imports a pre-decomposition blob on EnsureReady and re-baselines integrity", func() {
@@ -673,21 +874,14 @@ var _ = Describe("EtcdLegacyInventoryDecompose", func() {
 		ctx := context.Background()
 		const prefix = "/test-inv-legacy"
 
-		// Seed the exact state a pre-decomposition version leaves behind: the
-		// inventory text at inventory/data, a whole-blob HMAC under
-		// inventory/hmac, and the HMAC key.
-		key := bytes.Repeat([]byte{0x42}, 32)
+		// A blob larger than etcdImportBatch (32), so the import spans
+		// several transactions — the shape every real CA's upgrade takes.
+		const total = 80
 		blob := ""
-		for _, line := range sampleInventoryLines {
-			blob += line + "\n"
+		for i := 1; i <= total; i++ {
+			blob += fmt.Sprintf("%04d 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node%d\n", i, i%8)
 		}
-		now := time.Now()
-		_, err := cli.Put(ctx, prefix+"/private/hmac_key", string(encodeBlob(now, key)))
-		Expect(err).NotTo(HaveOccurred())
-		_, err = cli.Put(ctx, prefix+"/inventory/data", string(encodeBlob(now, []byte(blob))))
-		Expect(err).NotTo(HaveOccurred())
-		_, err = cli.Put(ctx, prefix+"/inventory/hmac", string(encodeBlob(now, wholeBlobInventoryMAC(key, []byte(blob)))))
-		Expect(err).NotTo(HaveOccurred())
+		seedLegacyInventory(cli, prefix, blob)
 
 		// newBackend runs EnsureReady, which performs the decomposition.
 		b := newBackend(cli, prefix)
@@ -695,10 +889,10 @@ var _ = Describe("EtcdLegacyInventoryDecompose", func() {
 
 		resp, err := cli.Get(ctx, prefix+"/inventory/entries/", clientv3.WithPrefix(), clientv3.WithCountOnly())
 		Expect(err).NotTo(HaveOccurred())
-		Expect(resp.Count).To(Equal(int64(len(sampleInventoryLines))), "blob lines must become entry keys")
+		Expect(resp.Count).To(Equal(int64(total)), "blob lines must become entry keys")
 		headResp, err := cli.Get(ctx, prefix+"/inventory/hmac")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(headResp.Kvs).To(BeEmpty(), "the whole-blob HMAC must be dropped: it is not a chain head")
+		Expect(headResp.Kvs).To(BeEmpty(), "the verified whole-blob HMAC must be dropped: it is not a chain head")
 
 		// InitHMAC re-baselines from the imported entries and verifies clean.
 		svc := NewWithBackend(b, filepath.Join(GinkgoT().TempDir(), "private"))
@@ -706,20 +900,159 @@ var _ = Describe("EtcdLegacyInventoryDecompose", func() {
 		inv, err := svc.ReadInventory(ctx)
 		Expect(err).NotTo(HaveOccurred(), "ReadInventory")
 		Expect(string(inv)).To(Equal(blob), "decomposed inventory must render the original text")
-		serial, err := svc.LatestSerialForSubject(ctx, "node1")
+		serial, err := svc.LatestSerialForSubject(ctx, "node7")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(serial).To(Equal("0003"), "the subject index must be built from the blob")
+		Expect(serial).To(Equal("0079"), "the subject index must be built from the blob")
 
 		// Running EnsureReady again must be a no-op.
 		Expect(b.EnsureReady(ctx)).To(Succeed(), "EnsureReady (again)")
 		resp, err = cli.Get(ctx, prefix+"/inventory/entries/", clientv3.WithPrefix(), clientv3.WithCountOnly())
 		Expect(err).NotTo(HaveOccurred())
-		Expect(resp.Count).To(Equal(int64(len(sampleInventoryLines))), "a second EnsureReady must not re-import")
+		Expect(resp.Count).To(Equal(int64(total)), "a second EnsureReady must not re-import")
 
 		// Appends extend the decomposed inventory and the fresh chain.
-		Expect(svc.AppendInventory(ctx, "0004 2024-01-04T00:00:00UTC 2029-01-04T00:00:00UTC /node3")).To(Succeed())
+		Expect(svc.AppendInventory(ctx, "9999 2024-01-04T00:00:00UTC 2029-01-04T00:00:00UTC /fresh")).To(Succeed())
 		_, err = svc.ReadInventory(ctx)
 		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("resumes an interrupted import from the intact blob", func() {
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		ctx := context.Background()
+		const prefix = "/test-inv-legacy-resume"
+
+		blob := ""
+		for _, line := range sampleInventoryLines {
+			blob += line + "\n"
+		}
+		seedLegacyInventory(cli, prefix, blob)
+
+		// Simulate a crash after the first import batch: the wipe ran and one
+		// entry was written, but the marker (and blob) were never emptied.
+		recs, err := parseInventoryRecords([]byte(blob))
+		Expect(err).NotTo(HaveOccurred())
+		val, err := encodeInventoryRecord(recs[0])
+		Expect(err).NotTo(HaveOccurred())
+		_, err = cli.Put(ctx, fmt.Sprintf("%s/inventory/entries/%020d", prefix, 1), string(val))
+		Expect(err).NotTo(HaveOccurred())
+		_, err = cli.Put(ctx, prefix+"/inventory/seq", "1")
+		Expect(err).NotTo(HaveOccurred())
+
+		b := newBackend(cli, prefix)
+		defer b.Close()
+
+		resp, err := cli.Get(ctx, prefix+"/inventory/entries/", clientv3.WithPrefix(), clientv3.WithCountOnly())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Count).To(Equal(int64(len(sampleInventoryLines))), "the interrupted import must be redone in full")
+
+		svc := NewWithBackend(b, filepath.Join(GinkgoT().TempDir(), "private"))
+		Expect(svc.InitHMAC(ctx)).To(Succeed())
+		inv, err := svc.ReadInventory(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(inv)).To(Equal(blob), "nothing from the blob may be lost to the interruption")
+	})
+
+	It("refuses to decompose when the blob and existing entries contradict each other", func() {
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		ctx := context.Background()
+		const prefix = "/test-inv-legacy-mixed"
+
+		seedLegacyInventory(cli, prefix, "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1\n")
+
+		// An entry that is not the import-written prefix of the blob — the
+		// state a mixed-version cluster produces.
+		val, err := encodeInventoryRecord(CertRecord{InventoryEntry: InventoryEntry{
+			Serial: "0009", NotBefore: "2024-01-01T00:00:00UTC", NotAfter: "2029-01-01T00:00:00UTC", Subject: "other",
+		}})
+		Expect(err).NotTo(HaveOccurred())
+		_, err = cli.Put(ctx, fmt.Sprintf("%s/inventory/entries/%020d", prefix, 1), string(val))
+		Expect(err).NotTo(HaveOccurred())
+
+		b := NewEtcdBackendFromClient(cli, prefix, 5*time.Second)
+		defer b.Close()
+		err = b.EnsureReady(ctx)
+		Expect(err).To(HaveOccurred(), "conflicting states must not be silently resolved")
+		Expect(err.Error()).To(ContainSubstring("do not match"), "the error must explain the conflict")
+
+		// Neither side may have been destroyed by the refusal.
+		blobResp, err := cli.Get(ctx, prefix+"/inventory/data")
+		Expect(err).NotTo(HaveOccurred())
+		_, payload, err := decodeBlob(blobResp.Kvs[0].Value)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(payload).NotTo(BeEmpty(), "the legacy blob must survive the refusal")
+	})
+
+	It("fails startup when the legacy blob does not match its stored HMAC", func() {
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		ctx := context.Background()
+		const prefix = "/test-inv-legacy-tampered"
+
+		seedLegacyInventory(cli, prefix, "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1\n")
+		// Tamper with the blob after the MAC was computed.
+		tampered := "0002 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /evil\n"
+		_, err := cli.Put(ctx, prefix+"/inventory/data", string(encodeBlob(time.Now(), []byte(tampered))))
+		Expect(err).NotTo(HaveOccurred())
+
+		b := NewEtcdBackendFromClient(cli, prefix, 5*time.Second)
+		defer b.Close()
+		Expect(b.EnsureReady(ctx)).To(MatchError(ErrInventoryTampered),
+			"a blob failing its own MAC must not become the new trusted baseline")
+
+		resp, err := cli.Get(ctx, prefix+"/inventory/entries/", clientv3.WithPrefix(), clientv3.WithCountOnly())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Count).To(BeZero(), "nothing may be imported from an unverified blob")
+	})
+
+	It("fails startup on a malformed legacy line, leaving the blob intact", func() {
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		ctx := context.Background()
+		const prefix = "/test-inv-legacy-malformed"
+
+		blob := "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1\ntruncated line\n"
+		seedLegacyInventory(cli, prefix, blob)
+
+		b := NewEtcdBackendFromClient(cli, prefix, 5*time.Second)
+		defer b.Close()
+		err := b.EnsureReady(ctx)
+		Expect(err).To(HaveOccurred(), "a corrupt blob must fail loudly, not import partially")
+		Expect(err.Error()).To(ContainSubstring("truncated line"), "the error must name the offending line")
+
+		blobResp, err := cli.Get(ctx, prefix+"/inventory/data")
+		Expect(err).NotTo(HaveOccurred())
+		_, payload, err := decodeBlob(blobResp.Kvs[0].Value)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(payload)).To(Equal(blob), "the blob must be untouched for the operator to repair")
+	})
+
+	It("tolerates duplicate serials in the legacy blob, pointing by-serial at the newest", func() {
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		ctx := context.Background()
+		const prefix = "/test-inv-legacy-dup"
+
+		// Blob backends never guaranteed cluster-wide serial uniqueness, so a
+		// legacy inventory can carry repeats; refusing would brick startup.
+		blob := "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1\n" +
+			"0001 2024-01-02T00:00:00UTC 2029-01-02T00:00:00UTC /node2\n"
+		seedLegacyInventory(cli, prefix, blob)
+
+		b := newBackend(cli, prefix)
+		defer b.Close()
+
+		svc := NewWithBackend(b, filepath.Join(GinkgoT().TempDir(), "private"))
+		Expect(svc.InitHMAC(ctx)).To(Succeed())
+		inv, err := svc.ReadInventory(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(inv)).To(Equal(blob), "both lines must be imported verbatim")
+
+		// The duplicate-serial guard works off the (deduplicated) by-serial
+		// index: the serial stays taken.
+		err = svc.AppendInventory(ctx, "0001 2024-01-03T00:00:00UTC 2029-01-03T00:00:00UTC /node3")
+		Expect(err).To(MatchError(ErrDuplicateSerial))
 	})
 })
 
@@ -795,12 +1128,44 @@ var _ = Describe("EtcdCertIndex", func() {
 	It("treats unknown serials as no-ops for revocation and projection writes", func() {
 		cli, stop := startEmbeddedEtcd()
 		defer stop()
-		svc, _ := newEtcdInventoryService(cli, "/test-certindex-noop")
+		svc, b := newEtcdInventoryService(cli, "/test-certindex-noop")
 		ctx := context.Background()
 
 		Expect(svc.MarkCertRevoked(ctx, "FFFF", time.Now())).To(Succeed())
 		Expect(svc.ClearCertRevoked(ctx, "FFFF")).To(Succeed())
 		Expect(svc.SetCertProjection(ctx, "FFFF", CertProjection{Fingerprint: "aa"})).To(Succeed())
+
+		// "No-op" means no observable state, not merely no error: nothing may
+		// have been created anywhere under the inventory namespace.
+		entries, err := b.Entries(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(entries).To(BeEmpty(), "no entry may be conjured for an unknown serial")
+		resp, err := cli.Get(ctx, "/test-certindex-noop/inventory/entries/", clientv3.WithPrefix(), clientv3.WithCountOnly())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Count).To(BeZero())
+		resp, err = cli.Get(ctx, "/test-certindex-noop/inventory/by-serial/", clientv3.WithPrefix(), clientv3.WithCountOnly())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Count).To(BeZero(), "no by-serial key may be conjured either")
+	})
+
+	It("treats a dangling by-serial pointer as a no-op instead of recreating the entry", func() {
+		// A prune deletes the entry and its by-serial key in one transaction,
+		// but mutateRecordBySerial reads the two keys separately, so it can
+		// observe a by-serial key whose entry a concurrent prune just removed.
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		svc, _ := newEtcdInventoryService(cli, "/test-certindex-dangling")
+		ctx := context.Background()
+
+		Expect(svc.AppendInventory(ctx, "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1")).To(Succeed())
+		// Delete just the entry key, leaving by-serial behind.
+		_, err := cli.Delete(ctx, fmt.Sprintf("/test-certindex-dangling/inventory/entries/%020d", 1))
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(svc.MarkCertRevoked(ctx, "0001", time.Now())).To(Succeed(), "dangling pointer must be a no-op")
+		resp, err := cli.Get(ctx, "/test-certindex-dangling/inventory/entries/", clientv3.WithPrefix(), clientv3.WithCountOnly())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Count).To(BeZero(), "the pruned entry must not be recreated")
 	})
 })
 

--- a/internal/storage/etcd_integration_test.go
+++ b/internal/storage/etcd_integration_test.go
@@ -178,50 +178,72 @@ var _ = Describe("EtcdBackendList", func() {
 	})
 })
 
-var _ = Describe("EtcdBackendAppendLineConcurrent", func() {
-	It("does not lose lines under concurrent appends from two backends", func() {
+// newEtcdInventoryService wraps a fresh backend on prefix in a StorageService
+// with the inventory touched and integrity initialised. Multiple services may
+// share a prefix; the first to initialise creates the HMAC key, the rest read
+// it back.
+func newEtcdInventoryService(cli *clientv3.Client, prefix string) (*StorageService, *EtcdBackend) {
+	b := newBackend(cli, prefix)
+	svc := NewWithBackend(b, filepath.Join(GinkgoT().TempDir(), "private"))
+	ctx := context.Background()
+	Expect(svc.EnsureDirs(ctx)).To(Succeed(), "EnsureDirs")
+	Expect(svc.TouchInventory(ctx)).To(Succeed(), "TouchInventory")
+	Expect(svc.InitHMAC(ctx)).To(Succeed(), "InitHMAC")
+	return svc, b
+}
+
+// EtcdInventoryConcurrentAppends drives concurrent AppendInventory calls
+// through two StorageServices sharing one etcd prefix (simulating two
+// replicas) with integrity enabled. Afterwards ReadInventory — which verifies
+// the hash chain — must succeed on both replicas, proving the chained head
+// never forked, and every appended line must appear exactly once.
+var _ = Describe("EtcdInventoryConcurrentAppends", func() {
+	It("loses no entries and keeps the hash chain intact across two replicas", func() {
 		cli, stop := startEmbeddedEtcd()
 		defer stop()
-		// Two backends sharing the cluster → simulates two processes.
-		a := newBackend(cli, "/test-append")
-		b := newBackend(cli, "/test-append")
+		svcA, _ := newEtcdInventoryService(cli, "/test-append")
+		svcB, _ := newEtcdInventoryService(cli, "/test-append")
 
 		const writers = 4
 		const perWriter = 25
 		var wg sync.WaitGroup
 		wg.Add(writers)
 		for w := 0; w < writers; w++ {
-			backend := a
+			svc := svcA
 			if w%2 == 1 {
-				backend = b
+				svc = svcB
 			}
-			w := w
 			go func() {
 				defer GinkgoRecover()
 				defer wg.Done()
 				for i := 0; i < perWriter; i++ {
-					line := fmt.Sprintf("w%d-i%d\n", w, i)
-					Expect(backend.AppendLine(context.Background(), KeyInventory, []byte(line), BlobPrivate)).To(Succeed(), "AppendLine")
+					line := fmt.Sprintf("%02d%02d 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /w%d", w, i, w)
+					Expect(svc.AppendInventory(context.Background(), line)).To(Succeed(), "AppendInventory")
 				}
 			}()
 		}
 		wg.Wait()
 
-		data, err := a.Get(context.Background(), KeyInventory)
-		Expect(err).NotTo(HaveOccurred(), "Get after appends")
+		// ReadInventory verifies the chained head before returning; success
+		// on both replicas proves entries and head stayed in sync throughout.
+		data, err := svcA.ReadInventory(context.Background())
+		Expect(err).NotTo(HaveOccurred(), "ReadInventory on A (chain forked?)")
+		_, err = svcB.ReadInventory(context.Background())
+		Expect(err).NotTo(HaveOccurred(), "ReadInventory on B (chain forked?)")
+
 		lines := bytes.Split(bytes.TrimRight(data, "\n"), []byte{'\n'})
 		Expect(lines).To(HaveLen(writers*perWriter), "got %d lines, want %d (no lines were lost?)", len(lines), writers*perWriter)
 
 		// Set-equality: a lost line masked by a duplicated one nets to the
-		// same count, so assert every expected token appears exactly once.
+		// same count, so assert every expected serial appears exactly once.
 		seen := make(map[string]int, writers*perWriter)
 		for _, l := range lines {
-			seen[string(l)]++
+			seen[string(bytes.Fields(l)[0])]++
 		}
 		for w := 0; w < writers; w++ {
 			for i := 0; i < perWriter; i++ {
-				tok := fmt.Sprintf("w%d-i%d", w, i)
-				Expect(seen[tok]).To(Equal(1), "token %q appeared %d times, want exactly 1", tok, seen[tok])
+				serial := fmt.Sprintf("%02d%02d", w, i)
+				Expect(seen[serial]).To(Equal(1), "serial %q appeared %d times, want exactly 1", serial, seen[serial])
 			}
 		}
 	})
@@ -259,8 +281,8 @@ var _ = Describe("EtcdBackendEndToEndViaStorageService", func() {
 		Expect(string(inv)).To(Equal(line1+"\n"+line2+"\n"), "ReadInventory = %q, want %q", inv, line1+"\n"+line2+"\n")
 
 		// Re-appending line1's serial (0001) under a different subject must be
-		// rejected by the blob-path duplicate scan, and must not mutate the
-		// inventory.
+		// rejected by the by-serial guard in the append transaction, and must
+		// not mutate the inventory.
 		dup := "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node3"
 		Expect(svc.AppendInventory(context.Background(), dup)).To(MatchError(ErrDuplicateSerial), "duplicate serial must be rejected")
 		inv, err = svc.ReadInventory(context.Background())
@@ -436,5 +458,387 @@ var _ = Describe("EtcdBackendWithLockCrossBackend", func() {
 		}
 		wg.Wait()
 		Expect(maxSeen.Load()).To(Equal(int32(1)), "maxSeen = %d, want 1", maxSeen.Load())
+	})
+})
+
+// --- InventoryStore ---
+
+var _ = Describe("EtcdInventoryStore", func() {
+	It("stores appends as per-entry keys and renders byte-identical inventory text", func() {
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		svc, b := newEtcdInventoryService(cli, "/test-inv-store")
+		ctx := context.Background()
+
+		for _, line := range sampleInventoryLines {
+			Expect(svc.AppendInventory(ctx, line)).To(Succeed(), "AppendInventory(%q)", line)
+		}
+
+		inv, err := svc.ReadInventory(ctx)
+		Expect(err).NotTo(HaveOccurred(), "ReadInventory")
+		want := ""
+		for _, line := range sampleInventoryLines {
+			want += line + "\n"
+		}
+		Expect(string(inv)).To(Equal(want), "rendered inventory must be byte-identical to the appended lines")
+
+		// The entries really are decomposed: one key per issuance.
+		resp, err := cli.Get(ctx, "/test-inv-store/inventory/entries/", clientv3.WithPrefix(), clientv3.WithCountOnly())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Count).To(Equal(int64(len(sampleInventoryLines))), "one entry key per appended line")
+
+		entries, err := b.Entries(ctx)
+		Expect(err).NotTo(HaveOccurred(), "Entries")
+		Expect(entries).To(HaveLen(3))
+		Expect(entries[2].Serial).To(Equal("0003"), "issuance order preserved")
+
+		// Subject lookups come from the by-subject index.
+		serial, err := svc.LatestSerialForSubject(ctx, "node1")
+		Expect(err).NotTo(HaveOccurred(), "LatestSerialForSubject")
+		Expect(serial).To(Equal("0003"), "node1's later issuance wins")
+		_, err = svc.LatestSerialForSubject(ctx, "unknown")
+		Expect(err).To(MatchError(fs.ErrNotExist), "unknown subject must wrap fs.ErrNotExist")
+	})
+
+	It("rejects a duplicate serial across two replicas", func() {
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		svcA, _ := newEtcdInventoryService(cli, "/test-inv-dup")
+		svcB, _ := newEtcdInventoryService(cli, "/test-inv-dup")
+		ctx := context.Background()
+
+		Expect(svcA.AppendInventory(ctx, "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1")).To(Succeed())
+		err := svcB.AppendInventory(ctx, "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node2")
+		Expect(err).To(MatchError(ErrDuplicateSerial), "replica B must see replica A's serial")
+		Expect(svcB.AppendInventory(ctx, "0002 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node2")).To(Succeed())
+
+		inv, err := svcA.ReadInventory(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(inv)).To(Equal(
+			"0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1\n"+
+				"0002 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node2\n"),
+			"the rejected duplicate must not have left any trace")
+	})
+
+	It("appends parsed rows for direct AppendLine calls and rejects bad input", func() {
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		_, b := newEtcdInventoryService(cli, "/test-inv-appendline")
+		ctx := context.Background()
+
+		lines := "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1\n" +
+			"0002 2024-01-02T00:00:00UTC 2029-01-02T00:00:00UTC /node2\n"
+		Expect(b.AppendLine(ctx, KeyInventory, []byte(lines), BlobPrivate)).To(Succeed(), "AppendLine")
+
+		entries, err := b.Entries(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(entries).To(HaveLen(2))
+
+		Expect(b.AppendLine(ctx, KeyInventory, []byte("too few fields\n"), BlobPrivate)).
+			To(HaveOccurred(), "malformed lines must be rejected, not dropped")
+		Expect(b.AppendLine(ctx, KeyInventory, []byte("0001 nb na /node3\n"), BlobPrivate)).
+			To(MatchError(ErrDuplicateSerial), "stored serials must be rejected")
+
+		entries, err = b.Entries(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(entries).To(HaveLen(2), "rejected appends must not add entries")
+	})
+
+	It("replaces and serves the inventory through the Put/Get shim", func() {
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		b := newBackend(cli, "/test-inv-shim")
+		ctx := context.Background()
+
+		// Never initialised → absent.
+		_, err := b.Get(ctx, KeyInventory)
+		Expect(err).To(MatchError(fs.ErrNotExist), "Get before init")
+
+		blob := "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1\n" +
+			"0002 2024-01-02T00:00:00UTC 2029-01-02T00:00:00UTC /node2\n"
+		Expect(b.Put(ctx, KeyInventory, []byte(blob), BlobPrivate)).To(Succeed(), "Put")
+
+		got, err := b.Get(ctx, KeyInventory)
+		Expect(err).NotTo(HaveOccurred(), "Get")
+		Expect(string(got)).To(Equal(blob), "render must be byte-identical to the imported blob")
+		ok, err := b.Exists(ctx, KeyInventory)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(BeTrue(), "Exists after Put")
+
+		// Replacement drops the previous contents entirely.
+		replacement := "0009 2025-01-01T00:00:00UTC 2030-01-01T00:00:00UTC /node9\n"
+		Expect(b.Put(ctx, KeyInventory, []byte(replacement), BlobPrivate)).To(Succeed(), "Put (replace)")
+		got, err = b.Get(ctx, KeyInventory)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(got)).To(Equal(replacement))
+		serial, err := b.LatestSerialForSubject(ctx, "node9")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(serial).To(Equal("0009"), "indices must be rebuilt on replace")
+		_, err = b.LatestSerialForSubject(ctx, "node1")
+		Expect(err).To(MatchError(fs.ErrNotExist), "replaced subjects must vanish from the index")
+
+		// A blob with duplicate serials must be rejected, like SQL's unique index.
+		Expect(b.Put(ctx, KeyInventory, []byte("0009 nb na /a\n0009 nb na /b\n"), BlobPrivate)).
+			To(MatchError(ErrDuplicateSerial))
+
+		Expect(b.Delete(ctx, KeyInventory)).To(Succeed(), "Delete")
+		_, err = b.Get(ctx, KeyInventory)
+		Expect(err).To(MatchError(fs.ErrNotExist), "Get after Delete")
+		Expect(b.Delete(ctx, KeyInventory)).To(MatchError(fs.ErrNotExist), "Delete on missing")
+	})
+})
+
+var _ = Describe("EtcdInventoryPrune", func() {
+	It("removes matching entries, rewrites the head, and repoints the subject index", func() {
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		svc, _ := newEtcdInventoryService(cli, "/test-inv-prune")
+		ctx := context.Background()
+
+		for _, line := range sampleInventoryLines {
+			Expect(svc.AppendInventory(ctx, line)).To(Succeed())
+		}
+
+		// Drop node1's *latest* issuance so the subject index must repoint.
+		removed, err := svc.PruneInventory(ctx, keepNotSerial("0003"))
+		Expect(err).NotTo(HaveOccurred(), "PruneInventory")
+		Expect(removed).To(HaveLen(1))
+		Expect(removed[0].Serial).To(Equal("0003"))
+
+		// ReadInventory verifies the chain, so success proves the head was
+		// rewritten for the survivors.
+		inv, err := svc.ReadInventory(ctx)
+		Expect(err).NotTo(HaveOccurred(), "ReadInventory after prune (head not rewritten?)")
+		Expect(string(inv)).To(Equal(
+			"0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1\n" +
+				"0002 2024-01-02T00:00:00UTC 2029-01-02T00:00:00UTC /node2\n"))
+
+		serial, err := svc.LatestSerialForSubject(ctx, "node1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(serial).To(Equal("0001"), "subject index must fall back to the surviving issuance")
+
+		// A pruned serial is free for reuse, and the chain extends cleanly.
+		Expect(svc.AppendInventory(ctx, "0003 2024-01-04T00:00:00UTC 2029-01-04T00:00:00UTC /node3")).To(Succeed())
+		_, err = svc.ReadInventory(ctx)
+		Expect(err).NotTo(HaveOccurred(), "ReadInventory after post-prune append")
+
+		// No-match prunes are a no-op.
+		removed, err = svc.PruneInventory(ctx, func(InventoryEntry) bool { return true })
+		Expect(err).NotTo(HaveOccurred())
+		Expect(removed).To(BeEmpty())
+	})
+
+	It("prunes more entries than one transaction batch holds, staying consistent throughout", func() {
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		svc, _ := newEtcdInventoryService(cli, "/test-inv-prune-big")
+		ctx := context.Background()
+
+		const total = 80
+		for i := 1; i <= total; i++ {
+			line := fmt.Sprintf("%04d 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node%d", i, i%8)
+			Expect(svc.AppendInventory(ctx, line)).To(Succeed())
+		}
+
+		// Remove the first 65 serials: spans three etcdPruneBatch (30)
+		// transactions, so the batched path with intermediate heads runs.
+		keep := func(e InventoryEntry) bool { return e.Serial > "0065" }
+		removed, err := svc.PruneInventory(ctx, keep)
+		Expect(err).NotTo(HaveOccurred(), "PruneInventory")
+		Expect(removed).To(HaveLen(65))
+
+		inv, err := svc.ReadInventory(ctx)
+		Expect(err).NotTo(HaveOccurred(), "ReadInventory after batched prune (head inconsistent?)")
+		lines := bytes.Split(bytes.TrimRight(inv, "\n"), []byte{'\n'})
+		Expect(lines).To(HaveLen(total - 65))
+		Expect(string(bytes.Fields(lines[0])[0])).To(Equal("0066"), "survivors keep issuance order")
+
+		// node7's newest surviving serial is 0079 (79 mod 8 == 7).
+		serial, err := svc.LatestSerialForSubject(ctx, "node7")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(serial).To(Equal("0079"))
+
+		Expect(svc.AppendInventory(ctx, "9999 2024-06-01T00:00:00UTC 2029-06-01T00:00:00UTC /fresh")).To(Succeed(), "append after batched prune")
+		_, err = svc.ReadInventory(ctx)
+		Expect(err).NotTo(HaveOccurred())
+	})
+})
+
+// --- Legacy blob decomposition ---
+
+var _ = Describe("EtcdLegacyInventoryDecompose", func() {
+	It("imports a pre-decomposition blob on EnsureReady and re-baselines integrity", func() {
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		ctx := context.Background()
+		const prefix = "/test-inv-legacy"
+
+		// Seed the exact state a pre-decomposition version leaves behind: the
+		// inventory text at inventory/data, a whole-blob HMAC under
+		// inventory/hmac, and the HMAC key.
+		key := bytes.Repeat([]byte{0x42}, 32)
+		blob := ""
+		for _, line := range sampleInventoryLines {
+			blob += line + "\n"
+		}
+		now := time.Now()
+		_, err := cli.Put(ctx, prefix+"/private/hmac_key", string(encodeBlob(now, key)))
+		Expect(err).NotTo(HaveOccurred())
+		_, err = cli.Put(ctx, prefix+"/inventory/data", string(encodeBlob(now, []byte(blob))))
+		Expect(err).NotTo(HaveOccurred())
+		_, err = cli.Put(ctx, prefix+"/inventory/hmac", string(encodeBlob(now, wholeBlobInventoryMAC(key, []byte(blob)))))
+		Expect(err).NotTo(HaveOccurred())
+
+		// newBackend runs EnsureReady, which performs the decomposition.
+		b := newBackend(cli, prefix)
+		defer b.Close()
+
+		resp, err := cli.Get(ctx, prefix+"/inventory/entries/", clientv3.WithPrefix(), clientv3.WithCountOnly())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Count).To(Equal(int64(len(sampleInventoryLines))), "blob lines must become entry keys")
+		headResp, err := cli.Get(ctx, prefix+"/inventory/hmac")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(headResp.Kvs).To(BeEmpty(), "the whole-blob HMAC must be dropped: it is not a chain head")
+
+		// InitHMAC re-baselines from the imported entries and verifies clean.
+		svc := NewWithBackend(b, filepath.Join(GinkgoT().TempDir(), "private"))
+		Expect(svc.InitHMAC(ctx)).To(Succeed(), "InitHMAC after decomposition")
+		inv, err := svc.ReadInventory(ctx)
+		Expect(err).NotTo(HaveOccurred(), "ReadInventory")
+		Expect(string(inv)).To(Equal(blob), "decomposed inventory must render the original text")
+		serial, err := svc.LatestSerialForSubject(ctx, "node1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(serial).To(Equal("0003"), "the subject index must be built from the blob")
+
+		// Running EnsureReady again must be a no-op.
+		Expect(b.EnsureReady(ctx)).To(Succeed(), "EnsureReady (again)")
+		resp, err = cli.Get(ctx, prefix+"/inventory/entries/", clientv3.WithPrefix(), clientv3.WithCountOnly())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Count).To(Equal(int64(len(sampleInventoryLines))), "a second EnsureReady must not re-import")
+
+		// Appends extend the decomposed inventory and the fresh chain.
+		Expect(svc.AppendInventory(ctx, "0004 2024-01-04T00:00:00UTC 2029-01-04T00:00:00UTC /node3")).To(Succeed())
+		_, err = svc.ReadInventory(ctx)
+		Expect(err).NotTo(HaveOccurred())
+	})
+})
+
+// --- CertIndex ---
+
+var _ = Describe("EtcdCertIndex", func() {
+	It("round-trips the certificate index end to end", func() {
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		svc, b := newEtcdInventoryService(cli, "/test-certindex")
+		ctx := context.Background()
+
+		proj := CertProjection{
+			Fingerprint:    "aa:bb:cc",
+			DNSAltNames:    []string{"node1", "node1.example.com"},
+			AuthExtensions: map[string]string{"pp_auth_role": "webserver"},
+		}
+		Expect(svc.AppendInventory(ctx, "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1")).To(Succeed())
+		Expect(svc.AppendInventoryRecord(ctx, "0003 2024-01-03T00:00:00UTC 2029-01-03T00:00:00UTC /node1", &proj)).To(Succeed())
+		Expect(svc.AppendInventory(ctx, "0002 2024-01-02T00:00:00UTC 2029-01-02T00:00:00UTC /node2")).To(Succeed())
+		// node1 and node2 hold stored certs; node3 has an inventory entry but
+		// no blob and must stay invisible.
+		Expect(svc.AppendInventory(ctx, "0004 2024-01-04T00:00:00UTC 2029-01-04T00:00:00UTC /node3")).To(Succeed())
+		for _, subject := range []string{"node1", "node2"} {
+			Expect(b.Put(ctx, CertKey(subject), []byte("pem-"+subject), BlobPublic)).To(Succeed())
+		}
+
+		recs, ok, err := svc.CertStatuses(ctx, "")
+		Expect(err).NotTo(HaveOccurred(), "CertStatuses")
+		Expect(ok).To(BeTrue(), "etcd backend must advertise the CertIndex capability")
+		Expect(recs).To(HaveLen(2), "one record per subject with a stored cert, latest issuance only")
+		Expect(recs[0].Subject).To(Equal("node1"))
+		Expect(recs[0].Serial).To(Equal("0003"), "node1's latest issuance wins")
+		Expect(recs[0].Fingerprint).To(Equal(proj.Fingerprint))
+		Expect(recs[0].DNSAltNames).To(Equal(proj.DNSAltNames))
+		Expect(recs[0].AuthExtensions).To(Equal(proj.AuthExtensions))
+		Expect(recs[1].Subject).To(Equal("node2"))
+		Expect(recs[1].Fingerprint).To(BeEmpty(), "appended without a projection")
+
+		// Revocation round-trip: idempotent marking keeps the first time, the
+		// state filter partitions, and clearing restores the signed state.
+		revokedAt := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+		Expect(svc.MarkCertRevoked(ctx, "0003", revokedAt)).To(Succeed())
+		Expect(svc.MarkCertRevoked(ctx, "0003", revokedAt.Add(24*time.Hour))).To(Succeed(), "re-marking must not error")
+		revoked, _, err := svc.CertStatuses(ctx, CertStateRevoked)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(revoked).To(HaveLen(1))
+		Expect(revoked[0].Subject).To(Equal("node1"))
+		Expect(revoked[0].RevokedAt).NotTo(BeNil())
+		Expect(*revoked[0].RevokedAt).To(BeTemporally("~", revokedAt, time.Second), "the first revocation time must be kept")
+		signed, _, err := svc.CertStatuses(ctx, CertStateSigned)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(signed).To(HaveLen(1))
+		Expect(signed[0].Subject).To(Equal("node2"))
+
+		Expect(svc.ClearCertRevoked(ctx, "0003")).To(Succeed())
+
+		// Projection backfill for the projection-less record.
+		Expect(svc.SetCertProjection(ctx, "0002", CertProjection{Fingerprint: "dd:ee:ff"})).To(Succeed())
+		recs, _, err = svc.CertStatuses(ctx, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(recs).To(HaveLen(2))
+		Expect(recs[0].State).To(Equal(CertStateSigned), "ClearCertRevoked restored node1")
+		Expect(recs[0].RevokedAt).To(BeNil())
+		Expect(recs[1].Fingerprint).To(Equal("dd:ee:ff"))
+
+		// The chain covers only canonical fields, so none of the index writes
+		// above may have disturbed it.
+		_, err = svc.ReadInventory(ctx)
+		Expect(err).NotTo(HaveOccurred(), "index writes must not touch the integrity chain")
+	})
+
+	It("treats unknown serials as no-ops for revocation and projection writes", func() {
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		svc, _ := newEtcdInventoryService(cli, "/test-certindex-noop")
+		ctx := context.Background()
+
+		Expect(svc.MarkCertRevoked(ctx, "FFFF", time.Now())).To(Succeed())
+		Expect(svc.ClearCertRevoked(ctx, "FFFF")).To(Succeed())
+		Expect(svc.SetCertProjection(ctx, "FFFF", CertProjection{Fingerprint: "aa"})).To(Succeed())
+	})
+})
+
+// --- Migration ---
+
+var _ = Describe("EtcdMigrateFromFilesystem", func() {
+	It("imports a filesystem CA and rebuilds the chain head for the decomposed inventory", func() {
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		ctx := context.Background()
+
+		src := New(GinkgoT().TempDir())
+		Expect(src.EnsureDirs(ctx)).To(Succeed())
+		Expect(src.SaveCACert(ctx, []byte("ca-cert-pem"))).To(Succeed())
+		Expect(src.TouchInventory(ctx)).To(Succeed())
+		Expect(src.InitHMAC(ctx)).To(Succeed())
+		for _, line := range sampleInventoryLines {
+			Expect(src.AppendInventory(ctx, line)).To(Succeed())
+		}
+		Expect(src.SaveCert(ctx, "node1", []byte("cert-pem"))).To(Succeed())
+
+		dstBackend := newBackend(cli, "/test-migrate")
+		dst := NewWithBackend(dstBackend, filepath.Join(GinkgoT().TempDir(), "private"))
+		_, err := MigrateService(ctx, src, dst, MigrateOptions{})
+		Expect(err).NotTo(HaveOccurred(), "MigrateService")
+
+		// InitHMAC verifies against the head MigrateService rebuilt over the
+		// decomposed entries; a whole-blob HMAC left behind would fail here.
+		Expect(dst.InitHMAC(ctx)).To(Succeed(), "InitHMAC on destination")
+
+		srcInv, err := src.ReadInventory(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		dstInv, err := dst.ReadInventory(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dstInv).To(Equal(srcInv), "migrated inventory must render identically")
+
+		serial, err := dst.LatestSerialForSubject(ctx, "node1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(serial).To(Equal("0003"), "the subject index must be built during import")
 	})
 })

--- a/internal/storage/etcd_integration_test.go
+++ b/internal/storage/etcd_integration_test.go
@@ -703,7 +703,11 @@ var _ = Describe("EtcdInventoryPrune", func() {
 	It("prunes more entries than one transaction batch holds, staying consistent throughout", func() {
 		cli, stop := startEmbeddedEtcd()
 		defer stop()
-		svc, _ := newEtcdInventoryService(cli, "/test-inv-prune-big")
+		svc, b := newEtcdInventoryService(cli, "/test-inv-prune-big")
+		// A second replica observing the store between batches: every
+		// committed intermediate state must verify, not just the final one —
+		// this is the design's central invariant, so make it an assertion.
+		observer, _ := newEtcdInventoryService(cli, "/test-inv-prune-big")
 		ctx := context.Background()
 
 		const total = 80
@@ -711,6 +715,18 @@ var _ = Describe("EtcdInventoryPrune", func() {
 			line := fmt.Sprintf("%04d 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node%d", i, i%8)
 			Expect(svc.AppendInventory(ctx, line)).To(Succeed())
 		}
+
+		batchesSeen := 0
+		lastCount := total + 1
+		b.pruneBatchHook = func() {
+			batchesSeen++
+			inv, err := observer.ReadInventory(ctx)
+			Expect(err).NotTo(HaveOccurred(), "intermediate state after batch %d must verify (entries and head out of sync?)", batchesSeen)
+			count := len(bytes.Split(bytes.TrimRight(inv, "\n"), []byte{'\n'}))
+			Expect(count).To(BeNumerically("<", lastCount), "each batch must shrink the inventory")
+			lastCount = count
+		}
+		defer func() { b.pruneBatchHook = nil }()
 
 		// Remove the first 65 serials plus all of node3's later issuances
 		// (0067, 0075): spans three etcdPruneBatch (30) transactions, so the
@@ -720,6 +736,7 @@ var _ = Describe("EtcdInventoryPrune", func() {
 		removed, err := svc.PruneInventory(ctx, keep)
 		Expect(err).NotTo(HaveOccurred(), "PruneInventory")
 		Expect(removed).To(HaveLen(67))
+		Expect(batchesSeen).To(Equal(3), "67 removals must span three batches")
 
 		inv, err := svc.ReadInventory(ctx)
 		Expect(err).NotTo(HaveOccurred(), "ReadInventory after batched prune (head inconsistent?)")
@@ -784,6 +801,52 @@ var _ = Describe("EtcdInventoryPrune", func() {
 		inv, err := svc.ReadInventory(ctx)
 		Expect(err).NotTo(HaveOccurred(), "chain must verify after the conflicted prune")
 		Expect(bytes.Split(bytes.TrimRight(inv, "\n"), []byte{'\n'})).To(HaveLen(total - 65))
+	})
+
+	It("returns the durably removed entries alongside the error when retries are exhausted", func() {
+		// The contract's hardest case: every attempt commits one batch and
+		// then conflicts, until the retry budget runs out. The error must
+		// arrive WITH the accumulated removals — without them the caller
+		// could never clean up after what was already durably deleted.
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		svc, b := newEtcdInventoryService(cli, "/test-inv-prune-exhaust")
+		ctx := context.Background()
+
+		const total = 520
+		for i := 1; i <= total; i++ {
+			line := fmt.Sprintf("%04d 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node%d", i, i%8)
+			Expect(svc.AppendInventory(ctx, line)).To(Succeed())
+		}
+
+		// Bump the fence after EVERY committed batch: each attempt commits
+		// exactly one batch (30 entries) and then conflicts, so the 16-try
+		// budget is exhausted with 480 entries durably removed.
+		b.pruneBatchHook = func() {
+			_, err := cli.Put(ctx, "/test-inv-prune-exhaust/inventory/seq", fmt.Sprintf("%d", total))
+			Expect(err).NotTo(HaveOccurred(), "hook: bump fence")
+		}
+
+		removed, err := svc.PruneInventory(ctx, func(e InventoryEntry) bool { return e.Serial > "0510" })
+		b.pruneBatchHook = nil
+		Expect(err).To(HaveOccurred(), "exhausted retries must surface an error")
+		Expect(err.Error()).To(ContainSubstring("too many concurrent writers"))
+		Expect(removed).To(HaveLen(480), "every durably removed entry must be returned with the error")
+
+		// The returned entries really are gone, everything else remains, and
+		// each committed state left the chain verifiable.
+		inv, err := svc.ReadInventory(ctx)
+		Expect(err).NotTo(HaveOccurred(), "chain must verify after the exhausted prune")
+		lines := bytes.Split(bytes.TrimRight(inv, "\n"), []byte{'\n'})
+		Expect(lines).To(HaveLen(total - 480))
+		gone := make(map[string]bool, len(removed))
+		for _, e := range removed {
+			gone[e.Serial] = true
+		}
+		Expect(gone).To(HaveLen(480), "no removed entry may be reported twice")
+		for _, l := range lines {
+			Expect(gone[string(bytes.Fields(l)[0])]).To(BeFalse(), "a returned entry is still in the inventory")
+		}
 	})
 })
 
@@ -1028,7 +1091,7 @@ var _ = Describe("EtcdLegacyInventoryDecompose", func() {
 		Expect(string(payload)).To(Equal(blob), "the blob must be untouched for the operator to repair")
 	})
 
-	It("tolerates duplicate serials in the legacy blob, pointing by-serial at the newest", func() {
+	It("tolerates duplicate serials in the legacy blob, refusing index writes for them", func() {
 		cli, stop := startEmbeddedEtcd()
 		defer stop()
 		ctx := context.Background()
@@ -1049,51 +1112,212 @@ var _ = Describe("EtcdLegacyInventoryDecompose", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(inv)).To(Equal(blob), "both lines must be imported verbatim")
 
-		// The duplicate-serial guard works off the (deduplicated) by-serial
-		// index: the serial stays taken.
+		// The duplicate-serial guard works off the (sentinel) by-serial
+		// index entry: the serial stays taken.
 		err = svc.AppendInventory(ctx, "0001 2024-01-03T00:00:00UTC 2029-01-03T00:00:00UTC /node3")
 		Expect(err).To(MatchError(ErrDuplicateSerial))
+
+		// A one-to-one index cannot say which bearer an index write is meant
+		// for, so writes for a duplicated serial must be refused outright —
+		// applying them to the newest bearer would hand one subject the other
+		// subject's fingerprint or revocation state.
+		for _, subject := range []string{"node1", "node2"} {
+			Expect(b.Put(ctx, CertKey(subject), []byte("pem-"+subject), BlobPublic)).To(Succeed())
+		}
+		Expect(svc.SetCertProjection(ctx, "0001", CertProjection{Fingerprint: "aa:bb:cc"})).To(Succeed())
+		Expect(svc.MarkCertRevoked(ctx, "0001", time.Now())).To(Succeed())
+		recs, _, err := svc.CertStatuses(ctx, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(recs).To(HaveLen(2))
+		for _, rec := range recs {
+			Expect(rec.Fingerprint).To(BeEmpty(), "no bearer may receive the projection for an ambiguous serial")
+			Expect(rec.State).To(Equal(CertStateSigned), "no bearer may receive the revocation for an ambiguous serial")
+		}
+	})
+
+	It("removes the stale whole-blob head when upgrading a CA whose inventory is empty", func() {
+		// A pre-decomposition CA always stores a whole-blob HMAC — bootstrap
+		// writes one over the empty inventory before any cert is issued — but
+		// with no blob content there is no import to drop it as part of.
+		// Left in place it would fail the first chain verification with a
+		// spurious tampering error.
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		ctx := context.Background()
+		const prefix = "/test-inv-legacy-empty"
+
+		seedLegacyInventory(cli, prefix, "")
+
+		b := newBackend(cli, prefix)
+		defer b.Close()
+
+		headResp, err := cli.Get(ctx, prefix+"/inventory/hmac")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(headResp.Kvs).To(BeEmpty(), "the verified empty-inventory head must be removed")
+
+		svc := NewWithBackend(b, filepath.Join(GinkgoT().TempDir(), "private"))
+		Expect(svc.InitHMAC(ctx)).To(Succeed(), "the upgraded empty CA must start cleanly")
+		inv, err := svc.ReadInventory(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(inv).To(BeEmpty())
+		Expect(svc.AppendInventory(ctx, "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1")).To(Succeed())
+	})
+
+	It("leaves an unverifiable head over an empty inventory for verification to fail closed", func() {
+		// A non-empty head over zero entries that is NOT the whole-blob MAC
+		// of an empty inventory may be the residue of entries tampered away;
+		// deleting it would silently accept that.
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		ctx := context.Background()
+		const prefix = "/test-inv-legacy-empty-bad"
+
+		seedLegacyInventory(cli, prefix, "")
+		_, err := cli.Put(ctx, prefix+"/inventory/hmac", string(encodeBlob(time.Now(), bytes.Repeat([]byte{0x7f}, 32))))
+		Expect(err).NotTo(HaveOccurred())
+
+		b := newBackend(cli, prefix)
+		defer b.Close()
+
+		headResp, err := cli.Get(ctx, prefix+"/inventory/hmac")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(headResp.Kvs).To(HaveLen(1), "an unverifiable head must be left in place")
+
+		svc := NewWithBackend(b, filepath.Join(GinkgoT().TempDir(), "private"))
+		Expect(svc.InitHMAC(ctx)).To(MatchError(ErrInventoryTampered), "verification must stay fail-closed")
+	})
+
+	It("fails startup when the stored head cannot be verified because the HMAC key is missing", func() {
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		ctx := context.Background()
+		const prefix = "/test-inv-legacy-nokey"
+
+		blob := "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1\n"
+		seedLegacyInventory(cli, prefix, blob)
+		_, err := cli.Delete(ctx, prefix+"/private/hmac_key")
+		Expect(err).NotTo(HaveOccurred())
+
+		b := NewEtcdBackendFromClient(cli, prefix, 5*time.Second)
+		defer b.Close()
+		err = b.EnsureReady(ctx)
+		Expect(err).To(MatchError(ErrInventoryTampered), "an unverifiable blob must not become the trusted baseline")
+		Expect(err.Error()).To(ContainSubstring("inventory/hmac"), "the error must tell the operator how to acknowledge the lost baseline")
+
+		resp, err := cli.Get(ctx, prefix+"/inventory/entries/", clientv3.WithPrefix(), clientv3.WithCountOnly())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Count).To(BeZero(), "nothing may be imported")
+	})
+
+	It("fails startup when the HMAC key is malformed rather than importing unverified", func() {
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		ctx := context.Background()
+		const prefix = "/test-inv-legacy-badkey"
+
+		seedLegacyInventory(cli, prefix, "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1\n")
+		_, err := cli.Put(ctx, prefix+"/private/hmac_key", string(encodeBlob(time.Now(), []byte("short"))))
+		Expect(err).NotTo(HaveOccurred())
+
+		b := NewEtcdBackendFromClient(cli, prefix, 5*time.Second)
+		defer b.Close()
+		Expect(b.EnsureReady(ctx)).To(MatchError(ErrInventoryTampered))
+	})
+
+	It("restarts the import when a legacy writer touches the blob mid-import", func() {
+		// The marker-revision guard is the mechanism the docs cite for the
+		// mixed-version window: an old-version replica appending to the blob
+		// between import batches must invalidate the import, which then redoes
+		// itself from the updated blob.
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		ctx := context.Background()
+		const prefix = "/test-inv-legacy-race"
+
+		blob := ""
+		const total = 40 // more than one etcdImportBatch, so batches interleave
+		for i := 1; i <= total; i++ {
+			blob += fmt.Sprintf("%04d 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node%d\n", i, i%4)
+		}
+		seedLegacyInventory(cli, prefix, blob)
+
+		extra := "9999 2024-06-01T00:00:00UTC 2029-06-01T00:00:00UTC /straggler\n"
+		b := NewEtcdBackendFromClient(cli, prefix, 5*time.Second)
+		defer b.Close()
+		fired := false
+		b.importBatchHook = func() {
+			if fired {
+				return
+			}
+			fired = true
+			// An old-version append: rewrite the whole blob and its
+			// whole-blob HMAC, exactly as the legacy AppendInventory did.
+			_, err := cli.Put(ctx, prefix+"/inventory/data", string(encodeBlob(time.Now(), []byte(blob+extra))))
+			Expect(err).NotTo(HaveOccurred(), "hook: legacy append")
+			_, err = cli.Put(ctx, prefix+"/inventory/hmac", string(encodeBlob(time.Now(), wholeBlobInventoryMAC(legacyHMACKey, []byte(blob+extra)))))
+			Expect(err).NotTo(HaveOccurred(), "hook: legacy HMAC update")
+		}
+		Expect(b.EnsureReady(ctx)).To(Succeed(), "EnsureReady")
+		b.importBatchHook = nil
+		Expect(fired).To(BeTrue(), "the conflicting write must actually have been injected")
+
+		got, err := b.Get(ctx, KeyInventory)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(got)).To(Equal(blob+extra), "the redone import must include the straggler's line")
 	})
 })
 
 // --- CertIndex ---
 
+// seedEtcdCertIndex seeds a service on prefix with the canonical index
+// fixture: node1 issued twice (latest carries certIndexProj), node2 once
+// without a projection, node3 in the inventory but with no stored cert blob,
+// and stored certs for node1/node2 only.
+var certIndexProj = CertProjection{
+	Fingerprint:    "aa:bb:cc",
+	DNSAltNames:    []string{"node1", "node1.example.com"},
+	AuthExtensions: map[string]string{"pp_auth_role": "webserver"},
+}
+
+func seedEtcdCertIndex(cli *clientv3.Client, prefix string) (*StorageService, *EtcdBackend) {
+	ctx := context.Background()
+	svc, b := newEtcdInventoryService(cli, prefix)
+	Expect(svc.AppendInventory(ctx, "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1")).To(Succeed())
+	Expect(svc.AppendInventoryRecord(ctx, "0003 2024-01-03T00:00:00UTC 2029-01-03T00:00:00UTC /node1", &certIndexProj)).To(Succeed())
+	Expect(svc.AppendInventory(ctx, "0002 2024-01-02T00:00:00UTC 2029-01-02T00:00:00UTC /node2")).To(Succeed())
+	Expect(svc.AppendInventory(ctx, "0004 2024-01-04T00:00:00UTC 2029-01-04T00:00:00UTC /node3")).To(Succeed())
+	for _, subject := range []string{"node1", "node2"} {
+		Expect(b.Put(ctx, CertKey(subject), []byte("pem-"+subject), BlobPublic)).To(Succeed())
+	}
+	return svc, b
+}
+
 var _ = Describe("EtcdCertIndex", func() {
-	It("round-trips the certificate index end to end", func() {
+	It("serves the projected latest issuance per subject, gated on stored certs", func() {
 		cli, stop := startEmbeddedEtcd()
 		defer stop()
-		svc, b := newEtcdInventoryService(cli, "/test-certindex")
+		svc, _ := seedEtcdCertIndex(cli, "/test-certindex-statuses")
 		ctx := context.Background()
-
-		proj := CertProjection{
-			Fingerprint:    "aa:bb:cc",
-			DNSAltNames:    []string{"node1", "node1.example.com"},
-			AuthExtensions: map[string]string{"pp_auth_role": "webserver"},
-		}
-		Expect(svc.AppendInventory(ctx, "0001 2024-01-01T00:00:00UTC 2029-01-01T00:00:00UTC /node1")).To(Succeed())
-		Expect(svc.AppendInventoryRecord(ctx, "0003 2024-01-03T00:00:00UTC 2029-01-03T00:00:00UTC /node1", &proj)).To(Succeed())
-		Expect(svc.AppendInventory(ctx, "0002 2024-01-02T00:00:00UTC 2029-01-02T00:00:00UTC /node2")).To(Succeed())
-		// node1 and node2 hold stored certs; node3 has an inventory entry but
-		// no blob and must stay invisible.
-		Expect(svc.AppendInventory(ctx, "0004 2024-01-04T00:00:00UTC 2029-01-04T00:00:00UTC /node3")).To(Succeed())
-		for _, subject := range []string{"node1", "node2"} {
-			Expect(b.Put(ctx, CertKey(subject), []byte("pem-"+subject), BlobPublic)).To(Succeed())
-		}
 
 		recs, ok, err := svc.CertStatuses(ctx, "")
 		Expect(err).NotTo(HaveOccurred(), "CertStatuses")
 		Expect(ok).To(BeTrue(), "etcd backend must advertise the CertIndex capability")
-		Expect(recs).To(HaveLen(2), "one record per subject with a stored cert, latest issuance only")
+		Expect(recs).To(HaveLen(2), "one record per subject with a stored cert; node3 has no blob and stays invisible")
 		Expect(recs[0].Subject).To(Equal("node1"))
 		Expect(recs[0].Serial).To(Equal("0003"), "node1's latest issuance wins")
-		Expect(recs[0].Fingerprint).To(Equal(proj.Fingerprint))
-		Expect(recs[0].DNSAltNames).To(Equal(proj.DNSAltNames))
-		Expect(recs[0].AuthExtensions).To(Equal(proj.AuthExtensions))
+		Expect(recs[0].Fingerprint).To(Equal(certIndexProj.Fingerprint))
+		Expect(recs[0].DNSAltNames).To(Equal(certIndexProj.DNSAltNames))
+		Expect(recs[0].AuthExtensions).To(Equal(certIndexProj.AuthExtensions))
 		Expect(recs[1].Subject).To(Equal("node2"))
 		Expect(recs[1].Fingerprint).To(BeEmpty(), "appended without a projection")
+	})
 
-		// Revocation round-trip: idempotent marking keeps the first time, the
-		// state filter partitions, and clearing restores the signed state.
+	It("projects revocation idempotently, partitions by state, and clears again", func() {
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		svc, _ := seedEtcdCertIndex(cli, "/test-certindex-revoke")
+		ctx := context.Background()
+
 		revokedAt := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
 		Expect(svc.MarkCertRevoked(ctx, "0003", revokedAt)).To(Succeed())
 		Expect(svc.MarkCertRevoked(ctx, "0003", revokedAt.Add(24*time.Hour))).To(Succeed(), "re-marking must not error")
@@ -1109,19 +1333,39 @@ var _ = Describe("EtcdCertIndex", func() {
 		Expect(signed[0].Subject).To(Equal("node2"))
 
 		Expect(svc.ClearCertRevoked(ctx, "0003")).To(Succeed())
-
-		// Projection backfill for the projection-less record.
-		Expect(svc.SetCertProjection(ctx, "0002", CertProjection{Fingerprint: "dd:ee:ff"})).To(Succeed())
-		recs, _, err = svc.CertStatuses(ctx, "")
+		recs, _, err := svc.CertStatuses(ctx, "")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(recs).To(HaveLen(2))
 		Expect(recs[0].State).To(Equal(CertStateSigned), "ClearCertRevoked restored node1")
 		Expect(recs[0].RevokedAt).To(BeNil())
-		Expect(recs[1].Fingerprint).To(Equal("dd:ee:ff"))
+	})
 
-		// The chain covers only canonical fields, so none of the index writes
-		// above may have disturbed it.
-		_, err = svc.ReadInventory(ctx)
+	It("backfills the projection for a projection-less record", func() {
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		svc, _ := seedEtcdCertIndex(cli, "/test-certindex-backfill")
+		ctx := context.Background()
+
+		Expect(svc.SetCertProjection(ctx, "0002", CertProjection{Fingerprint: "dd:ee:ff"})).To(Succeed())
+		recs, _, err := svc.CertStatuses(ctx, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(recs).To(HaveLen(2))
+		Expect(recs[1].Subject).To(Equal("node2"))
+		Expect(recs[1].Fingerprint).To(Equal("dd:ee:ff"))
+	})
+
+	It("keeps the integrity chain untouched by index writes", func() {
+		cli, stop := startEmbeddedEtcd()
+		defer stop()
+		svc, _ := seedEtcdCertIndex(cli, "/test-certindex-chain")
+		ctx := context.Background()
+
+		Expect(svc.MarkCertRevoked(ctx, "0003", time.Now())).To(Succeed())
+		Expect(svc.SetCertProjection(ctx, "0002", CertProjection{Fingerprint: "dd:ee:ff"})).To(Succeed())
+		Expect(svc.ClearCertRevoked(ctx, "0003")).To(Succeed())
+
+		// The chain covers only canonical fields, so none of the writes above
+		// may have disturbed it.
+		_, err := svc.ReadInventory(ctx)
 		Expect(err).NotTo(HaveOccurred(), "index writes must not touch the integrity chain")
 	})
 

--- a/internal/storage/etcd_inventory.go
+++ b/internal/storage/etcd_inventory.go
@@ -1,0 +1,882 @@
+// Copyright (C) 2026 Chris Boot
+// Copyright (C) 2026 Vox Pupuli and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package storage
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.etcd.io/etcd/api/v3/mvccpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+// The etcd backend stores the certificate inventory decomposed into per-entry
+// keys rather than the single append-only inventory/data blob (issue #138):
+//
+//	inventory/entries/<seq>      one JSON-encoded CertRecord per issuance;
+//	                             <seq> is zero-padded so a range scan returns
+//	                             issuance order
+//	inventory/seq                last allocated sequence number; its
+//	                             ModRevision doubles as the fence every
+//	                             structured mutation is guarded on
+//	inventory/by-serial/<serial> serial → seq; its existence is the atomic,
+//	                             cluster-wide duplicate-serial guard
+//	inventory/by-subject/<subj>  subject → most recently issued serial
+//	inventory/data               presence marker (empty payload); also where
+//	                             pre-decomposition versions kept the blob
+//	inventory/hmac               chained integrity head (blob-encoded, still
+//	                             addressed by the KeyInventoryHMAC logical key)
+//
+// etcd transactions are compare-then-op, not read-compute-write, so every
+// mutation is an optimistic loop: read the fence (and whatever else the
+// mutation needs), compute the new state in Go, then commit a Txn guarded on
+// the fence's ModRevision being unchanged, retrying on conflict. Appending is
+// O(1) in the inventory size; the by-serial guard gives etcd the cross-replica
+// duplicate-serial guarantee that previously only the SQL backends had.
+//
+// Index keys (seq, by-serial, by-subject) hold raw values; only blobs
+// addressed by logical keys carry the encodeBlob mtime header.
+const (
+	etcdInvDataSub    = "inventory/data"
+	etcdInvHMACSub    = "inventory/hmac"
+	etcdInvSeqSub     = "inventory/seq"
+	etcdInvEntriesSub = "inventory/entries/"
+	etcdInvSerialSub  = "inventory/by-serial/"
+	etcdInvSubjectSub = "inventory/by-subject/"
+)
+
+// etcdMaxTxnRetries bounds every optimistic-transaction retry loop in this
+// backend. Conflicts are transient (another writer won the race), so a bounded
+// loop with jittered backoff resolves them; hitting the bound means pathological
+// contention and is reported as an error.
+const etcdMaxTxnRetries = 16
+
+// Batch sizes for multi-transaction imports and prunes, chosen to keep each
+// transaction comfortably under etcd's default --max-txn-ops (128): an import
+// costs up to 3 ops per entry (entry, by-serial, by-subject) and a prune up to
+// 3 per removed entry, plus a handful of fixed ops (fence, head, marker).
+const (
+	etcdImportBatch = 32
+	etcdPruneBatch  = 30
+)
+
+// etcdInventoryRecord is the stored JSON form of a CertRecord. The field set
+// is spelled out (rather than marshalling CertRecord directly) so the wire
+// format is explicit and stable against refactors of the in-memory structs.
+type etcdInventoryRecord struct {
+	Serial         string            `json:"serial"`
+	NotBefore      string            `json:"not_before"`
+	NotAfter       string            `json:"not_after"`
+	Subject        string            `json:"subject"`
+	Fingerprint    string            `json:"fingerprint,omitempty"`
+	DNSAltNames    []string          `json:"dns_alt_names,omitempty"`
+	AuthExtensions map[string]string `json:"auth_extensions,omitempty"`
+	State          string            `json:"state,omitempty"`
+	RevokedAt      *time.Time        `json:"revoked_at,omitempty"`
+}
+
+func encodeInventoryRecord(rec CertRecord) ([]byte, error) {
+	if rec.State == "" {
+		rec.State = CertStateSigned
+	}
+	return json.Marshal(etcdInventoryRecord{
+		Serial:         rec.Serial,
+		NotBefore:      rec.NotBefore,
+		NotAfter:       rec.NotAfter,
+		Subject:        rec.Subject,
+		Fingerprint:    rec.Fingerprint,
+		DNSAltNames:    rec.DNSAltNames,
+		AuthExtensions: rec.AuthExtensions,
+		State:          rec.State,
+		RevokedAt:      rec.RevokedAt,
+	})
+}
+
+// decodeInventoryRecord is the inverse of encodeInventoryRecord. Unlike the
+// SQL row decoder — which can salvage the canonical columns when only the
+// projection JSON is corrupt — the whole record shares one JSON value here, so
+// an undecodable value is a hard error: there is nothing left to fall back on.
+func decodeInventoryRecord(data []byte) (CertRecord, error) {
+	var r etcdInventoryRecord
+	if err := json.Unmarshal(data, &r); err != nil {
+		return CertRecord{}, fmt.Errorf("decoding inventory record: %w", err)
+	}
+	rec := CertRecord{
+		InventoryEntry: InventoryEntry{
+			Serial:    r.Serial,
+			NotBefore: r.NotBefore,
+			NotAfter:  r.NotAfter,
+			Subject:   r.Subject,
+		},
+		CertProjection: CertProjection{
+			Fingerprint:    r.Fingerprint,
+			DNSAltNames:    r.DNSAltNames,
+			AuthExtensions: r.AuthExtensions,
+		},
+		State:     r.State,
+		RevokedAt: r.RevokedAt,
+	}
+	if rec.State == "" {
+		rec.State = CertStateSigned
+	}
+	return rec, nil
+}
+
+// invPhys returns the physical etcd key for an inventory sub-path.
+func (b *EtcdBackend) invPhys(sub string) string { return b.prefix + "/" + sub }
+
+// entryPhys returns the physical key of the entry with sequence number seq.
+// Zero-padding to 20 digits (the width of MaxUint64) keeps lexical key order
+// identical to numeric issuance order for any realistic sequence value.
+func (b *EtcdBackend) entryPhys(seq uint64) string {
+	return fmt.Sprintf("%s%020d", b.invPhys(etcdInvEntriesSub), seq)
+}
+
+// etcdSeqState is a snapshot of the inventory/seq fence key.
+type etcdSeqState struct {
+	present bool
+	rev     int64  // ModRevision; 0 when absent
+	last    uint64 // last allocated sequence number; 0 when absent
+}
+
+func decodeSeqState(kvs []*mvccpb.KeyValue) (etcdSeqState, error) {
+	if len(kvs) == 0 {
+		return etcdSeqState{}, nil
+	}
+	last, err := strconv.ParseUint(string(kvs[0].Value), 10, 64)
+	if err != nil {
+		return etcdSeqState{}, fmt.Errorf("parsing inventory sequence counter %q: %w", kvs[0].Value, err)
+	}
+	return etcdSeqState{present: true, rev: kvs[0].ModRevision, last: last}, nil
+}
+
+// seqGuard is the fence comparison every structured mutation includes: the
+// inventory/seq key must not have been touched since it was read. Every
+// mutating transaction also re-puts the key, so any interleaved append, prune,
+// or import invalidates the guard and forces a re-read.
+func (b *EtcdBackend) seqGuard(seq etcdSeqState) clientv3.Cmp {
+	return clientv3.Compare(clientv3.ModRevision(b.invPhys(etcdInvSeqSub)), "=", seq.rev)
+}
+
+// etcdIndexedRecord pairs a decoded record with its sequence number and the
+// entry key's ModRevision (for guarded in-place updates).
+type etcdIndexedRecord struct {
+	seq    uint64
+	modRev int64
+	rec    CertRecord
+}
+
+func decodeIndexedRecords(prefix string, kvs []*mvccpb.KeyValue) ([]etcdIndexedRecord, error) {
+	out := make([]etcdIndexedRecord, 0, len(kvs))
+	for _, kv := range kvs {
+		seq, err := strconv.ParseUint(strings.TrimPrefix(string(kv.Key), prefix), 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("parsing inventory entry key %q: %w", kv.Key, err)
+		}
+		rec, err := decodeInventoryRecord(kv.Value)
+		if err != nil {
+			return nil, fmt.Errorf("entry %q: %w", kv.Key, err)
+		}
+		out = append(out, etcdIndexedRecord{seq: seq, modRev: kv.ModRevision, rec: rec})
+	}
+	return out, nil
+}
+
+func entriesOf(recs []etcdIndexedRecord) []InventoryEntry {
+	entries := make([]InventoryEntry, len(recs))
+	for i, r := range recs {
+		entries[i] = r.rec.InventoryEntry
+	}
+	return entries
+}
+
+// readIndexedRecords returns every inventory entry in issuance order together
+// with the fence snapshot, read atomically in a single transaction.
+func (b *EtcdBackend) readIndexedRecords(ctx context.Context) ([]etcdIndexedRecord, etcdSeqState, error) {
+	ctx, cancel := b.callCtx(ctx)
+	defer cancel()
+	resp, err := b.client.Txn(ctx).Then(
+		clientv3.OpGet(b.invPhys(etcdInvSeqSub)),
+		clientv3.OpGet(b.invPhys(etcdInvEntriesSub), clientv3.WithPrefix()),
+	).Commit()
+	if err != nil {
+		return nil, etcdSeqState{}, err
+	}
+	seq, err := decodeSeqState(resp.Responses[0].GetResponseRange().Kvs)
+	if err != nil {
+		return nil, etcdSeqState{}, err
+	}
+	recs, err := decodeIndexedRecords(b.invPhys(etcdInvEntriesSub), resp.Responses[1].GetResponseRange().Kvs)
+	if err != nil {
+		return nil, etcdSeqState{}, err
+	}
+	return recs, seq, nil
+}
+
+// markerTouchOp returns the Put that (re)writes the inventory presence marker
+// with a fresh mtime, mirroring how the SQL backend bumps its marker row.
+func (b *EtcdBackend) markerTouchOp() clientv3.Op {
+	return clientv3.OpPut(b.invPhys(etcdInvDataSub), string(encodeBlob(time.Now(), []byte{})))
+}
+
+// EtcdBackend implements InventoryStore: the inventory lives as one key per
+// entry (plus by-serial/by-subject index keys) instead of a single append-only
+// blob, making appends O(1) and giving duplicate-serial rejection cluster-wide
+// semantics. The inventory/data key remains as a presence marker so the
+// KeyInventory logical key keeps its Get/Put/Exists/ModTime behaviour.
+var _ InventoryStore = (*EtcdBackend)(nil)
+
+// AppendEntry inserts rec and advances the integrity head atomically. The
+// commit transaction is guarded on the fence being unchanged since the read
+// (so the head cannot fork under concurrent appenders, including other
+// replicas) and on rec's by-serial key not existing (the cluster-wide
+// duplicate-serial guarantee). newHead runs in Go between the read and the
+// commit; a conflicting writer invalidates the guard and the loop re-reads.
+func (b *EtcdBackend) AppendEntry(ctx context.Context, rec CertRecord, newHead func(prev []byte) []byte) error {
+	b.appendMu.Lock()
+	defer b.appendMu.Unlock()
+
+	val, err := encodeInventoryRecord(rec)
+	if err != nil {
+		return err
+	}
+	serialPhys := b.invPhys(etcdInvSerialSub + rec.Serial)
+	subjectPhys := b.invPhys(etcdInvSubjectSub + rec.Subject)
+
+	for attempt := range etcdMaxTxnRetries {
+		readCtx, cancel := b.callCtx(ctx)
+		resp, err := b.client.Txn(readCtx).Then(
+			clientv3.OpGet(b.invPhys(etcdInvSeqSub)),
+			clientv3.OpGet(b.invPhys(etcdInvHMACSub)),
+			clientv3.OpGet(serialPhys, clientv3.WithCountOnly()),
+		).Commit()
+		cancel()
+		if err != nil {
+			return err
+		}
+		if resp.Responses[2].GetResponseRange().Count > 0 {
+			return fmt.Errorf("%w: %s", ErrDuplicateSerial, rec.Serial)
+		}
+		seq, err := decodeSeqState(resp.Responses[0].GetResponseRange().Kvs)
+		if err != nil {
+			return err
+		}
+		next := seq.last + 1
+
+		ops := []clientv3.Op{
+			clientv3.OpPut(b.entryPhys(next), string(val)),
+			clientv3.OpPut(b.invPhys(etcdInvSeqSub), strconv.FormatUint(next, 10)),
+			clientv3.OpPut(serialPhys, strconv.FormatUint(next, 10)),
+			clientv3.OpPut(subjectPhys, rec.Serial),
+			b.markerTouchOp(),
+		}
+		if newHead != nil {
+			var prev []byte
+			if kvs := resp.Responses[1].GetResponseRange().Kvs; len(kvs) > 0 {
+				if _, prev, err = decodeBlob(kvs[0].Value); err != nil {
+					return fmt.Errorf("decoding inventory head: %w", err)
+				}
+			}
+			ops = append(ops, clientv3.OpPut(b.invPhys(etcdInvHMACSub), string(encodeBlob(time.Now(), newHead(prev)))))
+		}
+
+		txnCtx, cancel2 := b.callCtx(ctx)
+		txnResp, err := b.client.Txn(txnCtx).If(
+			b.seqGuard(seq),
+			clientv3.Compare(clientv3.CreateRevision(serialPhys), "=", 0),
+		).Then(ops...).Commit()
+		cancel2()
+		if err != nil {
+			return err
+		}
+		if txnResp.Succeeded {
+			return nil
+		}
+		// Another writer won the race (or inserted this serial — the re-read
+		// at the top of the loop distinguishes the two).
+		if err := b.txnBackoff(ctx, attempt); err != nil {
+			return err
+		}
+	}
+	return fmt.Errorf("inventory append failed: too many concurrent writers")
+}
+
+// Entries returns every inventory entry in issuance order.
+func (b *EtcdBackend) Entries(ctx context.Context) ([]InventoryEntry, error) {
+	recs, _, err := b.readIndexedRecords(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return entriesOf(recs), nil
+}
+
+// LatestSerialForSubject returns the most recently issued serial for subject,
+// wrapping fs.ErrNotExist when the subject has no entry. This is a single
+// point read of the by-subject index key.
+func (b *EtcdBackend) LatestSerialForSubject(ctx context.Context, subject string) (string, error) {
+	ctx, cancel := b.callCtx(ctx)
+	defer cancel()
+	resp, err := b.client.Get(ctx, b.invPhys(etcdInvSubjectSub+subject))
+	if err != nil {
+		return "", err
+	}
+	if len(resp.Kvs) == 0 {
+		return "", &fs.PathError{Op: "latest-serial", Path: subject, Err: fs.ErrNotExist}
+	}
+	return string(resp.Kvs[0].Value), nil
+}
+
+// PruneEntries removes the entries for which keep returns false and rewrites
+// the integrity head over the survivors. A prune larger than one transaction's
+// op budget is split into batches; every intermediate transaction writes a
+// head that exactly covers the entries remaining after it, so each committed
+// revision is internally consistent (entries and head always match — a
+// concurrent verifier on another replica never observes a spurious mismatch,
+// and a crash mid-prune leaves a valid, partially-pruned inventory that the
+// caller's next prune completes). Interleaved appends invalidate the fence
+// and restart the prune from a fresh read.
+func (b *EtcdBackend) PruneEntries(ctx context.Context, keep func(InventoryEntry) bool, recomputeHead func(survivors []InventoryEntry) []byte) ([]InventoryEntry, error) {
+	b.appendMu.Lock()
+	defer b.appendMu.Unlock()
+
+	for attempt := range etcdMaxTxnRetries {
+		removed, conflict, err := b.pruneEntriesOnce(ctx, keep, recomputeHead)
+		if err != nil {
+			return nil, err
+		}
+		if !conflict {
+			return removed, nil
+		}
+		if err := b.txnBackoff(ctx, attempt); err != nil {
+			return nil, err
+		}
+	}
+	return nil, fmt.Errorf("inventory prune failed: too many concurrent writers")
+}
+
+func (b *EtcdBackend) pruneEntriesOnce(ctx context.Context, keep func(InventoryEntry) bool, recomputeHead func(survivors []InventoryEntry) []byte) ([]InventoryEntry, bool, error) {
+	recs, seq, err := b.readIndexedRecords(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+
+	var removed []etcdIndexedRecord
+	for _, r := range recs {
+		if !keep(r.rec.InventoryEntry) {
+			removed = append(removed, r)
+		}
+	}
+	if len(removed) == 0 {
+		return nil, false, nil
+	}
+
+	// Fence value: unchanged when present; derived from the highest allocated
+	// seq otherwise (possible only for indices built before appends ran).
+	seqVal := strconv.FormatUint(seq.last, 10)
+	if !seq.present && len(recs) > 0 {
+		seqVal = strconv.FormatUint(recs[len(recs)-1].seq, 10)
+	}
+
+	seqRev := seq.rev
+	for start := 0; start < len(removed); start += etcdPruneBatch {
+		batch := removed[start:min(start+etcdPruneBatch, len(removed))]
+		// The state this transaction commits is the full record set minus
+		// every entry removed up to and including this batch. Later batches'
+		// removals are still present, so each committed revision is
+		// internally consistent (its head covers exactly its entries).
+		afterSet := make([]etcdIndexedRecord, 0, len(recs))
+		removedSoFar := make(map[uint64]bool, start+len(batch))
+		for _, r := range removed[:start+len(batch)] {
+			removedSoFar[r.seq] = true
+		}
+		for _, r := range recs {
+			if !removedSoFar[r.seq] {
+				afterSet = append(afterSet, r)
+			}
+		}
+
+		ops := make([]clientv3.Op, 0, 3*len(batch)+3)
+		subjects := make(map[string]bool, len(batch))
+		for _, r := range batch {
+			ops = append(ops,
+				clientv3.OpDelete(b.entryPhys(r.seq)),
+				clientv3.OpDelete(b.invPhys(etcdInvSerialSub+r.rec.Serial)),
+			)
+			subjects[r.rec.Subject] = true
+		}
+		// Repoint each affected subject's by-subject key at its newest
+		// surviving serial, or drop the key when none survives.
+		for subject := range subjects {
+			latest := ""
+			for _, r := range afterSet {
+				if r.rec.Subject == subject {
+					latest = r.rec.Serial
+				}
+			}
+			key := b.invPhys(etcdInvSubjectSub + subject)
+			if latest == "" {
+				ops = append(ops, clientv3.OpDelete(key))
+			} else {
+				ops = append(ops, clientv3.OpPut(key, latest))
+			}
+		}
+		if recomputeHead != nil {
+			head := recomputeHead(entriesOf(afterSet))
+			ops = append(ops, clientv3.OpPut(b.invPhys(etcdInvHMACSub), string(encodeBlob(time.Now(), head))))
+		}
+		ops = append(ops, clientv3.OpPut(b.invPhys(etcdInvSeqSub), seqVal))
+
+		txnCtx, cancel := b.callCtx(ctx)
+		resp, err := b.client.Txn(txnCtx).If(
+			clientv3.Compare(clientv3.ModRevision(b.invPhys(etcdInvSeqSub)), "=", seqRev),
+		).Then(ops...).Commit()
+		cancel()
+		if err != nil {
+			return nil, false, err
+		}
+		if !resp.Succeeded {
+			return nil, true, nil
+		}
+		// Our own put moved the fence; subsequent batches guard on the new
+		// revision, which every op in this transaction committed at.
+		seqRev = resp.Header.Revision
+	}
+
+	out := make([]InventoryEntry, len(removed))
+	for i, r := range removed {
+		out[i] = r.rec.InventoryEntry
+	}
+	return out, false, nil
+}
+
+// --- KeyInventory blob shim ---
+//
+// A backend implementing InventoryStore must still serve the KeyInventory
+// logical key through Get/Put/Exists (rendering entries to inventory.txt text
+// and parsing text back) so Migrate and the OCSP index build stay
+// backend-agnostic. Exists and ModTime need no dispatch: the presence marker
+// lives at KeyInventory's own physical key.
+
+// getInventory renders the decomposed entries to byte-identical inventory.txt
+// text. An inventory that was never initialised (no marker, no entries) wraps
+// fs.ErrNotExist. A non-empty legacy blob that decomposeLegacyInventory has
+// not yet processed is returned verbatim so reads stay correct even before
+// EnsureReady has run.
+func (b *EtcdBackend) getInventory(ctx context.Context) ([]byte, error) {
+	ctx, cancel := b.callCtx(ctx)
+	defer cancel()
+	resp, err := b.client.Txn(ctx).Then(
+		clientv3.OpGet(b.invPhys(etcdInvDataSub)),
+		clientv3.OpGet(b.invPhys(etcdInvEntriesSub), clientv3.WithPrefix()),
+	).Commit()
+	if err != nil {
+		return nil, err
+	}
+	markerKVs := resp.Responses[0].GetResponseRange().Kvs
+	entryKVs := resp.Responses[1].GetResponseRange().Kvs
+	if len(markerKVs) == 0 && len(entryKVs) == 0 {
+		return nil, &fs.PathError{Op: "get", Path: KeyInventory, Err: fs.ErrNotExist}
+	}
+	if len(entryKVs) == 0 && len(markerKVs) > 0 {
+		_, legacy, err := decodeBlob(markerKVs[0].Value)
+		if err != nil {
+			return nil, fmt.Errorf("decoding blob %q: %w", KeyInventory, err)
+		}
+		if len(legacy) > 0 {
+			return legacy, nil
+		}
+	}
+	recs, err := decodeIndexedRecords(b.invPhys(etcdInvEntriesSub), entryKVs)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	for _, r := range recs {
+		buf.WriteString(canonicalInventoryLine(r.rec.InventoryEntry))
+		buf.WriteByte('\n')
+	}
+	// Normalise to a non-nil empty slice so a touched-but-empty inventory
+	// reads as present-but-empty, not absent (matching the other backends).
+	if buf.Len() == 0 {
+		return []byte{}, nil
+	}
+	return buf.Bytes(), nil
+}
+
+// parseInventoryRecords parses an inventory.txt blob into projection-less
+// records. Malformed lines are rejected so a corrupt import fails loudly
+// rather than silently dropping entries.
+func parseInventoryRecords(data []byte) ([]CertRecord, error) {
+	var recs []CertRecord
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		e, ok := parseInventoryEntry(line)
+		if !ok {
+			return nil, fmt.Errorf("malformed inventory line %q", line)
+		}
+		recs = append(recs, CertRecord{InventoryEntry: e, State: CertStateSigned})
+	}
+	return recs, nil
+}
+
+// rejectDuplicateSerials returns ErrDuplicateSerial (wrapped) when two records
+// share a serial, mirroring the unique index a SQL import would trip over.
+func rejectDuplicateSerials(recs []CertRecord) error {
+	seen := make(map[string]bool, len(recs))
+	for _, r := range recs {
+		if seen[r.Serial] {
+			return fmt.Errorf("%w: %s", ErrDuplicateSerial, r.Serial)
+		}
+		seen[r.Serial] = true
+	}
+	return nil
+}
+
+// putInventory replaces the entire decomposed inventory with the entries
+// parsed from data (an inventory.txt blob) and sets the presence marker. Used
+// by TouchInventory (empty data) and by Migrate when importing into etcd. The
+// integrity head is not touched: Migrate recomputes it afterwards, and a
+// touched-but-empty inventory gets its baseline on first verification.
+func (b *EtcdBackend) putInventory(ctx context.Context, data []byte) error {
+	recs, err := parseInventoryRecords(data)
+	if err != nil {
+		return err
+	}
+	if err := rejectDuplicateSerials(recs); err != nil {
+		return err
+	}
+
+	b.appendMu.Lock()
+	defer b.appendMu.Unlock()
+
+	for attempt := range etcdMaxTxnRetries {
+		conflict, err := b.replaceInventoryOnce(ctx, recs, -1, false)
+		if err != nil {
+			return err
+		}
+		if !conflict {
+			return nil
+		}
+		if err := b.txnBackoff(ctx, attempt); err != nil {
+			return err
+		}
+	}
+	return fmt.Errorf("inventory replace failed: too many concurrent writers")
+}
+
+// replaceInventoryOnce performs one attempt at atomically-observed replacement
+// of the decomposed structure with recs: clear everything, import in batches,
+// then write the fresh presence marker. Each transaction is guarded on the
+// fence; markerRev >= 0 additionally guards every transaction on the marker
+// being unchanged (used by decomposeLegacyInventory to detect a
+// pre-decomposition replica appending to the blob mid-import). dropHead also
+// deletes the stored integrity head in the final transaction, for callers
+// whose head is known to be in the wrong scheme. Returns conflict=true when a
+// guard failed and the caller should re-read and retry.
+func (b *EtcdBackend) replaceInventoryOnce(ctx context.Context, recs []CertRecord, markerRev int64, dropHead bool) (bool, error) {
+	readCtx, cancel := b.callCtx(ctx)
+	resp, err := b.client.Get(readCtx, b.invPhys(etcdInvSeqSub))
+	cancel()
+	if err != nil {
+		return false, err
+	}
+	seq, err := decodeSeqState(resp.Kvs)
+	if err != nil {
+		return false, err
+	}
+
+	guards := func(seqRev int64) []clientv3.Cmp {
+		cmps := []clientv3.Cmp{clientv3.Compare(clientv3.ModRevision(b.invPhys(etcdInvSeqSub)), "=", seqRev)}
+		if markerRev >= 0 {
+			cmps = append(cmps, clientv3.Compare(clientv3.ModRevision(b.invPhys(etcdInvDataSub)), "=", markerRev))
+		}
+		return cmps
+	}
+
+	commit := func(seqRev int64, ops []clientv3.Op) (int64, bool, error) {
+		txnCtx, cancel := b.callCtx(ctx)
+		defer cancel()
+		resp, err := b.client.Txn(txnCtx).If(guards(seqRev)...).Then(ops...).Commit()
+		if err != nil {
+			return 0, false, err
+		}
+		if !resp.Succeeded {
+			return 0, true, nil
+		}
+		return resp.Header.Revision, false, nil
+	}
+
+	// Clear the existing structure and reset the fence.
+	seqRev, conflict, err := commit(seq.rev, []clientv3.Op{
+		clientv3.OpDelete(b.invPhys(etcdInvEntriesSub), clientv3.WithPrefix()),
+		clientv3.OpDelete(b.invPhys(etcdInvSerialSub), clientv3.WithPrefix()),
+		clientv3.OpDelete(b.invPhys(etcdInvSubjectSub), clientv3.WithPrefix()),
+		clientv3.OpPut(b.invPhys(etcdInvSeqSub), "0"),
+	})
+	if err != nil || conflict {
+		return conflict, err
+	}
+
+	for start := 0; start < len(recs); start += etcdImportBatch {
+		batch := recs[start:min(start+etcdImportBatch, len(recs))]
+		ops := make([]clientv3.Op, 0, 3*len(batch)+1)
+		// One by-subject put per subject per transaction (etcd rejects
+		// duplicate keys within a txn); later batches overwrite earlier ones,
+		// leaving each subject pointing at its newest serial.
+		subjectLatest := make(map[string]string, len(batch))
+		for i, rec := range batch {
+			val, err := encodeInventoryRecord(rec)
+			if err != nil {
+				return false, err
+			}
+			n := uint64(start+i) + 1
+			ops = append(ops,
+				clientv3.OpPut(b.entryPhys(n), string(val)),
+				clientv3.OpPut(b.invPhys(etcdInvSerialSub+rec.Serial), strconv.FormatUint(n, 10)),
+			)
+			subjectLatest[rec.Subject] = rec.Serial
+		}
+		for subject, serial := range subjectLatest {
+			ops = append(ops, clientv3.OpPut(b.invPhys(etcdInvSubjectSub+subject), serial))
+		}
+		ops = append(ops, clientv3.OpPut(b.invPhys(etcdInvSeqSub), strconv.Itoa(start+len(batch))))
+		if seqRev, conflict, err = commit(seqRev, ops); err != nil || conflict {
+			return conflict, err
+		}
+	}
+
+	final := []clientv3.Op{b.markerTouchOp()}
+	if dropHead {
+		final = append(final, clientv3.OpDelete(b.invPhys(etcdInvHMACSub)))
+	}
+	final = append(final, clientv3.OpPut(b.invPhys(etcdInvSeqSub), strconv.Itoa(len(recs))))
+	_, conflict, err = commit(seqRev, final)
+	return conflict, err
+}
+
+// appendInventoryLines appends the entries parsed from data as new records,
+// without touching the integrity head. StorageService routes inventory appends
+// through AppendEntry; this runs only when a caller invokes
+// Backend.AppendLine(KeyInventory, ...) directly. Duplicate serials — within
+// data or against the stored inventory — are rejected, mirroring the unique
+// index the SQL backend's direct-append path trips over.
+func (b *EtcdBackend) appendInventoryLines(ctx context.Context, data []byte) error {
+	recs, err := parseInventoryRecords(data)
+	if err != nil {
+		return err
+	}
+	if err := rejectDuplicateSerials(recs); err != nil {
+		return err
+	}
+
+	b.appendMu.Lock()
+	defer b.appendMu.Unlock()
+
+	for attempt := range etcdMaxTxnRetries {
+		readOps := []clientv3.Op{clientv3.OpGet(b.invPhys(etcdInvSeqSub))}
+		for _, rec := range recs {
+			readOps = append(readOps, clientv3.OpGet(b.invPhys(etcdInvSerialSub+rec.Serial), clientv3.WithCountOnly()))
+		}
+		readCtx, cancel := b.callCtx(ctx)
+		resp, err := b.client.Txn(readCtx).Then(readOps...).Commit()
+		cancel()
+		if err != nil {
+			return err
+		}
+		for i, rec := range recs {
+			if resp.Responses[i+1].GetResponseRange().Count > 0 {
+				return fmt.Errorf("%w: %s", ErrDuplicateSerial, rec.Serial)
+			}
+		}
+		seq, err := decodeSeqState(resp.Responses[0].GetResponseRange().Kvs)
+		if err != nil {
+			return err
+		}
+
+		cmps := []clientv3.Cmp{b.seqGuard(seq)}
+		ops := make([]clientv3.Op, 0, 3*len(recs)+2)
+		subjectLatest := make(map[string]string, len(recs))
+		next := seq.last
+		for _, rec := range recs {
+			next++
+			val, err := encodeInventoryRecord(rec)
+			if err != nil {
+				return err
+			}
+			serialPhys := b.invPhys(etcdInvSerialSub + rec.Serial)
+			cmps = append(cmps, clientv3.Compare(clientv3.CreateRevision(serialPhys), "=", 0))
+			ops = append(ops,
+				clientv3.OpPut(b.entryPhys(next), string(val)),
+				clientv3.OpPut(serialPhys, strconv.FormatUint(next, 10)),
+			)
+			subjectLatest[rec.Subject] = rec.Serial
+		}
+		for subject, serial := range subjectLatest {
+			ops = append(ops, clientv3.OpPut(b.invPhys(etcdInvSubjectSub+subject), serial))
+		}
+		if len(recs) > 0 {
+			ops = append(ops, clientv3.OpPut(b.invPhys(etcdInvSeqSub), strconv.FormatUint(next, 10)))
+		}
+		ops = append(ops, b.markerTouchOp())
+
+		txnCtx, cancel2 := b.callCtx(ctx)
+		txnResp, err := b.client.Txn(txnCtx).If(cmps...).Then(ops...).Commit()
+		cancel2()
+		if err != nil {
+			return err
+		}
+		if txnResp.Succeeded {
+			return nil
+		}
+		if err := b.txnBackoff(ctx, attempt); err != nil {
+			return err
+		}
+	}
+	return fmt.Errorf("inventory append failed: too many concurrent writers")
+}
+
+// deleteInventory removes the presence marker and the whole decomposed
+// structure, wrapping fs.ErrNotExist when the inventory was never initialised.
+// The integrity head is left in place, matching the SQL backend (it is a
+// separate logical key).
+func (b *EtcdBackend) deleteInventory(ctx context.Context) error {
+	ctx, cancel := b.callCtx(ctx)
+	defer cancel()
+	resp, err := b.client.Txn(ctx).
+		If(clientv3.Compare(clientv3.CreateRevision(b.invPhys(etcdInvDataSub)), ">", 0)).
+		Then(
+			clientv3.OpDelete(b.invPhys(etcdInvDataSub)),
+			clientv3.OpDelete(b.invPhys(etcdInvSeqSub)),
+			clientv3.OpDelete(b.invPhys(etcdInvEntriesSub), clientv3.WithPrefix()),
+			clientv3.OpDelete(b.invPhys(etcdInvSerialSub), clientv3.WithPrefix()),
+			clientv3.OpDelete(b.invPhys(etcdInvSubjectSub), clientv3.WithPrefix()),
+		).Commit()
+	if err != nil {
+		return err
+	}
+	if !resp.Succeeded {
+		return &fs.PathError{Op: "delete", Path: KeyInventory, Err: fs.ErrNotExist}
+	}
+	return nil
+}
+
+// --- Legacy blob decomposition ---
+
+// decomposeLegacyInventory upgrades an inventory written by a pre-#138 version
+// of this backend — a single text blob at inventory/data — into the decomposed
+// per-entry structure. It runs from EnsureReady on every start; when there is
+// no legacy blob (fresh cluster, or already decomposed) it is a cheap no-op.
+//
+// The stored integrity head is deleted as part of the import: it was computed
+// under the whole-blob HMAC scheme, which does not match the hash chain the
+// decomposed inventory verifies under, and the backend does not hold the HMAC
+// key needed to translate it. The next VerifyInventoryHMAC re-establishes the
+// baseline from the imported entries — meaning tamper detection does not cover
+// the decomposition window itself. That trade is documented in
+// docs/development/inventory-store.md; run all replicas on the same version so
+// no old replica keeps appending to the blob mid-upgrade (such an append is
+// detected via the marker guard and the import restarts, but the window only
+// closes once the old writers are gone).
+func (b *EtcdBackend) decomposeLegacyInventory(ctx context.Context) error {
+	legacy, _, err := b.legacyInventoryBlob(ctx)
+	if err != nil || legacy == nil {
+		return err
+	}
+
+	// Serialise the import across replicas starting up together.
+	ul, err := b.AcquireLock(ctx, "inventory-decompose")
+	if err != nil {
+		return fmt.Errorf("locking for inventory decomposition: %w", err)
+	}
+	defer func() {
+		if err := ul.Unlock(); err != nil {
+			slog.Warn("Failed to release inventory-decompose lock", "error", err)
+		}
+	}()
+
+	for attempt := range etcdMaxTxnRetries {
+		// (Re-)read under the lock: another replica may have completed the
+		// import while we waited, or an old-version replica may have appended.
+		legacy, markerRev, err := b.legacyInventoryBlob(ctx)
+		if err != nil {
+			return err
+		}
+		if legacy == nil {
+			return nil
+		}
+		recs, err := parseInventoryRecords(legacy)
+		if err != nil {
+			return fmt.Errorf("decomposing legacy etcd inventory: %w", err)
+		}
+		conflict, err := b.replaceInventoryOnce(ctx, recs, markerRev, true)
+		if err != nil {
+			return fmt.Errorf("decomposing legacy etcd inventory: %w", err)
+		}
+		if !conflict {
+			slog.Info("Decomposed legacy etcd inventory blob into per-entry keys", "entries", len(recs))
+			return nil
+		}
+		if err := b.txnBackoff(ctx, attempt); err != nil {
+			return err
+		}
+	}
+	return fmt.Errorf("decomposing legacy etcd inventory: too many concurrent writers")
+}
+
+// legacyInventoryBlob returns the not-yet-decomposed inventory blob and the
+// marker's ModRevision, or nil when there is nothing to decompose (no marker,
+// an empty marker, or per-entry keys already present).
+func (b *EtcdBackend) legacyInventoryBlob(ctx context.Context) ([]byte, int64, error) {
+	ctx, cancel := b.callCtx(ctx)
+	defer cancel()
+	resp, err := b.client.Txn(ctx).Then(
+		clientv3.OpGet(b.invPhys(etcdInvDataSub)),
+		clientv3.OpGet(b.invPhys(etcdInvEntriesSub), clientv3.WithPrefix(), clientv3.WithCountOnly()),
+	).Commit()
+	if err != nil {
+		return nil, 0, err
+	}
+	markerKVs := resp.Responses[0].GetResponseRange().Kvs
+	if len(markerKVs) == 0 {
+		return nil, 0, nil
+	}
+	_, payload, err := decodeBlob(markerKVs[0].Value)
+	if err != nil {
+		return nil, 0, fmt.Errorf("decoding legacy inventory blob: %w", err)
+	}
+	if len(payload) == 0 {
+		return nil, 0, nil
+	}
+	if resp.Responses[1].GetResponseRange().Count > 0 {
+		// Should not happen: decomposition empties the marker in the same
+		// transaction that finishes the import. Prefer the decomposed entries
+		// (they may hold appends newer than the stale blob) but say so.
+		slog.Warn("etcd inventory has both a legacy blob and decomposed entries; ignoring the blob")
+		return nil, 0, nil
+	}
+	return payload, markerKVs[0].ModRevision, nil
+}

--- a/internal/storage/etcd_inventory.go
+++ b/internal/storage/etcd_inventory.go
@@ -20,10 +20,12 @@ package storage
 import (
 	"bytes"
 	"context"
+	"crypto/hmac"
 	"encoding/json"
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -180,12 +182,10 @@ func (b *EtcdBackend) seqGuard(seq etcdSeqState) clientv3.Cmp {
 	return clientv3.Compare(clientv3.ModRevision(b.invPhys(etcdInvSeqSub)), "=", seq.rev)
 }
 
-// etcdIndexedRecord pairs a decoded record with its sequence number and the
-// entry key's ModRevision (for guarded in-place updates).
+// etcdIndexedRecord pairs a decoded record with its sequence number.
 type etcdIndexedRecord struct {
-	seq    uint64
-	modRev int64
-	rec    CertRecord
+	seq uint64
+	rec CertRecord
 }
 
 func decodeIndexedRecords(prefix string, kvs []*mvccpb.KeyValue) ([]etcdIndexedRecord, error) {
@@ -199,7 +199,7 @@ func decodeIndexedRecords(prefix string, kvs []*mvccpb.KeyValue) ([]etcdIndexedR
 		if err != nil {
 			return nil, fmt.Errorf("entry %q: %w", kv.Key, err)
 		}
-		out = append(out, etcdIndexedRecord{seq: seq, modRev: kv.ModRevision, rec: rec})
+		out = append(out, etcdIndexedRecord{seq: seq, rec: rec})
 	}
 	return out, nil
 }
@@ -357,34 +357,71 @@ func (b *EtcdBackend) LatestSerialForSubject(ctx context.Context, subject string
 // and a crash mid-prune leaves a valid, partially-pruned inventory that the
 // caller's next prune completes). Interleaved appends invalidate the fence
 // and restart the prune from a fresh read.
-func (b *EtcdBackend) PruneEntries(ctx context.Context, keep func(InventoryEntry) bool, recomputeHead func(survivors []InventoryEntry) []byte) ([]InventoryEntry, error) {
+//
+// Per the interface contract, the returned slice contains every entry that
+// was durably removed — accumulated across batches and retries, and returned
+// even alongside a non-nil error — so the caller's CRL/blob cleanup never
+// misses an entry that a partially-completed prune already deleted.
+func (b *EtcdBackend) PruneEntries(ctx context.Context, keep func(InventoryEntry) bool, advanceHead func(prev []byte, e InventoryEntry) []byte) ([]InventoryEntry, error) {
 	b.appendMu.Lock()
 	defer b.appendMu.Unlock()
 
+	// Committed removals accumulate across attempts: a retry re-reads the
+	// inventory, so entries deleted by an earlier attempt's batches no longer
+	// appear in its view and would otherwise vanish from the result.
+	var all []etcdIndexedRecord
+	finish := func() []InventoryEntry {
+		if len(all) == 0 {
+			return nil
+		}
+		// A conflicting append may add (and a later attempt remove) entries
+		// newer than an earlier attempt's, so restore issuance order globally.
+		sort.Slice(all, func(i, j int) bool { return all[i].seq < all[j].seq })
+		return entriesOf(all)
+	}
+
 	for attempt := range etcdMaxTxnRetries {
-		removed, conflict, err := b.pruneEntriesOnce(ctx, keep, recomputeHead)
+		committed, conflict, err := b.pruneEntriesOnce(ctx, keep, advanceHead)
+		all = append(all, committed...)
 		if err != nil {
-			return nil, err
+			return finish(), err
 		}
 		if !conflict {
-			return removed, nil
+			return finish(), nil
 		}
 		if err := b.txnBackoff(ctx, attempt); err != nil {
-			return nil, err
+			return finish(), err
 		}
 	}
-	return nil, fmt.Errorf("inventory prune failed: too many concurrent writers")
+	return finish(), fmt.Errorf("inventory prune failed: too many concurrent writers")
 }
 
-func (b *EtcdBackend) pruneEntriesOnce(ctx context.Context, keep func(InventoryEntry) bool, recomputeHead func(survivors []InventoryEntry) []byte) ([]InventoryEntry, bool, error) {
+// pruneEntriesOnce performs one prune attempt. It returns the records whose
+// delete transactions committed (possibly a subset when a later batch hits a
+// fence conflict or an error), plus whether the caller should re-read and
+// retry.
+//
+// Batches are taken from the tail of the removal list, newest first. That
+// ordering makes intermediate heads cheap: after committing the batches from
+// removal index s onward, every entry older than removed[s] is still intact
+// (earlier removals are in not-yet-processed batches), and everything from
+// removed[s] onward is survivors only. Each intermediate head is therefore a
+// cached prefix fold over the original entries resumed across the survivor
+// tail — one O(n) checkpoint pass plus the survivor tails, instead of a full
+// O(n) refold per batch (quadratic when a large expiry cleanup prunes most of
+// a large inventory).
+func (b *EtcdBackend) pruneEntriesOnce(ctx context.Context, keep func(InventoryEntry) bool, advanceHead func(prev []byte, e InventoryEntry) []byte) ([]etcdIndexedRecord, bool, error) {
 	recs, seq, err := b.readIndexedRecords(ctx)
 	if err != nil {
 		return nil, false, err
 	}
 
 	var removed []etcdIndexedRecord
+	survivors := make([]etcdIndexedRecord, 0, len(recs))
 	for _, r := range recs {
-		if !keep(r.rec.InventoryEntry) {
+		if keep(r.rec.InventoryEntry) {
+			survivors = append(survivors, r)
+		} else {
 			removed = append(removed, r)
 		}
 	}
@@ -395,27 +432,51 @@ func (b *EtcdBackend) pruneEntriesOnce(ctx context.Context, keep func(InventoryE
 	// Fence value: unchanged when present; derived from the highest allocated
 	// seq otherwise (possible only for indices built before appends ran).
 	seqVal := strconv.FormatUint(seq.last, 10)
-	if !seq.present && len(recs) > 0 {
+	if !seq.present {
 		seqVal = strconv.FormatUint(recs[len(recs)-1].seq, 10)
 	}
 
-	seqRev := seq.rev
-	for start := 0; start < len(removed); start += etcdPruneBatch {
-		batch := removed[start:min(start+etcdPruneBatch, len(removed))]
-		// The state this transaction commits is the full record set minus
-		// every entry removed up to and including this batch. Later batches'
-		// removals are still present, so each committed revision is
-		// internally consistent (its head covers exactly its entries).
-		afterSet := make([]etcdIndexedRecord, 0, len(recs))
-		removedSoFar := make(map[uint64]bool, start+len(batch))
-		for _, r := range removed[:start+len(batch)] {
-			removedSoFar[r.seq] = true
-		}
+	// Batch start offsets into removed, ascending; batches run tail-first.
+	var starts []int
+	for s := 0; s < len(removed); s += etcdPruneBatch {
+		starts = append(starts, s)
+	}
+
+	// One forward fold over the full record set, checkpointing the chain
+	// value just before each batch's oldest removed entry. For the state
+	// committed by the batch starting at removed[s], that checkpoint covers
+	// exactly the entries older than removed[s] (all still present).
+	var prefixAt map[int][]byte
+	if advanceHead != nil {
+		prefixAt = make(map[int][]byte, len(starts))
+		var head []byte
+		si := 0
 		for _, r := range recs {
-			if !removedSoFar[r.seq] {
-				afterSet = append(afterSet, r)
+			if si < len(starts) && removed[starts[si]].seq == r.seq {
+				prefixAt[starts[si]] = head
+				si++
 			}
+			head = advanceHead(head, r.rec.InventoryEntry)
 		}
+	}
+
+	// Per-subject indices for repointing by-subject keys without rescanning
+	// the whole record set per batch.
+	subjAll := make(map[string][]etcdIndexedRecord)
+	for _, r := range recs {
+		subjAll[r.rec.Subject] = append(subjAll[r.rec.Subject], r)
+	}
+	subjSurvLast := make(map[string]etcdIndexedRecord, len(survivors))
+	for _, r := range survivors {
+		subjSurvLast[r.rec.Subject] = r
+	}
+
+	seqRev := seq.rev
+	committedFrom := len(removed) // removal index from which deletes have committed
+	for si := len(starts) - 1; si >= 0; si-- {
+		s := starts[si]
+		batch := removed[s:min(s+etcdPruneBatch, len(removed))]
+		cutSeq := removed[s].seq
 
 		ops := make([]clientv3.Op, 0, 3*len(batch)+3)
 		subjects := make(map[string]bool, len(batch))
@@ -426,14 +487,20 @@ func (b *EtcdBackend) pruneEntriesOnce(ctx context.Context, keep func(InventoryE
 			)
 			subjects[r.rec.Subject] = true
 		}
-		// Repoint each affected subject's by-subject key at its newest
-		// surviving serial, or drop the key when none survives.
+		// Repoint each affected subject at its newest entry still present in
+		// the committed state: entries older than the cut are all present, and
+		// from the cut onward only survivors are.
 		for subject := range subjects {
-			latest := ""
-			for _, r := range afterSet {
-				if r.rec.Subject == subject {
-					latest = r.rec.Serial
-				}
+			var latest string
+			var latestSeq uint64
+			entries := subjAll[subject]
+			i := sort.Search(len(entries), func(i int) bool { return entries[i].seq >= cutSeq })
+			if i > 0 {
+				latest = entries[i-1].rec.Serial
+				latestSeq = entries[i-1].seq
+			}
+			if lv, ok := subjSurvLast[subject]; ok && lv.seq > cutSeq && lv.seq > latestSeq {
+				latest = lv.rec.Serial
 			}
 			key := b.invPhys(etcdInvSubjectSub + subject)
 			if latest == "" {
@@ -442,8 +509,12 @@ func (b *EtcdBackend) pruneEntriesOnce(ctx context.Context, keep func(InventoryE
 				ops = append(ops, clientv3.OpPut(key, latest))
 			}
 		}
-		if recomputeHead != nil {
-			head := recomputeHead(entriesOf(afterSet))
+		if advanceHead != nil {
+			head := prefixAt[s]
+			j := sort.Search(len(survivors), func(i int) bool { return survivors[i].seq > cutSeq })
+			for _, r := range survivors[j:] {
+				head = advanceHead(head, r.rec.InventoryEntry)
+			}
 			ops = append(ops, clientv3.OpPut(b.invPhys(etcdInvHMACSub), string(encodeBlob(time.Now(), head))))
 		}
 		ops = append(ops, clientv3.OpPut(b.invPhys(etcdInvSeqSub), seqVal))
@@ -454,21 +525,20 @@ func (b *EtcdBackend) pruneEntriesOnce(ctx context.Context, keep func(InventoryE
 		).Then(ops...).Commit()
 		cancel()
 		if err != nil {
-			return nil, false, err
+			return removed[committedFrom:], false, err
 		}
 		if !resp.Succeeded {
-			return nil, true, nil
+			return removed[committedFrom:], true, nil
 		}
 		// Our own put moved the fence; subsequent batches guard on the new
 		// revision, which every op in this transaction committed at.
 		seqRev = resp.Header.Revision
+		committedFrom = s
+		if b.pruneBatchHook != nil {
+			b.pruneBatchHook()
+		}
 	}
-
-	out := make([]InventoryEntry, len(removed))
-	for i, r := range removed {
-		out[i] = r.rec.InventoryEntry
-	}
-	return out, false, nil
+	return removed, false, nil
 }
 
 // --- KeyInventory blob shim ---
@@ -644,21 +714,25 @@ func (b *EtcdBackend) replaceInventoryOnce(ctx context.Context, recs []CertRecor
 	for start := 0; start < len(recs); start += etcdImportBatch {
 		batch := recs[start:min(start+etcdImportBatch, len(recs))]
 		ops := make([]clientv3.Op, 0, 3*len(batch)+1)
-		// One by-subject put per subject per transaction (etcd rejects
-		// duplicate keys within a txn); later batches overwrite earlier ones,
-		// leaving each subject pointing at its newest serial.
+		// One put per index key per transaction (etcd rejects duplicate keys
+		// within a txn); later occurrences — in the same batch via these maps,
+		// across batches via plain overwrite — win, leaving each subject
+		// pointing at its newest serial and, for a legacy blob that carries
+		// duplicate serials, each serial at its newest bearer.
 		subjectLatest := make(map[string]string, len(batch))
+		serialLatest := make(map[string]uint64, len(batch))
 		for i, rec := range batch {
 			val, err := encodeInventoryRecord(rec)
 			if err != nil {
 				return false, err
 			}
 			n := uint64(start+i) + 1
-			ops = append(ops,
-				clientv3.OpPut(b.entryPhys(n), string(val)),
-				clientv3.OpPut(b.invPhys(etcdInvSerialSub+rec.Serial), strconv.FormatUint(n, 10)),
-			)
+			ops = append(ops, clientv3.OpPut(b.entryPhys(n), string(val)))
+			serialLatest[rec.Serial] = n
 			subjectLatest[rec.Subject] = rec.Serial
+		}
+		for serial, n := range serialLatest {
+			ops = append(ops, clientv3.OpPut(b.invPhys(etcdInvSerialSub+serial), strconv.FormatUint(n, 10)))
 		}
 		for subject, serial := range subjectLatest {
 			ops = append(ops, clientv3.OpPut(b.invPhys(etcdInvSubjectSub+subject), serial))
@@ -691,6 +765,12 @@ func (b *EtcdBackend) appendInventoryLines(ctx context.Context, data []byte) err
 	}
 	if err := rejectDuplicateSerials(recs); err != nil {
 		return err
+	}
+	// This path appends all lines in one transaction (unlike imports and
+	// prunes, which batch), so bound it explicitly rather than let the etcd
+	// server reject an oversized transaction with an opaque error.
+	if len(recs) > etcdImportBatch {
+		return fmt.Errorf("appending %d inventory lines in one call exceeds the etcd transaction budget of %d (bounded by the server's --max-txn-ops, default 128); append in smaller chunks", len(recs), etcdImportBatch)
 	}
 
 	b.appendMu.Lock()
@@ -791,20 +871,32 @@ func (b *EtcdBackend) deleteInventory(ctx context.Context) error {
 // per-entry structure. It runs from EnsureReady on every start; when there is
 // no legacy blob (fresh cluster, or already decomposed) it is a cheap no-op.
 //
-// The stored integrity head is deleted as part of the import: it was computed
-// under the whole-blob HMAC scheme, which does not match the hash chain the
-// decomposed inventory verifies under, and the backend does not hold the HMAC
-// key needed to translate it. The next VerifyInventoryHMAC re-establishes the
-// baseline from the imported entries — meaning tamper detection does not cover
-// the decomposition window itself. That trade is documented in
-// docs/development/inventory-store.md; run all replicas on the same version so
-// no old replica keeps appending to the blob mid-upgrade (such an append is
-// detected via the marker guard and the import restarts, but the window only
-// closes once the old writers are gone).
+// The blob stays authoritative until the import completes: the marker is only
+// emptied by the import's final transaction, so an interrupted import (crash,
+// etcd error, Ctrl-C) leaves the blob intact and the next start detects the
+// partial entry set as a resumable state and redoes the import from the blob.
+// Entry keys that are NOT a prefix of the blob mean something else wrote to
+// the decomposed structure while the blob still had content — a mixed-version
+// cluster — and that is refused with an explicit error rather than guessing
+// which side to keep.
+//
+// Integrity: when both the HMAC key and a stored head are present, the blob's
+// whole-blob HMAC is verified before it is trusted, and a mismatch fails
+// startup with ErrInventoryTampered exactly as the pre-decomposition code
+// would have. The (verified) head is then deleted as part of the import — it
+// is not a hash-chain head, so it cannot carry over — and the next
+// VerifyInventoryHMAC re-establishes the baseline from the imported entries.
+// Only the import window itself is therefore uncovered; run all replicas on
+// the same version so no old replica keeps appending to the blob mid-upgrade
+// (such an append is detected via the marker guard and the import restarts,
+// but the window only closes once the old writers are gone).
 func (b *EtcdBackend) decomposeLegacyInventory(ctx context.Context) error {
-	legacy, _, err := b.legacyInventoryBlob(ctx)
-	if err != nil || legacy == nil {
+	state, err := b.legacyInventoryState(ctx)
+	if err != nil {
 		return err
+	}
+	if len(state.blob) == 0 {
+		return nil
 	}
 
 	// Serialise the import across replicas starting up together.
@@ -821,18 +913,38 @@ func (b *EtcdBackend) decomposeLegacyInventory(ctx context.Context) error {
 	for attempt := range etcdMaxTxnRetries {
 		// (Re-)read under the lock: another replica may have completed the
 		// import while we waited, or an old-version replica may have appended.
-		legacy, markerRev, err := b.legacyInventoryBlob(ctx)
+		state, err := b.legacyInventoryState(ctx)
 		if err != nil {
 			return err
 		}
-		if legacy == nil {
+		if len(state.blob) == 0 {
 			return nil
 		}
-		recs, err := parseInventoryRecords(legacy)
+		recs, err := parseInventoryRecords(state.blob)
 		if err != nil {
 			return fmt.Errorf("decomposing legacy etcd inventory: %w", err)
 		}
-		conflict, err := b.replaceInventoryOnce(ctx, recs, markerRev, true)
+		if len(state.entries) > 0 {
+			if !recordsArePrefixOf(state.entries, recs) {
+				return fmt.Errorf("etcd inventory holds both a non-empty legacy blob and decomposed entries that do not match it; " +
+					"this usually means a pre-decomposition replica wrote to the blob after another replica upgraded. " +
+					"Refusing to guess: inspect inventory/data and inventory/entries/ under the key prefix and remove whichever is stale")
+			}
+			slog.Info("Resuming interrupted etcd inventory decomposition", "imported", len(state.entries), "total", len(recs))
+		}
+		if err := b.verifyLegacyInventoryMAC(ctx, state.blob); err != nil {
+			return err
+		}
+		if dups := duplicateSerials(recs); len(dups) > 0 {
+			// Blob backends never had a cluster-wide duplicate-serial
+			// guarantee, so a legacy inventory can legitimately carry
+			// repeats. Refusing would brick startup; instead every line is
+			// imported verbatim (preserving the rendered text) and the
+			// by-serial index points at each serial's newest bearer.
+			slog.Warn("Legacy etcd inventory contains duplicate serials; by-serial index will point at the newest entry for each",
+				"serials", dups)
+		}
+		conflict, err := b.replaceInventoryOnce(ctx, recs, state.markerRev, true)
 		if err != nil {
 			return fmt.Errorf("decomposing legacy etcd inventory: %w", err)
 		}
@@ -847,36 +959,122 @@ func (b *EtcdBackend) decomposeLegacyInventory(ctx context.Context) error {
 	return fmt.Errorf("decomposing legacy etcd inventory: too many concurrent writers")
 }
 
-// legacyInventoryBlob returns the not-yet-decomposed inventory blob and the
-// marker's ModRevision, or nil when there is nothing to decompose (no marker,
-// an empty marker, or per-entry keys already present).
-func (b *EtcdBackend) legacyInventoryBlob(ctx context.Context) ([]byte, int64, error) {
+// etcdLegacyState is a snapshot of the inventory keys a decomposition cares
+// about: the marker/blob payload (empty when there is nothing to decompose)
+// with its ModRevision, and any decomposed entry keys already present.
+type etcdLegacyState struct {
+	blob      []byte
+	markerRev int64
+	entries   []etcdIndexedRecord
+}
+
+// legacyInventoryState returns the not-yet-decomposed inventory blob together
+// with any existing entry keys, read atomically. A zero-length blob means
+// there is nothing to decompose (no marker, or an already-emptied one).
+func (b *EtcdBackend) legacyInventoryState(ctx context.Context) (etcdLegacyState, error) {
 	ctx, cancel := b.callCtx(ctx)
 	defer cancel()
 	resp, err := b.client.Txn(ctx).Then(
 		clientv3.OpGet(b.invPhys(etcdInvDataSub)),
-		clientv3.OpGet(b.invPhys(etcdInvEntriesSub), clientv3.WithPrefix(), clientv3.WithCountOnly()),
+		clientv3.OpGet(b.invPhys(etcdInvEntriesSub), clientv3.WithPrefix()),
 	).Commit()
 	if err != nil {
-		return nil, 0, err
+		return etcdLegacyState{}, err
 	}
 	markerKVs := resp.Responses[0].GetResponseRange().Kvs
 	if len(markerKVs) == 0 {
-		return nil, 0, nil
+		return etcdLegacyState{}, nil
 	}
 	_, payload, err := decodeBlob(markerKVs[0].Value)
 	if err != nil {
-		return nil, 0, fmt.Errorf("decoding legacy inventory blob: %w", err)
+		return etcdLegacyState{}, fmt.Errorf("decoding legacy inventory blob: %w", err)
 	}
 	if len(payload) == 0 {
-		return nil, 0, nil
+		return etcdLegacyState{}, nil
 	}
-	if resp.Responses[1].GetResponseRange().Count > 0 {
-		// Should not happen: decomposition empties the marker in the same
-		// transaction that finishes the import. Prefer the decomposed entries
-		// (they may hold appends newer than the stale blob) but say so.
-		slog.Warn("etcd inventory has both a legacy blob and decomposed entries; ignoring the blob")
-		return nil, 0, nil
+	entries, err := decodeIndexedRecords(b.invPhys(etcdInvEntriesSub), resp.Responses[1].GetResponseRange().Kvs)
+	if err != nil {
+		return etcdLegacyState{}, err
 	}
-	return payload, markerKVs[0].ModRevision, nil
+	return etcdLegacyState{blob: payload, markerRev: markerKVs[0].ModRevision, entries: entries}, nil
+}
+
+// recordsArePrefixOf reports whether the stored entries are exactly the
+// import-written prefix of recs: sequence numbers 1..len(entries) carrying the
+// same canonical fields. That is the state an interrupted import leaves
+// behind (the wipe ran, then some batches committed), and the only state a
+// re-run may safely overwrite.
+func recordsArePrefixOf(entries []etcdIndexedRecord, recs []CertRecord) bool {
+	if len(entries) > len(recs) {
+		return false
+	}
+	for i, e := range entries {
+		if e.seq != uint64(i)+1 || e.rec.InventoryEntry != recs[i].InventoryEntry {
+			return false
+		}
+	}
+	return true
+}
+
+// verifyLegacyInventoryMAC checks the legacy blob against its stored
+// whole-blob HMAC before the blob is trusted as the import source. Absent
+// head: nothing to check (the baseline is established after the import).
+// Absent or malformed key with a head present: verification is impossible;
+// log loudly and proceed, since the alternative is bricking startup on a
+// state the operator can no longer influence. Mismatch: fail startup with
+// ErrInventoryTampered, exactly as the pre-decomposition verify would have.
+func (b *EtcdBackend) verifyLegacyInventoryMAC(ctx context.Context, blob []byte) error {
+	keyPhys, err := b.physicalKey(KeyHMACKey)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := b.callCtx(ctx)
+	defer cancel()
+	resp, err := b.client.Txn(ctx).Then(
+		clientv3.OpGet(b.invPhys(etcdInvHMACSub)),
+		clientv3.OpGet(keyPhys),
+	).Commit()
+	if err != nil {
+		return err
+	}
+	headKVs := resp.Responses[0].GetResponseRange().Kvs
+	if len(headKVs) == 0 {
+		return nil
+	}
+	_, stored, err := decodeBlob(headKVs[0].Value)
+	if err != nil {
+		return fmt.Errorf("decoding legacy inventory HMAC: %w", err)
+	}
+	keyKVs := resp.Responses[1].GetResponseRange().Kvs
+	if len(keyKVs) == 0 {
+		slog.Warn("Legacy etcd inventory has a stored HMAC but no HMAC key; skipping verification before decomposition")
+		return nil
+	}
+	_, key, err := decodeBlob(keyKVs[0].Value)
+	if err != nil || len(key) != hmacKeyLen {
+		slog.Warn("Legacy etcd inventory HMAC key is unreadable or malformed; skipping verification before decomposition", "error", err)
+		return nil
+	}
+	if !hmac.Equal(wholeBlobInventoryMAC(key, blob), stored) {
+		return fmt.Errorf("legacy etcd inventory failed integrity verification before decomposition: %w", ErrInventoryTampered)
+	}
+	return nil
+}
+
+// duplicateSerials returns each serial that appears on more than one record,
+// once, in first-seen order.
+func duplicateSerials(recs []CertRecord) []string {
+	counts := make(map[string]int, len(recs))
+	for _, r := range recs {
+		counts[r.Serial]++
+	}
+	var dups []string
+	seen := make(map[string]bool)
+	for _, r := range recs {
+		if counts[r.Serial] > 1 && !seen[r.Serial] {
+			dups = append(dups, r.Serial)
+			seen[r.Serial] = true
+		}
+	}
+	return dups
 }

--- a/internal/storage/etcd_inventory.go
+++ b/internal/storage/etcd_inventory.go
@@ -468,7 +468,15 @@ func (b *EtcdBackend) pruneEntriesOnce(ctx context.Context, keep func(InventoryE
 	// calls. Never silently: the caller's log should explain a short count.
 	if len(starts) > etcdPruneMaxBatchesPerCall {
 		starts = starts[len(starts)-etcdPruneMaxBatchesPerCall:]
-		slog.Info("Bounding inventory prune to keep it inside the caller's time budget; later runs will remove the rest",
+		logFn := slog.Info
+		if starts[0] > etcdPruneMaxBatchesPerCall*etcdPruneBatch {
+			// More is deferred than a whole run can remove: at the current
+			// cleanup interval the backlog is growing, not draining. Make
+			// that visible rather than inferable — the operator's lever is
+			// shortening the cleanup interval.
+			logFn = slog.Warn
+		}
+		logFn("Bounding inventory prune to keep it inside the caller's time budget; later runs will remove the rest",
 			"removing", len(removed)-starts[0], "deferred", starts[0])
 	}
 

--- a/internal/storage/etcd_inventory.go
+++ b/internal/storage/etcd_inventory.go
@@ -84,6 +84,24 @@ const (
 	etcdPruneBatch  = 30
 )
 
+// etcdPruneMaxBatchesPerCall bounds one PruneEntries call to this many
+// committed batches (currently 900 entries). Each batch writes an
+// intermediate head folded over the entries that remain, so a prune's total
+// hashing cost grows with batches × survivors; an unbounded call over a large
+// backlog could not finish inside the caller's lock budget. Deferred entries
+// stay present and consistent and are removed by subsequent calls (the
+// cleanup job runs periodically), which the PruneEntries contract permits.
+const etcdPruneMaxBatchesPerCall = 30
+
+// etcdSerialAmbiguous is the by-serial index value recorded for a serial that
+// appears on more than one imported record (possible only in a legacy blob:
+// blob backends never had a cluster-wide uniqueness guarantee, and every
+// other write path rejects duplicates). The one-to-one index cannot name all
+// bearers, so instead of silently aliasing certificate-index writes onto an
+// arbitrary record, the sentinel makes them explicit no-ops while still
+// keeping the serial reserved against reissue.
+const etcdSerialAmbiguous = "ambiguous"
+
 // etcdInventoryRecord is the stored JSON form of a CertRecord. The field set
 // is spelled out (rather than marshalling CertRecord directly) so the wire
 // format is explicit and stable against refactors of the in-memory structs.
@@ -361,7 +379,10 @@ func (b *EtcdBackend) LatestSerialForSubject(ctx context.Context, subject string
 // Per the interface contract, the returned slice contains every entry that
 // was durably removed — accumulated across batches and retries, and returned
 // even alongside a non-nil error — so the caller's CRL/blob cleanup never
-// misses an entry that a partially-completed prune already deleted.
+// misses an entry that a partially-completed prune already deleted. One call
+// removes at most etcdPruneMaxBatchesPerCall batches' worth of entries;
+// matches beyond that stay in the inventory for later calls (the interface
+// contract permits bounding, and the periodic cleanup job converges).
 func (b *EtcdBackend) PruneEntries(ctx context.Context, keep func(InventoryEntry) bool, advanceHead func(prev []byte, e InventoryEntry) []byte) ([]InventoryEntry, error) {
 	b.appendMu.Lock()
 	defer b.appendMu.Unlock()
@@ -440,6 +461,15 @@ func (b *EtcdBackend) pruneEntriesOnce(ctx context.Context, keep func(InventoryE
 	var starts []int
 	for s := 0; s < len(removed); s += etcdPruneBatch {
 		starts = append(starts, s)
+	}
+	// Bound one call's work (see etcdPruneMaxBatchesPerCall). Batches run
+	// tail-first, so keeping the last starts removes the newest matches and
+	// defers the older ones — which stay present and consistent — to later
+	// calls. Never silently: the caller's log should explain a short count.
+	if len(starts) > etcdPruneMaxBatchesPerCall {
+		starts = starts[len(starts)-etcdPruneMaxBatchesPerCall:]
+		slog.Info("Bounding inventory prune to keep it inside the caller's time budget; later runs will remove the rest",
+			"removing", len(removed)-starts[0], "deferred", starts[0])
 	}
 
 	// One forward fold over the full record set, checkpointing the chain
@@ -538,7 +568,9 @@ func (b *EtcdBackend) pruneEntriesOnce(ctx context.Context, keep func(InventoryE
 			b.pruneBatchHook()
 		}
 	}
-	return removed, false, nil
+	// All selected batches committed; entries before starts[0] (if any) were
+	// deferred by the per-call bound and remain in the inventory.
+	return removed[starts[0]:], false, nil
 }
 
 // --- KeyInventory blob shim ---
@@ -697,7 +729,18 @@ func (b *EtcdBackend) replaceInventoryOnce(ctx context.Context, recs []CertRecor
 		if !resp.Succeeded {
 			return 0, true, nil
 		}
+		if b.importBatchHook != nil {
+			b.importBatchHook()
+		}
 		return resp.Header.Revision, false, nil
+	}
+
+	// Serials appearing on more than one record cannot be pointed at through
+	// the one-to-one by-serial index without picking a wrong record for the
+	// others; mark them ambiguous so index writes refuse instead of aliasing.
+	dupSerials := make(map[string]bool)
+	for _, serial := range duplicateSerials(recs) {
+		dupSerials[serial] = true
 	}
 
 	// Clear the existing structure and reset the fence.
@@ -717,10 +760,10 @@ func (b *EtcdBackend) replaceInventoryOnce(ctx context.Context, recs []CertRecor
 		// One put per index key per transaction (etcd rejects duplicate keys
 		// within a txn); later occurrences — in the same batch via these maps,
 		// across batches via plain overwrite — win, leaving each subject
-		// pointing at its newest serial and, for a legacy blob that carries
-		// duplicate serials, each serial at its newest bearer.
+		// pointing at its newest serial. A serial borne by several records
+		// gets the ambiguity sentinel instead of a sequence number.
 		subjectLatest := make(map[string]string, len(batch))
-		serialLatest := make(map[string]uint64, len(batch))
+		serialValue := make(map[string]string, len(batch))
 		for i, rec := range batch {
 			val, err := encodeInventoryRecord(rec)
 			if err != nil {
@@ -728,11 +771,15 @@ func (b *EtcdBackend) replaceInventoryOnce(ctx context.Context, recs []CertRecor
 			}
 			n := uint64(start+i) + 1
 			ops = append(ops, clientv3.OpPut(b.entryPhys(n), string(val)))
-			serialLatest[rec.Serial] = n
+			if dupSerials[rec.Serial] {
+				serialValue[rec.Serial] = etcdSerialAmbiguous
+			} else {
+				serialValue[rec.Serial] = strconv.FormatUint(n, 10)
+			}
 			subjectLatest[rec.Subject] = rec.Serial
 		}
-		for serial, n := range serialLatest {
-			ops = append(ops, clientv3.OpPut(b.invPhys(etcdInvSerialSub+serial), strconv.FormatUint(n, 10)))
+		for serial, value := range serialValue {
+			ops = append(ops, clientv3.OpPut(b.invPhys(etcdInvSerialSub+serial), value))
 		}
 		for subject, serial := range subjectLatest {
 			ops = append(ops, clientv3.OpPut(b.invPhys(etcdInvSubjectSub+subject), serial))
@@ -891,12 +938,17 @@ func (b *EtcdBackend) deleteInventory(ctx context.Context) error {
 // (such an append is detected via the marker guard and the import restarts,
 // but the window only closes once the old writers are gone).
 func (b *EtcdBackend) decomposeLegacyInventory(ctx context.Context) error {
-	state, err := b.legacyInventoryState(ctx)
+	// Cheap probe first: on every start after the one-time conversion this
+	// path must not transfer the whole inventory keyspace, so read only the
+	// marker to decide whether the expensive state read is needed at all.
+	payload, err := b.legacyMarkerPayload(ctx)
 	if err != nil {
 		return err
 	}
-	if len(state.blob) == 0 {
-		return nil
+	if len(payload) == 0 {
+		// Nothing to import — but an upgraded CA whose inventory was empty
+		// still carries a whole-blob head that no import will ever drop.
+		return b.convertLegacyEmptyHead(ctx)
 	}
 
 	// Serialise the import across replicas starting up together.
@@ -939,9 +991,11 @@ func (b *EtcdBackend) decomposeLegacyInventory(ctx context.Context) error {
 			// Blob backends never had a cluster-wide duplicate-serial
 			// guarantee, so a legacy inventory can legitimately carry
 			// repeats. Refusing would brick startup; instead every line is
-			// imported verbatim (preserving the rendered text) and the
-			// by-serial index points at each serial's newest bearer.
-			slog.Warn("Legacy etcd inventory contains duplicate serials; by-serial index will point at the newest entry for each",
+			// imported verbatim (preserving the rendered text), the serials
+			// stay reserved against reissue, and certificate-index writes
+			// for them are refused (see etcdSerialAmbiguous) so revocation
+			// state and projections cannot land on the wrong record.
+			slog.Warn("Legacy etcd inventory contains duplicate serials; certificate-index state for them will be unavailable until the duplicates are resolved",
 				"serials", dups)
 		}
 		conflict, err := b.replaceInventoryOnce(ctx, recs, state.markerRev, true)
@@ -999,6 +1053,103 @@ func (b *EtcdBackend) legacyInventoryState(ctx context.Context) (etcdLegacyState
 	return etcdLegacyState{blob: payload, markerRev: markerKVs[0].ModRevision, entries: entries}, nil
 }
 
+// legacyMarkerPayload returns the marker/blob payload at inventory/data, or
+// nil when the marker is absent. This is the cheap every-start probe: it
+// reads a single key, unlike legacyInventoryState which also transfers the
+// whole entry range.
+func (b *EtcdBackend) legacyMarkerPayload(ctx context.Context) ([]byte, error) {
+	ctx, cancel := b.callCtx(ctx)
+	defer cancel()
+	resp, err := b.client.Get(ctx, b.invPhys(etcdInvDataSub))
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.Kvs) == 0 {
+		return nil, nil
+	}
+	_, payload, err := decodeBlob(resp.Kvs[0].Value)
+	if err != nil {
+		return nil, fmt.Errorf("decoding legacy inventory blob: %w", err)
+	}
+	return payload, nil
+}
+
+// convertLegacyEmptyHead completes the upgrade for a pre-decomposition CA
+// whose inventory was empty. Such a CA always stores a whole-blob HMAC (CA
+// bootstrap writes one over the empty inventory before the first cert is ever
+// issued), but with no blob content there is no import to drop it as part of,
+// so it would survive the upgrade and fail the first chain verification with
+// a spurious tampering error that nothing re-baselines away.
+//
+// The head is deleted only when it verifies as the whole-blob MAC of an empty
+// inventory under the stored key — the exact value the legacy code wrote — so
+// the next verification re-establishes the chained baseline. Any other
+// non-empty head over zero entries is deliberately left in place for
+// verification to flag: it is indistinguishable from the residue of a
+// decomposed inventory whose entries were tampered away, and deleting it
+// would silently accept that.
+func (b *EtcdBackend) convertLegacyEmptyHead(ctx context.Context) error {
+	keyPhys, err := b.physicalKey(KeyHMACKey)
+	if err != nil {
+		return err
+	}
+	for attempt := range etcdMaxTxnRetries {
+		readCtx, cancel := b.callCtx(ctx)
+		resp, err := b.client.Txn(readCtx).Then(
+			clientv3.OpGet(b.invPhys(etcdInvHMACSub)),
+			clientv3.OpGet(keyPhys),
+			clientv3.OpGet(b.invPhys(etcdInvEntriesSub), clientv3.WithPrefix(), clientv3.WithCountOnly()),
+		).Commit()
+		cancel()
+		if err != nil {
+			return err
+		}
+		if resp.Responses[2].GetResponseRange().Count > 0 {
+			return nil // decomposed entries exist; the head is theirs
+		}
+		headKVs := resp.Responses[0].GetResponseRange().Kvs
+		if len(headKVs) == 0 {
+			return nil
+		}
+		_, stored, err := decodeBlob(headKVs[0].Value)
+		if err != nil {
+			return fmt.Errorf("decoding legacy inventory HMAC: %w", err)
+		}
+		if len(stored) == 0 {
+			return nil // already the chained baseline of an empty inventory
+		}
+		keyKVs := resp.Responses[1].GetResponseRange().Kvs
+		if len(keyKVs) == 0 {
+			return nil // cannot verify; leave it for verification to fail closed
+		}
+		_, key, err := decodeBlob(keyKVs[0].Value)
+		if err != nil || len(key) != hmacKeyLen {
+			return nil //nolint:nilerr // same: unverifiable, so leave the head alone
+		}
+		if !hmac.Equal(wholeBlobInventoryMAC(key, nil), stored) {
+			return nil
+		}
+
+		txnCtx, cancel2 := b.callCtx(ctx)
+		txnResp, err := b.client.Txn(txnCtx).
+			If(clientv3.Compare(clientv3.ModRevision(b.invPhys(etcdInvHMACSub)), "=", headKVs[0].ModRevision)).
+			Then(clientv3.OpDelete(b.invPhys(etcdInvHMACSub))).
+			Commit()
+		cancel2()
+		if err != nil {
+			return err
+		}
+		if txnResp.Succeeded {
+			slog.Info("Removed legacy whole-blob inventory HMAC for an empty inventory; the integrity baseline will be re-established on first verification")
+			return nil
+		}
+		if err := b.txnBackoff(ctx, attempt); err != nil {
+			return err
+		}
+	}
+	return fmt.Errorf("removing legacy inventory HMAC: too many concurrent writers")
+}
+
 // recordsArePrefixOf reports whether the stored entries are exactly the
 // import-written prefix of recs: sequence numbers 1..len(entries) carrying the
 // same canonical fields. That is the state an interrupted import leaves
@@ -1019,10 +1170,13 @@ func recordsArePrefixOf(entries []etcdIndexedRecord, recs []CertRecord) bool {
 // verifyLegacyInventoryMAC checks the legacy blob against its stored
 // whole-blob HMAC before the blob is trusted as the import source. Absent
 // head: nothing to check (the baseline is established after the import).
-// Absent or malformed key with a head present: verification is impossible;
-// log loudly and proceed, since the alternative is bricking startup on a
-// state the operator can no longer influence. Mismatch: fail startup with
-// ErrInventoryTampered, exactly as the pre-decomposition verify would have.
+// Mismatch: fail startup with ErrInventoryTampered, exactly as the
+// pre-decomposition verify would have. A head that cannot be verified —
+// because the HMAC key is missing or malformed — also fails startup: the
+// pre-decomposition code was fail-closed in that state too (it regenerated
+// the key and then flagged the surviving head as tampering), and proceeding
+// would silently promote an unverifiable blob to the new trusted baseline.
+// The operator acknowledges a lost baseline by deleting the stored head.
 func (b *EtcdBackend) verifyLegacyInventoryMAC(ctx context.Context, blob []byte) error {
 	keyPhys, err := b.physicalKey(KeyHMACKey)
 	if err != nil {
@@ -1047,13 +1201,15 @@ func (b *EtcdBackend) verifyLegacyInventoryMAC(ctx context.Context, blob []byte)
 	}
 	keyKVs := resp.Responses[1].GetResponseRange().Kvs
 	if len(keyKVs) == 0 {
-		slog.Warn("Legacy etcd inventory has a stored HMAC but no HMAC key; skipping verification before decomposition")
-		return nil
+		return fmt.Errorf("legacy etcd inventory has a stored integrity value but no HMAC key to verify it with; "+
+			"delete the %s key under the etcd prefix to acknowledge the lost baseline and retry: %w",
+			etcdInvHMACSub, ErrInventoryTampered)
 	}
 	_, key, err := decodeBlob(keyKVs[0].Value)
 	if err != nil || len(key) != hmacKeyLen {
-		slog.Warn("Legacy etcd inventory HMAC key is unreadable or malformed; skipping verification before decomposition", "error", err)
-		return nil
+		return fmt.Errorf("legacy etcd inventory HMAC key is unreadable or malformed, so the stored integrity value cannot be verified; "+
+			"delete the %s key under the etcd prefix to acknowledge the lost baseline and retry: %w",
+			etcdInvHMACSub, ErrInventoryTampered)
 	}
 	if !hmac.Equal(wholeBlobInventoryMAC(key, blob), stored) {
 		return fmt.Errorf("legacy etcd inventory failed integrity verification before decomposition: %w", ErrInventoryTampered)

--- a/internal/storage/etcd_unit_test.go
+++ b/internal/storage/etcd_unit_test.go
@@ -23,6 +23,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"go.etcd.io/etcd/api/v3/mvccpb"
 )
 
 // These tests exercise pure helpers of the etcd backend without requiring a
@@ -212,5 +214,75 @@ var _ = Describe("ParseInventoryRecords", func() {
 			"0001 nb1 na1 /node1\n0001 nb2 na2 /node2\n"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rejectDuplicateSerials(recs)).To(MatchError(ErrDuplicateSerial))
+	})
+
+	It("lists each duplicate serial once via duplicateSerials", func() {
+		recs, err := parseInventoryRecords([]byte(
+			"0001 nb na /a\n0002 nb na /b\n0001 nb na /c\n0001 nb na /d\n"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(duplicateSerials(recs)).To(Equal([]string{"0001"}))
+		Expect(duplicateSerials(recs[:2])).To(BeEmpty())
+	})
+})
+
+// EtcdInventoryDecodeCorruptKeyspace pins the failure mode of the two decode
+// helpers that gate every inventory read: a foreign or corrupt key under the
+// inventory namespace must fail hard, with an error naming the offending
+// key/value so an operator can find it.
+var _ = Describe("EtcdInventoryDecodeCorruptKeyspace", func() {
+	It("rejects a non-numeric sequence counter, naming the value", func() {
+		_, err := decodeSeqState([]*mvccpb.KeyValue{{Key: []byte("/p/inventory/seq"), Value: []byte("not-a-number")}})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not-a-number"))
+	})
+
+	It("rejects an entry key whose suffix is not a sequence number, naming the key", func() {
+		_, err := decodeIndexedRecords("/p/inventory/entries/", []*mvccpb.KeyValue{
+			{Key: []byte("/p/inventory/entries/stray"), Value: []byte("{}")},
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("stray"))
+	})
+
+	It("rejects an entry with an undecodable value, naming the key", func() {
+		_, err := decodeIndexedRecords("/p/inventory/entries/", []*mvccpb.KeyValue{
+			{Key: []byte("/p/inventory/entries/00000000000000000001"), Value: []byte("{not-json")},
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("00000000000000000001"))
+	})
+})
+
+// EtcdLegacyPrefixCheck pins the discriminator the decomposition uses to tell
+// a resumable interrupted import (entries are the import-written prefix of
+// the blob) from an unsupported mixed-version state.
+var _ = Describe("EtcdLegacyPrefixCheck", func() {
+	recsOf := func(text string) []CertRecord {
+		recs, err := parseInventoryRecords([]byte(text))
+		Expect(err).NotTo(HaveOccurred())
+		return recs
+	}
+	entryOf := func(seq uint64, line string) etcdIndexedRecord {
+		e, ok := parseInventoryEntry(line)
+		Expect(ok).To(BeTrue())
+		return etcdIndexedRecord{seq: seq, rec: CertRecord{InventoryEntry: e, State: CertStateSigned}}
+	}
+
+	It("accepts an import-written prefix and rejects everything else", func() {
+		recs := recsOf("0001 nb na /a\n0002 nb na /b\n0003 nb na /c\n")
+		prefix := []etcdIndexedRecord{entryOf(1, "0001 nb na /a"), entryOf(2, "0002 nb na /b")}
+		Expect(recordsArePrefixOf(prefix, recs)).To(BeTrue())
+		Expect(recordsArePrefixOf(nil, recs)).To(BeTrue(), "no entries at all is the trivial prefix")
+
+		// Wrong contents, wrong sequence numbering, or more entries than the
+		// blob has lines all mean the entries did not come from importing
+		// this blob.
+		Expect(recordsArePrefixOf([]etcdIndexedRecord{entryOf(1, "0009 nb na /x")}, recs)).To(BeFalse())
+		Expect(recordsArePrefixOf([]etcdIndexedRecord{entryOf(5, "0001 nb na /a")}, recs)).To(BeFalse())
+		long := []etcdIndexedRecord{
+			entryOf(1, "0001 nb na /a"), entryOf(2, "0002 nb na /b"),
+			entryOf(3, "0003 nb na /c"), entryOf(4, "0004 nb na /d"),
+		}
+		Expect(recordsArePrefixOf(long, recs)).To(BeFalse())
 	})
 })

--- a/internal/storage/etcd_unit_test.go
+++ b/internal/storage/etcd_unit_test.go
@@ -133,3 +133,84 @@ var _ = Describe("EtcdBackendImplementsBackend", func() {
 		var _ Backend = (*EtcdBackend)(nil)
 	})
 })
+
+var _ = Describe("EtcdInventoryRecordCodec", func() {
+	It("round-trips a fully-populated record", func() {
+		revokedAt := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+		rec := CertRecord{
+			InventoryEntry: InventoryEntry{
+				Serial:    "0001",
+				NotBefore: "2024-01-01T00:00:00UTC",
+				NotAfter:  "2029-01-01T00:00:00UTC",
+				Subject:   "node1.example.com",
+			},
+			CertProjection: CertProjection{
+				Fingerprint:    "aa:bb:cc",
+				DNSAltNames:    []string{"node1", "node1.example.com"},
+				AuthExtensions: map[string]string{"pp_auth_role": "webserver"},
+			},
+			State:     CertStateRevoked,
+			RevokedAt: &revokedAt,
+		}
+		data, err := encodeInventoryRecord(rec)
+		Expect(err).NotTo(HaveOccurred(), "encodeInventoryRecord")
+		got, err := decodeInventoryRecord(data)
+		Expect(err).NotTo(HaveOccurred(), "decodeInventoryRecord")
+		Expect(got).To(Equal(rec))
+	})
+
+	It("normalises a missing state to signed on both encode and decode", func() {
+		rec := CertRecord{InventoryEntry: InventoryEntry{
+			Serial: "0001", NotBefore: "nb", NotAfter: "na", Subject: "node1",
+		}}
+		data, err := encodeInventoryRecord(rec)
+		Expect(err).NotTo(HaveOccurred())
+		got, err := decodeInventoryRecord(data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.State).To(Equal(CertStateSigned), "encoded state defaults to signed")
+
+		// A record written without a state field (e.g. by hand) decodes as
+		// signed too, mirroring the SQL row decoder.
+		got, err = decodeInventoryRecord([]byte(`{"serial":"0002","subject":"node2"}`))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.State).To(Equal(CertStateSigned))
+	})
+
+	It("rejects an undecodable record outright", func() {
+		_, err := decodeInventoryRecord([]byte("{not-json"))
+		Expect(err).To(HaveOccurred(), "corrupt records must fail loudly: the whole record is one JSON value, so there are no canonical columns to salvage")
+	})
+})
+
+var _ = Describe("EtcdInventoryEntryKeys", func() {
+	It("zero-pads sequence numbers so lexical order equals issuance order", func() {
+		b := &EtcdBackend{prefix: "/puppet-ca"}
+		Expect(b.entryPhys(1)).To(Equal("/puppet-ca/inventory/entries/00000000000000000001"))
+		Expect(b.entryPhys(9) < b.entryPhys(10)).To(BeTrue(), "9 must sort before 10")
+		Expect(b.entryPhys(99) < b.entryPhys(100)).To(BeTrue(), "99 must sort before 100")
+	})
+})
+
+var _ = Describe("ParseInventoryRecords", func() {
+	It("parses lines, skipping blanks, and preserves order", func() {
+		recs, err := parseInventoryRecords([]byte(
+			"0001 nb1 na1 /node1\n\n0002 nb2 na2 /node2\n"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(recs).To(HaveLen(2))
+		Expect(recs[0].Serial).To(Equal("0001"))
+		Expect(recs[1].Subject).To(Equal("node2"))
+		Expect(recs[0].State).To(Equal(CertStateSigned))
+	})
+
+	It("rejects malformed lines instead of dropping them", func() {
+		_, err := parseInventoryRecords([]byte("too few fields\n"))
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("flags duplicate serials via rejectDuplicateSerials", func() {
+		recs, err := parseInventoryRecords([]byte(
+			"0001 nb1 na1 /node1\n0001 nb2 na2 /node2\n"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rejectDuplicateSerials(recs)).To(MatchError(ErrDuplicateSerial))
+	})
+})

--- a/internal/storage/sql_inventory.go
+++ b/internal/storage/sql_inventory.go
@@ -272,10 +272,11 @@ func (b *SQLBackend) LatestSerialForSubject(ctx context.Context, subject string)
 // PruneEntries removes the rows for which keep returns false and rewrites the
 // integrity head over the survivors in a single transaction, so a concurrent
 // reader on another replica never observes the rows and the chained head out of
-// sync. Survivors keep their original ids (and thus issuance order); only the
-// dropped rows are deleted. The presence-marker row is locked first so this
-// serialises with AppendEntry across replicas, exactly as appends do.
-func (b *SQLBackend) PruneEntries(ctx context.Context, keep func(InventoryEntry) bool, recomputeHead func(survivors []InventoryEntry) []byte) ([]InventoryEntry, error) {
+// sync, and a returned error always means nothing was removed. Survivors keep
+// their original ids (and thus issuance order); only the dropped rows are
+// deleted. The presence-marker row is locked first so this serialises with
+// AppendEntry across replicas, exactly as appends do.
+func (b *SQLBackend) PruneEntries(ctx context.Context, keep func(InventoryEntry) bool, advanceHead func(prev []byte, e InventoryEntry) []byte) ([]InventoryEntry, error) {
 	b.appendMu.Lock()
 	defer b.appendMu.Unlock()
 
@@ -284,7 +285,7 @@ func (b *SQLBackend) PruneEntries(ctx context.Context, keep func(InventoryEntry)
 
 	const maxAttempts = 10
 	for attempt := 0; ; attempt++ {
-		removed, err := b.pruneEntriesOnce(ctx, keep, recomputeHead)
+		removed, err := b.pruneEntriesOnce(ctx, keep, advanceHead)
 		if err == nil {
 			return removed, nil
 		}
@@ -299,7 +300,7 @@ func (b *SQLBackend) PruneEntries(ctx context.Context, keep func(InventoryEntry)
 	}
 }
 
-func (b *SQLBackend) pruneEntriesOnce(ctx context.Context, keep func(InventoryEntry) bool, recomputeHead func(survivors []InventoryEntry) []byte) ([]InventoryEntry, error) {
+func (b *SQLBackend) pruneEntriesOnce(ctx context.Context, keep func(InventoryEntry) bool, advanceHead func(prev []byte, e InventoryEntry) []byte) ([]InventoryEntry, error) {
 	var removed []InventoryEntry
 	err := b.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
 		removed = nil // reset so a retried transaction does not double-count
@@ -336,10 +337,14 @@ func (b *SQLBackend) pruneEntriesOnce(ctx context.Context, keep func(InventoryEn
 			return err
 		}
 
-		if recomputeHead != nil {
+		if advanceHead != nil {
+			var head []byte
+			for _, e := range survivors {
+				head = advanceHead(head, e)
+			}
 			return b.upsert(ctx, tx, &sqlBlob{
 				Key:        KeyInventoryHMAC,
-				Data:       recomputeHead(survivors),
+				Data:       head,
 				Kind:       int(BlobPrivate),
 				ModifiedAt: time.Now(),
 			})

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -361,8 +361,11 @@ func (s *StorageService) inventoryEntriesLocked(ctx context.Context) ([]Inventor
 // rewriting the inventory and its integrity head together under the inventory
 // write lock. It returns the removed entries (in issuance order) so the caller
 // can act on them — drop their CRL revocations, invalidate caches, delete the
-// stored cert. When nothing is removed the inventory and head are left
-// untouched and (nil, nil) is returned.
+// stored cert. The returned slice is authoritative even when err is non-nil:
+// structured backends that prune in batches (etcd) may fail mid-way with some
+// entries already durably removed, and those are still returned so the caller
+// can finish cleaning up after them. When nothing is removed the inventory and
+// head are left untouched and (nil, nil) is returned.
 //
 // The current inventory integrity is verified before pruning, so a tampered
 // inventory surfaces ErrInventoryTampered rather than being silently rewritten.
@@ -383,22 +386,19 @@ func (s *StorageService) PruneInventory(ctx context.Context, keep func(Inventory
 		}
 	}
 
-	// Structured backends prune rows and rewrite the chained integrity head in a
-	// single transaction, so the two can never be observed out of sync across
-	// replicas (mirroring the atomic AppendEntry path).
+	// Structured backends prune rows and rewrite the chained integrity head
+	// so the two are never observed out of sync across replicas: SQL in a
+	// single transaction, etcd in batches whose every commit is internally
+	// consistent (see the PruneEntries contract in backend.go).
 	if store, ok := asInventoryStore(s.backend); ok {
-		var recomputeHead func(survivors []InventoryEntry) []byte
+		var advanceHead func(prev []byte, e InventoryEntry) []byte
 		if s.hmacKey != nil {
 			key := s.hmacKey
-			recomputeHead = func(survivors []InventoryEntry) []byte {
-				var head []byte
-				for _, e := range survivors {
-					head = chainInventoryMAC(key, head, canonicalInventoryLine(e))
-				}
-				return head
+			advanceHead = func(prev []byte, e InventoryEntry) []byte {
+				return chainInventoryMAC(key, prev, canonicalInventoryLine(e))
 			}
 		}
-		return store.PruneEntries(ctx, keep, recomputeHead)
+		return store.PruneEntries(ctx, keep, advanceHead)
 	}
 
 	// Blob backends: read, filter, and rewrite the whole inventory, then

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -172,16 +172,15 @@ func (s *StorageService) InitHMAC(ctx context.Context) error {
 
 // ErrDuplicateSerial is returned by AppendInventory when the entry's serial
 // number already exists in the inventory. SQL backends detect this via their
-// unique index (translated from the dialect-specific driver error); blob
-// backends via an explicit scan performed under the same inventoryMu that
-// already serialises every append within a process.
-//
-// This is NOT a cross-replica guarantee on non-SQL backends: nothing today
-// wraps the whole AppendInventory call in a distributed lock for
-// filesystem/etcd/redis backends (see the blob-fallback HMAC-update comment
-// below, which already documents a similar limitation for that path).
-// Structured (SQL) backends remain the only ones with a true cluster-wide
-// guarantee, via the database's own unique index.
+// unique index (translated from the dialect-specific driver error); the etcd
+// backend via a by-serial marker key whose absence is a condition of the
+// append transaction. Both are true cluster-wide guarantees. The remaining
+// blob backends (filesystem, redis) detect it via an explicit scan performed
+// under the same inventoryMu that already serialises every append within a
+// process — NOT a cross-replica guarantee: nothing wraps the whole
+// AppendInventory call in a distributed lock for them (see the blob-fallback
+// HMAC-update comment below, which documents a similar limitation for that
+// path).
 var ErrDuplicateSerial = errors.New("serial number already exists in inventory")
 
 // AppendInventory adds entry (a single inventory.txt line, without a trailing
@@ -220,7 +219,10 @@ func (s *StorageService) AppendInventoryRecord(ctx context.Context, entry string
 			newHead = func(prev []byte) []byte { return chainInventoryMAC(key, prev, entry) }
 		}
 		if err := store.AppendEntry(ctx, rec, newHead); err != nil {
-			if isUniqueSerialViolation(err) {
+			// The etcd backend already wraps ErrDuplicateSerial itself; SQL
+			// backends surface the dialect's unique-index violation instead
+			// and are translated here.
+			if !errors.Is(err, ErrDuplicateSerial) && isUniqueSerialViolation(err) {
 				return fmt.Errorf("%w: %s", ErrDuplicateSerial, parsed.Serial)
 			}
 			return err

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -362,20 +362,23 @@ func (s *StorageService) inventoryEntriesLocked(ctx context.Context) ([]Inventor
 // write lock. It returns the removed entries (in issuance order) so the caller
 // can act on them — drop their CRL revocations, invalidate caches, delete the
 // stored cert. The returned slice is authoritative even when err is non-nil:
-// structured backends that prune in batches (etcd) may fail mid-way with some
-// entries already durably removed, and those are still returned so the caller
-// can finish cleaning up after them. When nothing is removed the inventory and
-// head are left untouched and (nil, nil) is returned.
+// any path that has durably removed entries before failing still returns
+// them, so the caller can finish cleaning up after them. A backend may bound
+// how much one call removes (see the PruneEntries contract); deferred matches
+// stay in the inventory for later calls. When nothing is removed the
+// inventory and head are left untouched and (nil, nil) is returned.
 //
 // The current inventory integrity is verified before pruning, so a tampered
 // inventory surfaces ErrInventoryTampered rather than being silently rewritten.
 //
-// Concurrency: appends (AppendInventory) and reads (ReadInventory) take the same
-// inventoryMu, so within a process a prune never interleaves with them. The
-// rewrite is a single Backend.Put on KeyInventory, which structured backends
-// service as an atomic table replacement and blob backends as an atomic file
-// swap; callers needing cross-replica serialisation against revocation should
-// hold the cluster CRL lock around this (see ca.CA.CleanupExpiredCerts).
+// Concurrency: appends (AppendInventory) and reads (ReadInventory) take the
+// same inventoryMu, so within a process a prune never interleaves with them.
+// Structured backends prune through PruneEntries (see the contract in
+// backend.go: SQL in one transaction, etcd in individually-consistent
+// batches); the blob fallback below rewrites the whole inventory with a
+// single Backend.Put, which blob backends service as an atomic file swap.
+// Callers needing cross-replica serialisation against revocation should hold
+// the cluster CRL lock around this (see ca.CA.CleanupExpiredCerts).
 func (s *StorageService) PruneInventory(ctx context.Context, keep func(InventoryEntry) bool) ([]InventoryEntry, error) {
 	s.inventoryMu.Lock()
 	defer s.inventoryMu.Unlock()
@@ -434,10 +437,13 @@ func (s *StorageService) PruneInventory(ctx context.Context, keep func(Inventory
 
 	if s.hmacKey != nil {
 		if err := s.updateInventoryHMACLocked(ctx, s.hmacKey); err != nil {
-			// The inventory is already rewritten but the stored head now lags it;
-			// surface the failure so the operator/job can react rather than leave
-			// a mismatch that the next verify would flag as tampering.
-			return nil, fmt.Errorf("updating inventory HMAC after prune: %w", err)
+			// The inventory is already rewritten but the stored head now lags
+			// it; surface the failure so the operator/job can react rather
+			// than leave a mismatch the next verify would flag as tampering.
+			// The entries are durably removed, so return them alongside the
+			// error per this method's contract — the caller's CRL/blob
+			// cleanup must still run for them.
+			return removed, fmt.Errorf("updating inventory HMAC after prune: %w", err)
 		}
 	}
 	return removed, nil


### PR DESCRIPTION
Implements #138: the etcd backend stores the certificate inventory as one key per issued certificate instead of the single append-only `inventory/data` blob, implementing `InventoryStore` and — since #137 settled the `CertRecord` field set — `CertIndex` as well.

**Stacked on #151** (`feature/cert-index`): only the commits from "Decompose the etcd inventory into per-entry keys" onwards belong to this PR; the diff will collapse once #151 merges.

## Why

The blob append was read-everything, concatenate, write-everything: O(size of the inventory) per signing, O(n²) to issue n certificates, plus a whole-blob HMAC recompute per append. At fleet scale every signing rewrote megabytes. Decomposition also closes the duplicate-serial gap: blob backends had no cross-replica uniqueness guarantee — that was previously exclusive to SQL.

## Design

Zero-padded `inventory/entries/<seq>` keys hold JSON records in issuance order; `inventory/by-serial/<serial>` existence is the atomic duplicate-serial guard; `inventory/by-subject/<subject>` gives O(1) latest-serial lookups; `inventory/seq` is both sequence allocator and the fence every mutation guards on and re-puts. etcd transactions are compare-then-op, so the chained integrity head is computed in Go between a read and a fence-guarded commit — the same optimistic ModRevision-retry shape the blob append already used, now with O(1) appends.

- **Bulk rewrites are batched** under etcd's default `--max-txn-ops`. Every prune batch commits a head covering exactly the entries that remain, so no observer ever sees entries and head out of sync, and a crash mid-prune leaves a valid partially-pruned inventory. One cleanup pass removes at most 900 entries so a large backlog drains over scheduled runs instead of blowing the CRL lock budget; `PruneEntries` returns every entry actually removed — accumulated across batches and retries, even alongside an error — and `CleanupExpiredCerts` finishes the CRL/blob cleanup for them on a context that survives the prune's deadline.
- **In-place upgrade.** `EnsureReady` converts a pre-decomposition blob under a distributed lock: the blob is verified against its stored whole-blob HMAC first (unverifiable or mismatching states fail startup, as the old code would have), stays authoritative until the final commit so an interrupted conversion resumes, and mixed-version writes are detected and refused. A CA upgraded while its inventory is empty has its verified whole-blob head removed so the first verification re-baselines cleanly.
- **Certificate index.** `GET /certificate_statuses` is answered from the decomposed entries with the same rebuildable-projection semantics as SQL. Serials duplicated in a legacy blob (possible pre-conversion) cannot be addressed by the one-to-one by-serial index: index writes for them are refused rather than aliased onto the wrong bearer, `Statuses` reports them with a new `CertStateUnknown`, and the handler derives their real state from the signed CRL.
- The `KeyInventory` logical key stays served through a render/parse shim, so `Migrate` and the OCSP index build are untouched; filesystem ⇄ etcd migrations work in both directions with the head rebuilt by `MigrateService`.

The interface change to note: `InventoryStore.PruneEntries` now takes a step function (`advanceHead`) instead of a whole-fold callback, and its contract documents partial completion, the authoritative-even-on-error return, and per-call bounding. The SQL implementation is updated to match; its behaviour is unchanged.

## Review

The branch went through three rounds of automated multi-persona review, finishing with a unanimous APPROVE and zero retracted findings across 49 raised; every CRITICAL/HIGH/MEDIUM was fixed in code (interruption safety, partial-prune accounting, fail-closed legacy verification, ambiguous-serial state resolution) rather than documented away. The etcd integration suite grew from 6 to ~30 specs, including chain tamper negative controls, multi-batch prune consistency observed between commits, conversion resume/refusal states, and both ends of the partial-prune contract.

No new dependencies and no new cryptography: `go.etcd.io/etcd/api/v3` moves from indirect to direct at the version already in the module graph, and the hash chain uses the existing `crypto/hmac`/SHA-256 helpers.

Closes #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)