### PR TITLE
Record the current authorisation outcomes as an oracle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,10 +131,11 @@ Conventions:
   `baseline:` line, which is what makes one in a diff worth stopping on.
 
   Two cases the above does not cover. A *new* row needs **both** digests, not
-  just one: write `baseline: ""` and run the suite, which prints a paste-ready
-  `fingerprint`/`baseline` pair. Leave `changedBy` empty — a new row has not
-  moved, and attributing it from birth permanently retires its baseline check.
-  "Do not edit `baseline`" applies from its second commit onwards.
+  just one: add its name to `expectedRoutes`, write `baseline: ""`, and run the
+  suite, which prints a paste-ready `fingerprint`/`baseline` pair. Leave
+  `changedBy` empty — a new row has not moved, and attributing it from birth
+  permanently retires its baseline check. "Do not edit `baseline`" applies from
+  its second commit onwards.
 
   Adding or removing a *client class* re-digests every row, so that commit sets
   `changedBy` on all of them naming the class, even though no authorisation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,13 @@ Conventions:
   conditions; sleeps make the suite flaky on loaded CI runners.
 - Keep negative and edge cases first-class: every security-relevant branch
   (rejection paths, tamper detection, auth denial) needs an explicit `It`.
+- `internal/api/authbaseline_test.go` is the recorded authorisation baseline:
+  every client class against every covered route, as the middleware behaves
+  today. A change that deliberately alters who may reach an endpoint updates the
+  affected row, sets `changedBy`, and refreshes that row's `fingerprint`, all in
+  the same commit — the suite fails otherwise, which is the point. Update
+  `docs/api.md#authorization-tiers` in step, since it publishes the same matrix
+  to operators.
 
 ### Integration suites (build-tagged)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,9 @@ Conventions:
   `changedBy` on all of them naming the class, even though no authorisation
   behaviour changed. Note what that costs: an attributed row's `baseline` is
   never compared again, so a class change retires the baseline layer repo-wide.
+  Such a commit also updates `expectedClientClasses`, gives the class a property
+  function in the fixture-property spec, and records its outcome on every row —
+  the suite enforces all three, but only after the digests stop it first.
 
   The suite cannot judge whether an attribution is *accurate*, nor whether a
   fixture still means what its class name says; reviewers should.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,13 +123,24 @@ Conventions:
   every client class against every covered route, as the middleware behaves
   today. A change that deliberately alters who may reach an endpoint updates the
   affected row, records the responsible change in `changedBy`, and refreshes
-  that row's `fingerprint` — all in the same commit. Leaving `changedBy` empty
-  fails permanently, because each row also carries a `baseline` digest of its
-  originally committed outcomes that is never updated. Do not edit `baseline`.
-  The suite cannot judge whether the attribution is *accurate*; reviewers
-  should.
-  Update `docs/api.md#authorization-tiers` in step, since it publishes the same
-  matrix to operators.
+  that row's `fingerprint` — all in the same commit, in that order (the suite
+  withholds the digest you need while `changedBy` is empty).
+
+  Each row also carries a `baseline` digest of its originally committed
+  outcomes. Do not edit it: no legitimate change to an existing row touches a
+  `baseline:` line, which is what makes one in a diff worth stopping on.
+
+  Two cases the above does not cover. A *new* row needs a `baseline` of its own
+  first outcomes, written once with `changedBy` left empty — "do not edit
+  `baseline`" applies from its second commit onwards. Adding or removing a
+  *client class* re-digests every row, so that commit sets `changedBy` on all of
+  them naming the class, even though no authorisation behaviour changed.
+
+  The suite cannot judge whether an attribution is *accurate*, nor whether a
+  fixture still means what its class name says; reviewers should.
+  `docs/api.md#authorization-tiers` publishes the tier assignment to operators,
+  so update it when a change moves a route between tiers — it is a tier table,
+  not this matrix, and most cells here have no counterpart there.
 
 ### Integration suites (build-tagged)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,10 +122,14 @@ Conventions:
 - `internal/api/authbaseline_test.go` is the recorded authorisation baseline:
   every client class against every covered route, as the middleware behaves
   today. A change that deliberately alters who may reach an endpoint updates the
-  affected row, sets `changedBy`, and refreshes that row's `fingerprint`, all in
-  the same commit — the suite fails otherwise, which is the point. Update
-  `docs/api.md#authorization-tiers` in step, since it publishes the same matrix
-  to operators.
+  affected row, records the responsible change in `changedBy`, and refreshes
+  that row's `fingerprint` — all in the same commit. Leaving `changedBy` empty
+  fails permanently, because each row also carries a `baseline` digest of its
+  originally committed outcomes that is never updated. Do not edit `baseline`.
+  The suite cannot judge whether the attribution is *accurate*; reviewers
+  should.
+  Update `docs/api.md#authorization-tiers` in step, since it publishes the same
+  matrix to operators.
 
 ### Integration suites (build-tagged)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,11 +130,16 @@ Conventions:
   outcomes. Do not edit it: no legitimate change to an existing row touches a
   `baseline:` line, which is what makes one in a diff worth stopping on.
 
-  Two cases the above does not cover. A *new* row needs a `baseline` of its own
-  first outcomes, written once with `changedBy` left empty — "do not edit
-  `baseline`" applies from its second commit onwards. Adding or removing a
-  *client class* re-digests every row, so that commit sets `changedBy` on all of
-  them naming the class, even though no authorisation behaviour changed.
+  Two cases the above does not cover. A *new* row needs **both** digests, not
+  just one: write `baseline: ""` and run the suite, which prints a paste-ready
+  `fingerprint`/`baseline` pair. Leave `changedBy` empty — a new row has not
+  moved, and attributing it from birth permanently retires its baseline check.
+  "Do not edit `baseline`" applies from its second commit onwards.
+
+  Adding or removing a *client class* re-digests every row, so that commit sets
+  `changedBy` on all of them naming the class, even though no authorisation
+  behaviour changed. Note what that costs: an attributed row's `baseline` is
+  never compared again, so a class change retires the baseline layer repo-wide.
 
   The suite cannot judge whether an attribution is *accurate*, nor whether a
   fixture still means what its class name says; reviewers should.

--- a/docs/api.md
+++ b/docs/api.md
@@ -179,7 +179,15 @@ When mTLS is enabled (both `--tls-cert` and `--tls-key` set), each endpoint requ
 | **Self or admin** | Cert CN matches path subject, OR cert is admin | `GET /certificate_request/{subject}` |
 | **Admin** | Cert is admin (see below) | `PUT /certificate_status/{subject}`, `DELETE /certificate_status/{subject}`, `DELETE /certificate_request/{subject}`, `GET /certificate_statuses/*`, `POST /sign`, `POST /sign/all`, `POST /generate/{subject}`, `PUT /clean`, `PUT /certificate_revocation_list/ca`, `PUT /certificate/{subject}` |
 
-In plain HTTP mode (no TLS), all endpoints are accessible without authentication.
+Above the public tier, a presented certificate must also be **currently valid and
+not revoked**: an expired certificate, or one listed in the CRL, is refused at
+every tier — including `POST /certificate_renewal`, so revoking an agent's
+certificate immediately cuts off its access to the CA API rather than only
+preventing the next renewal.
+
+In plain HTTP mode (no TLS), all endpoints are accessible without authentication:
+the authorisation middleware is only installed when `tls_cert` and `tls_key` are
+both set.
 
 > **Note:** `GET /certificate_status/{subject}` requires a CA-signed client certificate by default. Use `--allow-public-status` to make it public for environments where bootstrapping agents need to poll status before obtaining a client certificate. The response exposes state, fingerprint, serial number, and authorization extensions.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -198,20 +198,31 @@ path), so the difference between the two verbs is only *when* the stored
 certificate goes away:
 
 - `PUT /certificate_status/{subject}` with `{"desired_state":"revoked"}` adds
-  the serial to the CRL and leaves the certificate in storage until the next
-  CSR for that subject displaces it.
-- `DELETE /certificate_status/{subject}` revokes *and* deletes it immediately.
+  the serial to the CRL and leaves the certificate in storage until a later CSR
+  displaces it. Eviction reads the same per-process CRL cache as the admission
+  check described below, so on the HA backends a peer that has not yet seen the
+  revocation instead answers `200 OK` and silently discards the CSR.
+- `DELETE /certificate_status/{subject}` revokes *and* deletes it immediately,
+  on shared storage, so it does not depend on any replica's cache.
 
-Either way the next CSR is accepted: with autosign enabled it is signed at once
+Otherwise the next CSR is accepted: with autosign enabled it is signed at once
 and the agent is back with a fresh, unrevoked certificate; with autosign off it
 queues for manual signing. The CRL entry for the old serial persists in both
 cases, so the old certificate stays refused — but that is not the same as
 locking the *agent* out.
 
-When containing a compromised agent, the levers that actually hold are:
-disabling autosign, or using an autosign policy that excludes the subject;
-blocking the agent at the network layer; and forcing a CRL re-sign on every
-replica so no peer keeps admitting the old certificate from a stale cache.
+When containing a compromised agent, apply the levers that hold, in this order:
+
+1. Close off issuance: disable autosign, or use an autosign policy that
+   excludes the subject, and block the agent at the network layer.
+2. Revoke the certificate.
+3. Force a CRL re-sign on every replica, so no peer keeps admitting the old
+   certificate from a stale cache.
+
+The order matters. Step 3 is also what makes a stale replica willing to evict
+the revoked certificate and issue a replacement, so running it while autosign
+is still open hands whoever holds the compromised key a fresh, valid
+certificate.
 
 > **Revocation is not enforced cluster-wide straight away.** The check reads an
 > in-memory copy of the CRL that each process loads at startup and thereafter

--- a/docs/api.md
+++ b/docs/api.md
@@ -182,8 +182,18 @@ When mTLS is enabled (both `--tls-cert` and `--tls-key` set), each endpoint requ
 Above the public tier, a presented certificate must also be **currently valid and
 not revoked**: an expired certificate, or one listed in the CRL, is refused at
 every tier — including `POST /certificate_renewal`, so revoking an agent's
-certificate immediately cuts off its access to the CA API rather than only
-preventing the next renewal.
+certificate cuts off its access to the CA API, not merely its next renewal.
+
+> **Revocation is not enforced cluster-wide straight away.** The check reads an
+> in-memory copy of the CRL that each process loads at startup and thereafter
+> refreshes only when *that* process re-signs the CRL — on revocation, reissue,
+> or the periodic refresh once the CRL is near expiry. On the HA backends, a
+> revocation performed against one replica reaches shared storage immediately,
+> and `GET /certificate_revocation_list/ca` serves it from there, but a peer
+> replica keeps admitting the revoked certificate until it re-signs or restarts.
+> With default settings that can be weeks. Restart the fleet, or force a
+> re-sign on each replica, when locking out a compromised agent promptly
+> matters.
 
 In plain HTTP mode (no TLS), all endpoints are accessible without authentication:
 the authorisation middleware is only installed when `tls_cert` and `tls_key` are

--- a/docs/api.md
+++ b/docs/api.md
@@ -191,9 +191,11 @@ certificate cuts off its access to the CA API, not merely its next renewal.
 > revocation performed against one replica reaches shared storage immediately,
 > and `GET /certificate_revocation_list/ca` serves it from there, but a peer
 > replica keeps admitting the revoked certificate until it re-signs or restarts.
-> With default settings that can be weeks. Restart the fleet, or force a
-> re-sign on each replica, when locking out a compromised agent promptly
-> matters.
+> The periodic refresh does not bound this: it re-signs on only whichever
+> replica wins the shared CRL lock, and the peers then observe a fresh CRL and
+> do nothing, so a peer can stay stale well past the refresh interval. Restart
+> the fleet, or force a re-sign on each replica, when locking out a compromised
+> agent promptly matters.
 
 In plain HTTP mode (no TLS), all endpoints are accessible without authentication:
 the authorisation middleware is only installed when `tls_cert` and `tls_key` are

--- a/docs/api.md
+++ b/docs/api.md
@@ -189,18 +189,29 @@ endpoint, not merely its next renewal.
 The public tier is unaffected, because it examines no client certificate at
 all. A revoked agent can still fetch the CA certificate and the CRL, read
 `/expirations`, query OCSP, and submit a CSR to
-`PUT /certificate_request/{subject}`. Whether that lets it back in depends on
-which revocation you used:
+`PUT /certificate_request/{subject}`.
 
-- `PUT /certificate_status/{subject}` with `{"desired_state":"revoked"}` revokes
-  but leaves the certificate in storage, so a fresh CSR for the same subject is
-  refused and the agent cannot re-enrol under that name.
-- `DELETE /certificate_status/{subject}` revokes *and* deletes, freeing the
-  subject name. With autosign enabled, the agent can immediately submit a new
-  CSR and be issued a fresh, unrevoked certificate.
+**Neither form of revocation prevents re-enrolment under the same subject.**
+Submitting a CSR evicts a revoked certificate for that subject (see
+[Certificate import](#certificate-import) for the same rule on the import
+path), so the difference between the two verbs is only *when* the stored
+certificate goes away:
 
-When containing a compromised agent, prefer revoke-without-clean, or disable
-autosign for that subject before cleaning, and block it at the network layer.
+- `PUT /certificate_status/{subject}` with `{"desired_state":"revoked"}` adds
+  the serial to the CRL and leaves the certificate in storage until the next
+  CSR for that subject displaces it.
+- `DELETE /certificate_status/{subject}` revokes *and* deletes it immediately.
+
+Either way the next CSR is accepted: with autosign enabled it is signed at once
+and the agent is back with a fresh, unrevoked certificate; with autosign off it
+queues for manual signing. The CRL entry for the old serial persists in both
+cases, so the old certificate stays refused — but that is not the same as
+locking the *agent* out.
+
+When containing a compromised agent, the levers that actually hold are:
+disabling autosign, or using an autosign policy that excludes the subject;
+blocking the agent at the network layer; and forcing a CRL re-sign on every
+replica so no peer keeps admitting the old certificate from a stale cache.
 
 > **Revocation is not enforced cluster-wide straight away.** The check reads an
 > in-memory copy of the CRL that each process loads at startup and thereafter
@@ -216,8 +227,8 @@ autosign for that subject before cleaning, and block it at the network layer.
 > agent promptly matters.
 
 In plain HTTP mode (no TLS), all endpoints are accessible without authentication:
-the authorisation middleware is only installed when `tls_cert` and `tls_key` are
-both set.
+the authorisation middleware is only installed when `--tls-cert`/`--tls-key`
+(`tls_cert`/`tls_key` in the config file) are both set.
 
 > **Note:** `GET /certificate_status/{subject}` requires a CA-signed client certificate by default. Use `--allow-public-status` to make it public for environments where bootstrapping agents need to poll status before obtaining a client certificate. The response exposes state, fingerprint, serial number, and authorization extensions.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -175,14 +175,32 @@ When mTLS is enabled (both `--tls-cert` and `--tls-key` set), each endpoint requ
 | Tier | Required client cert | Endpoints |
 | --- | --- | --- |
 | **Public** | None | `GET /healthz/*`, `GET /certificate/{subject}`, `GET /certificate_revocation_list/ca`, `PUT /certificate_request/{subject}`, `GET /expirations`, `POST /ocsp`, `GET /ocsp/{request}` |
-| **Any client** | Any CA-signed cert | `GET /certificate_status/{subject}` (public with `--allow-public-status`), `POST /certificate_renewal` |
+| **Any client** | Any CA-signed cert with `clientAuth` EKU | `GET /certificate_status/{subject}` (public with `--allow-public-status`), `POST /certificate_renewal` |
 | **Self or admin** | Cert CN matches path subject, OR cert is admin | `GET /certificate_request/{subject}` |
 | **Admin** | Cert is admin (see below) | `PUT /certificate_status/{subject}`, `DELETE /certificate_status/{subject}`, `DELETE /certificate_request/{subject}`, `GET /certificate_statuses/*`, `POST /sign`, `POST /sign/all`, `POST /generate/{subject}`, `PUT /clean`, `PUT /certificate_revocation_list/ca`, `PUT /certificate/{subject}` |
 
-Above the public tier, a presented certificate must also be **currently valid and
-not revoked**: an expired certificate, or one listed in the CRL, is refused at
-every tier — including `POST /certificate_renewal`, so revoking an agent's
-certificate cuts off its access to the CA API, not merely its next renewal.
+Above the public tier, a presented certificate must also be **currently valid,
+not revoked, and carry the `clientAuth` extended key usage**: an expired
+certificate, one listed in the CRL, or one issued for `serverAuth` only is
+refused at every tier above public — including `POST /certificate_renewal`, so
+revoking an agent's certificate cuts off its access to every *authenticated*
+endpoint, not merely its next renewal.
+
+The public tier is unaffected, because it examines no client certificate at
+all. A revoked agent can still fetch the CA certificate and the CRL, read
+`/expirations`, query OCSP, and submit a CSR to
+`PUT /certificate_request/{subject}`. Whether that lets it back in depends on
+which revocation you used:
+
+- `PUT /certificate_status/{subject}` with `{"desired_state":"revoked"}` revokes
+  but leaves the certificate in storage, so a fresh CSR for the same subject is
+  refused and the agent cannot re-enrol under that name.
+- `DELETE /certificate_status/{subject}` revokes *and* deletes, freeing the
+  subject name. With autosign enabled, the agent can immediately submit a new
+  CSR and be issued a fresh, unrevoked certificate.
+
+When containing a compromised agent, prefer revoke-without-clean, or disable
+autosign for that subject before cleaning, and block it at the network layer.
 
 > **Revocation is not enforced cluster-wide straight away.** The check reads an
 > in-memory copy of the CRL that each process loads at startup and thereafter

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -952,6 +952,12 @@ var _ = Describe("Auth Middleware", func() {
 // /puppet-ca/v1 prefix stripping and the default-deny tierAdminOnly fallthrough
 // for unrecognised paths. A case classifying LESS restrictively than expected
 // would surface here as a probe mismatch.
+// This is the sibling of the oracle in authbaseline_test.go, and the two are
+// deliberately different instruments. This one infers the *tier* each route
+// sits in by probing three certificates and reading the shape of the answers;
+// that one records the observable HTTP outcome for eight named client classes
+// and asserts each cell. A tier change should move a row in both, and a change
+// that moves only one is worth understanding before it is accepted.
 var _ = Describe("lookupTier classification", func() {
 	var (
 		tmpDir         string

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -956,9 +956,9 @@ var _ = Describe("Auth Middleware", func() {
 // deliberately different instruments. This one infers the *tier* each route
 // sits in by probing three certificates and reading the shape of the answers;
 // that one records the observable HTTP outcome for every client class in its
-// expectedClientClasses list
-// and asserts each cell. A tier change should move a row in both, and a change
-// that moves only one is worth understanding before it is accepted.
+// expectedClientClasses list and asserts each cell. For the routes both cover,
+// a tier change should move a row in both, and a change that moves only one is
+// worth understanding before it is accepted.
 var _ = Describe("lookupTier classification", func() {
 	var (
 		tmpDir         string

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -955,7 +955,8 @@ var _ = Describe("Auth Middleware", func() {
 // This is the sibling of the oracle in authbaseline_test.go, and the two are
 // deliberately different instruments. This one infers the *tier* each route
 // sits in by probing three certificates and reading the shape of the answers;
-// that one records the observable HTTP outcome for eight named client classes
+// that one records the observable HTTP outcome for every client class in its
+// expectedClientClasses list
 // and asserts each cell. A tier change should move a row in both, and a change
 // that moves only one is worth understanding before it is accepted.
 var _ = Describe("lookupTier classification", func() {

--- a/internal/api/authbaseline_test.go
+++ b/internal/api/authbaseline_test.go
@@ -23,14 +23,18 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
+	"encoding/hex"
 	"encoding/pem"
 	"fmt"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strings"
 	"time"
 
@@ -67,17 +71,31 @@ import (
 //
 // Scope, stated plainly so nobody mistakes this for total coverage:
 //
-//   - 10 of the 19 routes registered by Routes(). The omitted ones are OCSP and
-//     the health probes (public and uninteresting here), and duplicates of a
-//     tier already represented by another row.
+//   - 11 rows over 10 of the 19 protocol routes registered by Routes().
+//     GET /certificate_request/{subject} gets two rows because the self-match is
+//     the only signal separating tierSelfOrAdmin from tierAdminOnly. The three
+//     /healthz/ probes are registered separately and are not among the 19. The
+//     omitted protocol routes are the two OCSP entries and duplicates of a tier
+//     already represented by another row.
 //   - Both the bare and the /puppet-ca/v1-prefixed forms of each path, which
 //     the mux registers separately — see the prefix spec below.
-//   - The default AuthConfig, plus the two flags that move a tier
+//   - Only denials emitted by the *middleware*. A handler that refuses with its
+//     own 403 is recorded as "got past authorisation", because that is what it
+//     is. Of the three changes named above, that makes certificate_status
+//     unconditionally observable here; renewal gating only if it lands in the
+//     middleware rather than in handlePostCertificateRenewal, where the route's
+//     existing refusals live; and issuer-scoping not at all through the
+//     foreign-CA row, since this fixture's CA stays unconfigured as a second
+//     trust anchor (see foreignClientCert). Anything landing in a handler needs
+//     its own anchor in that handler's tests.
+//   - The default AuthConfig, an absent one, plus the two flags that move a tier
 //     (AllowPublicStatus, NoPpCliAuth), covered in their own Describe rather
 //     than by multiplying every row.
 //
-// A second, overlapping oracle lives in auth_test.go ("authorisation matrix"),
-// which drives lookupTier directly rather than through the mux. That one pins
+// A second, overlapping oracle lives in auth_test.go ("lookupTier classification"),
+// which drives lookupTier directly rather than through the mux. The same matrix
+// is published for operators at docs/api.md#authorization-tiers; a row that
+// moves here moves there too. That one pins
 // tier assignment; this one pins the observable HTTP outcome. Keep them in
 // step: a tier change should move a row in both.
 
@@ -95,33 +113,76 @@ type routeCase struct {
 	path   string
 	// denied maps clientClass.name to whether the middleware rejects it.
 	denied map[string]bool
+	// fingerprint is a digest of the denied map as first recorded. It is what
+	// makes changedBy enforceable rather than advisory: editing a cell changes
+	// the digest, and the spec then requires changedBy to be set in the same
+	// commit. Without it nothing distinguished a deliberate change from a
+	// silent one, because no copy of the original values was retained
+	// anywhere — the header claimed that distinction was "the whole point"
+	// while nothing implemented it.
+	fingerprint string
 	// changedBy names the change that last altered this row's outcomes, empty
-	// for rows still at their original recorded values. Always asserted either
-	// way; this only says why a value differs from the first recording.
+	// for rows still at their originally recorded values.
 	changedBy string
 }
 
-// middlewareDenied reports whether the response is the *middleware's* rejection.
+// handler403Bodies are the 403s the *handlers* emit, as opposed to the
+// middleware. The set is exactly three:
 //
-// Status alone is not enough. Handlers on these routes return 403 of their own —
-// handlePostCertificateRenewal does so twice (handlers.go:903, :955), and
-// handleGetCert once — so a bare code check would record a handler outcome as an
-// authorisation outcome and the table would drift without failing. The
-// middleware's two messages are matched exactly instead. Note "client
-// certificate required" is a strict prefix of the renewal handler's "client
-// certificate required for renewal", so this must not become a prefix match.
+//   - handlePostCertificateRenewal, twice (handlers.go, "client certificate
+//     required for renewal" and "CSR CN does not match authenticated client CN")
+//   - handlePostGenerate, once ("private key delivery requires TLS"), on
+//     POST /generate/{subject}, which this table does not cover
+//
+// Note "client certificate required" is a strict prefix of the renewal
+// handler's "client certificate required for renewal", so these must be
+// compared for equality and never by prefix.
+var handler403Bodies = map[string]bool{
+	"client certificate required for renewal":       true,
+	"CSR CN does not match authenticated client CN": true,
+	"private key delivery requires TLS":             true,
+}
+
+// denialKind classifies a response as an authorisation denial, an admission, or
+// something this file does not recognise.
+type denialKind int
+
+const (
+	admitted denialKind = iota
+	deniedByMiddleware
+	unrecognised403
+)
+
+// classify reports whether the response is the *middleware's* rejection.
+//
+// Status alone is not enough: the handlers emit 403s of their own, so a bare
+// code check would record a handler outcome as an authorisation outcome. But the
+// inverse — recognising only the middleware messages we know today — is worse,
+// and was the original shape of this function. Every change this table exists to
+// precede is a *narrowing*, which adds denials; a narrowing that rejects with a
+// new message would have fallen into "not one of our two strings" and been
+// recorded as admitted, leaving every row unmoved and the oracle silent on
+// exactly the change it was committed ahead of.
+//
+// So the test is inverted. Any 403 is the middleware's unless its body is one of
+// the enumerated handler messages, and a 403 body in neither set is
+// unrecognised — which callers must fail on rather than quietly bucket. That way
+// introducing a new denial reason forces a deliberate edit here.
 //
 // Every other outcome (404 for an absent subject, 400 for a malformed body)
 // means the request got past authorisation, which is what this table measures.
-func middlewareDenied(rec *httptest.ResponseRecorder) bool {
+func classify(rec *httptest.ResponseRecorder) denialKind {
 	if rec.Code != http.StatusForbidden {
-		return false
+		return admitted
 	}
-	switch strings.TrimSpace(rec.Body.String()) {
-	case "client certificate required", "access denied":
-		return true
+	body := strings.TrimSpace(rec.Body.String())
+	switch {
+	case body == "client certificate required", body == "access denied":
+		return deniedByMiddleware
+	case handler403Bodies[body]:
+		return admitted
 	default:
-		return false
+		return unrecognised403
 	}
 }
 
@@ -143,10 +204,10 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 
 		store = storage.New(tmpDir)
 		myCA = ca.New(store, ca.AutosignConfig{Mode: "off"}, "puppet.test")
-		// The revoked fixture is issued through the CA, so leaf generation is on
-		// the fixture path. Nothing here depends on the leaf algorithm and ECDSA
-		// is an order of magnitude cheaper to generate than RSA.
-		myCA.LeafKeyConfig = ca.KeyConfig{Algo: ca.KeyAlgoECDSA, Size: 256}
+		// No LeafKeyConfig here: this block mints its certificates directly with
+		// issueClientCert and never issues through the CA, so the setting had no
+		// consumer and its rationale described a fixture path this Describe does
+		// not have.
 		Expect(store.EnsureDirs(ctx)).To(Succeed())
 		Expect(store.SaveCAKey(ctx, cachedKeyPEM)).To(Succeed())
 		Expect(store.SaveCACert(ctx, cachedCrtPEM)).To(Succeed())
@@ -182,8 +243,10 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 		// The *keys*, though, are generated once and reused. What must be fresh
 		// is the certificate — its serial is what the CRL names — and RSA key
 		// generation is the whole cost of minting one. Re-minting per route with
-		// cached keys keeps the independence and takes the matrix from ~130 key
-		// generations to eight.
+		// cached keys keeps the independence and takes the matrix from ~250
+		// RSA-2048 generations to four. The revoked, CA-issued and foreign
+		// fixtures still generate a P-256 key each per call, which is cheap
+		// enough not to be worth pooling.
 		keyPool := newRSAKeyPool(4)
 
 		newClasses = func() []clientClass {
@@ -198,7 +261,29 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				// makes the two grants exclusive rather than additive.
 				{name: "own-ca-admin-both", cert: clientCertFromKey(keyPool[3], "puppet-server", caCert, caKey, true, false)},
 				{name: "own-ca-expired", cert: clientCertFromKey(keyPool[0], "stale", caCert, caKey, false, true)},
+				// Chain-valid *and* recorded in the CA's inventory, unlike every
+				// other admitted class here — those are minted by signing a
+				// template directly, with serials the CA has never seen. Today
+				// nothing distinguishes them: AutoRenew reissues purely from the
+				// presented certificate. A gate on "certificates this CA issued"
+				// must consult something recorded at issuance, so without this
+				// class the renewal row could only record "renewal now denies
+				// every ordinary agent" — a fiction, since a genuinely-issued
+				// agent would still be admitted.
+				{name: "own-ca-issued", cert: caIssuedClientCert(ctx, myCA)},
 				{name: "own-ca-revoked", cert: revokedClientCert(ctx, myCA)},
+				// Chain-valid but carrying only serverAuth EKU. The middleware
+				// requires ExtKeyUsageClientAuth in its Verify call, and no
+				// other class distinguishes that: every one of them carries
+				// clientAuth, so relaxing the requirement to ExtKeyUsageAny
+				// would move no cell. That predicate sits inside the block the
+				// multi-trust-anchor work has to rewrite.
+				{name: "own-ca-server-eku", cert: serverEKUClientCert(keyPool[1], "server-only", caCert, caKey)},
+				// pp_cli_auth present but not "true". isAdmin compares the
+				// extension value for equality; reducing it to a presence test
+				// would grant admin to this certificate and, again, move no
+				// existing cell.
+				{name: "own-ca-pp-cli-auth-false", cert: ppCliAuthValueCert(keyPool[2], "cli-false", caCert, caKey, "false")},
 				{name: "foreign-ca", cert: foreignClientCert(selfName)},
 			}
 		}
@@ -211,25 +296,47 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 			name: "public: fetch the CA certificate", method: "GET", path: "/certificate/ca",
 			denied: map[string]bool{
 				"none": false, "own-ca-plain": false, "own-ca-allowlisted": false,
-				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-expired": false,
-				"own-ca-revoked": false, "foreign-ca": false,
+				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-issued": false,
+				"own-ca-expired": false, "own-ca-revoked": false, "own-ca-server-eku": false,
+				"own-ca-pp-cli-auth-false": false, "foreign-ca": false,
 			},
+			fingerprint: "20efd5d41098722c",
 		},
 		{
 			name: "public: fetch the CRL", method: "GET", path: "/certificate_revocation_list/ca",
 			denied: map[string]bool{
 				"none": false, "own-ca-plain": false, "own-ca-allowlisted": false,
-				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-expired": false,
-				"own-ca-revoked": false, "foreign-ca": false,
+				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-issued": false,
+				"own-ca-expired": false, "own-ca-revoked": false, "own-ca-server-eku": false,
+				"own-ca-pp-cli-auth-false": false, "foreign-ca": false,
 			},
+			fingerprint: "20efd5d41098722c",
 		},
 		{
 			name: "public: submit a CSR", method: "PUT", path: "/certificate_request/newnode",
 			denied: map[string]bool{
 				"none": false, "own-ca-plain": false, "own-ca-allowlisted": false,
-				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-expired": false,
-				"own-ca-revoked": false, "foreign-ca": false,
+				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-issued": false,
+				"own-ca-expired": false, "own-ca-revoked": false, "own-ca-server-eku": false,
+				"own-ca-pp-cli-auth-false": false, "foreign-ca": false,
 			},
+			fingerprint: "20efd5d41098722c",
+		},
+		{
+			// Its own branch in the classifier, and the only genuinely
+			// uncovered route among those omitted. It returns certificate
+			// expiry metadata to any caller with no client certificate, and it
+			// is the obvious sibling question when certificate_status narrows
+			// to admin-only — so a change that tightens, loosens or reorders
+			// this case relative to the one above it should move a cell here.
+			name: "public: read expiry metadata", method: "GET", path: "/expirations",
+			denied: map[string]bool{
+				"none": false, "own-ca-plain": false, "own-ca-allowlisted": false,
+				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-issued": false,
+				"own-ca-expired": false, "own-ca-revoked": false, "own-ca-server-eku": false,
+				"own-ca-pp-cli-auth-false": false, "foreign-ca": false,
+			},
+			fingerprint: "20efd5d41098722c",
 		},
 		{
 			// Any certificate that chains to our trust anchor is admitted, with
@@ -238,17 +345,21 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 			name: "any-client: read a certificate status", method: "GET", path: "/certificate_status/somenode",
 			denied: map[string]bool{
 				"none": true, "own-ca-plain": false, "own-ca-allowlisted": false,
-				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-expired": true,
-				"own-ca-revoked": true, "foreign-ca": true,
+				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-issued": false,
+				"own-ca-expired": true, "own-ca-revoked": true, "own-ca-server-eku": true,
+				"own-ca-pp-cli-auth-false": false, "foreign-ca": true,
 			},
+			fingerprint: "bca6da2164bcceeb",
 		},
 		{
 			name: "any-client: renew own certificate", method: "POST", path: "/certificate_renewal",
 			denied: map[string]bool{
 				"none": true, "own-ca-plain": false, "own-ca-allowlisted": false,
-				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-expired": true,
-				"own-ca-revoked": true, "foreign-ca": true,
+				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-issued": false,
+				"own-ca-expired": true, "own-ca-revoked": true, "own-ca-server-eku": true,
+				"own-ca-pp-cli-auth-false": false, "foreign-ca": true,
 			},
+			fingerprint: "bca6da2164bcceeb",
 		},
 		{
 			// Self-match: the CN must equal the path subject, or the caller must
@@ -256,41 +367,51 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 			name: "self-or-admin: read own CSR", method: "GET", path: "/certificate_request/" + selfName,
 			denied: map[string]bool{
 				"none": true, "own-ca-plain": false, "own-ca-allowlisted": false,
-				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-expired": true,
-				"own-ca-revoked": true, "foreign-ca": true,
+				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-issued": true,
+				"own-ca-expired": true, "own-ca-revoked": true, "own-ca-server-eku": true,
+				"own-ca-pp-cli-auth-false": true, "foreign-ca": true,
 			},
+			fingerprint: "97f9f0c0deb8b53d",
 		},
 		{
 			name: "self-or-admin: read another node's CSR", method: "GET", path: "/certificate_request/othernode",
 			denied: map[string]bool{
 				"none": true, "own-ca-plain": true, "own-ca-allowlisted": false,
-				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-expired": true,
-				"own-ca-revoked": true, "foreign-ca": true,
+				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-issued": true,
+				"own-ca-expired": true, "own-ca-revoked": true, "own-ca-server-eku": true,
+				"own-ca-pp-cli-auth-false": true, "foreign-ca": true,
 			},
+			fingerprint: "a5e45fefd4a8d0ef",
 		},
 		{
 			name: "admin: list all statuses", method: "GET", path: "/certificate_statuses/all",
 			denied: map[string]bool{
 				"none": true, "own-ca-plain": true, "own-ca-allowlisted": false,
-				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-expired": true,
-				"own-ca-revoked": true, "foreign-ca": true,
+				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-issued": true,
+				"own-ca-expired": true, "own-ca-revoked": true, "own-ca-server-eku": true,
+				"own-ca-pp-cli-auth-false": true, "foreign-ca": true,
 			},
+			fingerprint: "a5e45fefd4a8d0ef",
 		},
 		{
 			name: "admin: sign all pending", method: "POST", path: "/sign/all",
 			denied: map[string]bool{
 				"none": true, "own-ca-plain": true, "own-ca-allowlisted": false,
-				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-expired": true,
-				"own-ca-revoked": true, "foreign-ca": true,
+				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-issued": true,
+				"own-ca-expired": true, "own-ca-revoked": true, "own-ca-server-eku": true,
+				"own-ca-pp-cli-auth-false": true, "foreign-ca": true,
 			},
+			fingerprint: "a5e45fefd4a8d0ef",
 		},
 		{
 			name: "admin: reissue the CRL", method: "PUT", path: "/certificate_revocation_list/ca",
 			denied: map[string]bool{
 				"none": true, "own-ca-plain": true, "own-ca-allowlisted": false,
-				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-expired": true,
-				"own-ca-revoked": true, "foreign-ca": true,
+				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-issued": true,
+				"own-ca-expired": true, "own-ca-revoked": true, "own-ca-server-eku": true,
+				"own-ca-pp-cli-auth-false": true, "foreign-ca": true,
 			},
+			fingerprint: "a5e45fefd4a8d0ef",
 		},
 	}
 
@@ -300,10 +421,31 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 		req := httptest.NewRequest(route.method, pathPrefix+route.path, strings.NewReader(""))
 		if class.cert != nil {
 			req = withClientCert(req, class.cert)
+		} else {
+			// A TLS connection that presented no client certificate, which is
+			// what a real mTLS listener produces. Leaving r.TLS nil instead
+			// would reach the middleware's other disjunct — the one the
+			// production code itself calls "shouldn't happen" — so the whole
+			// "none" column would have recorded the defensive branch rather
+			// than the case operators actually hit. The sibling oracle in
+			// auth_test.go models it this way for the same reason.
+			req.TLS = &tls.ConnectionState{}
 		}
 		rec := httptest.NewRecorder()
 		mux.ServeHTTP(rec, req)
-		return middlewareDenied(rec)
+		switch classify(rec) {
+		case deniedByMiddleware:
+			return true
+		case unrecognised403:
+			Fail(fmt.Sprintf("route %q, client %q: 403 with body %q is neither a known middleware "+
+				"denial nor a known handler refusal. Classify it in classify()/handler403Bodies "+
+				"before trusting this table: an unrecognised denial recorded as an admission is "+
+				"how this oracle goes quiet on the change it exists to watch.",
+				route.name, class.name, strings.TrimSpace(rec.Body.String())))
+			return false
+		default:
+			return false
+		}
 	}
 
 	// One Entry per route rather than a doubly-nested loop inside a single It.
@@ -346,23 +488,88 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 		routeEntries,
 	)
 
-	It("applies the same authorisation at the /puppet-ca/v1 prefix", func() {
-		// Routes() registers every path twice, bare and prefixed, against the
-		// same handler. That is half the registered mux, and nothing else here
-		// touches it: a prefix-sensitive change to lookupTier — which matches on
-		// path prefixes — would move the prefixed surface alone and go unnoticed.
-		//
-		// Compared against the same recorded table rather than a second copy of
-		// it, so the two cannot drift.
-		for _, route := range routes {
+	// One Entry per route, matching the bare-path table, for the same two
+	// reasons: a single It aborts at the first moved cell, and this surface is
+	// half the registered mux — a prefix-sensitive change to lookupTier, which
+	// matches on path prefixes, would move it alone.
+	//
+	// Compared against the same recorded table rather than a second copy, so the
+	// two cannot drift.
+	DescribeTable("applies the same authorisation at the /puppet-ca/v1 prefix",
+		func(route routeCase) {
+			var mismatches []string
 			for _, class := range newClasses() {
 				want := route.denied[class.name]
-				Expect(probe(route, class, "/puppet-ca/v1")).To(Equal(want),
-					"route %q at the /puppet-ca/v1 prefix, client %q: recorded denied=%v but the prefixed "+
-						"path disagrees. Both forms must authorise identically.",
-					route.name, class.name, want)
+				if got := probe(route, class, "/puppet-ca/v1"); got != want {
+					mismatches = append(mismatches,
+						fmt.Sprintf("  client %q: recorded denied=%v, got denied=%v", class.name, want, got))
+				}
+			}
+			Expect(mismatches).To(BeEmpty(),
+				"route %q disagrees between its bare and /puppet-ca/v1 forms:\n%s\n\n"+
+					"Both must authorise identically.",
+				route.name, strings.Join(mismatches, "\n"))
+		},
+		routeEntries,
+	)
+
+	// Without this, editing a recorded cell and leaving changedBy empty was a
+	// green suite: nothing retained the original values, so no assertion could
+	// tell a deliberate change from a silent one. The digest is that retained
+	// copy, in one line per row.
+	It("requires a changed row to say what changed it", func() {
+		var undocumented []string
+		for _, route := range routes {
+			got := fingerprintDenied(route.denied)
+			if got == route.fingerprint {
+				continue
+			}
+			if route.changedBy == "" {
+				undocumented = append(undocumented, fmt.Sprintf(
+					"  %q: recorded outcomes have been edited but changedBy is empty.\n"+
+						"    Set changedBy to the change that did it, and update fingerprint to %q.",
+					route.name, got))
 			}
 		}
+		Expect(undocumented).To(BeEmpty(),
+			"the recorded baseline was edited without saying why:\n%s\n\n"+
+				"That distinction — deliberate versus accidental — is what this table is for.",
+			strings.Join(undocumented, "\n"))
+	})
+
+	It("keeps every fingerprint in step with the row it digests", func() {
+		// The other half: a row whose fingerprint is stale (updated outcomes,
+		// updated changedBy, forgotten digest) would silently stop enforcing.
+		var stale []string
+		for _, route := range routes {
+			if got := fingerprintDenied(route.denied); got != route.fingerprint && route.changedBy != "" {
+				stale = append(stale, fmt.Sprintf("  %q: set fingerprint to %q", route.name, got))
+			}
+		}
+		Expect(stale).To(BeEmpty(),
+			"these rows changed and were documented, but their fingerprints were not "+
+				"updated, so the next edit would go unnoticed:\n%s", strings.Join(stale, "\n"))
+	})
+
+	// The table above cannot tell "denied by the middleware" from "this path is
+	// not registered at all": Routes() wraps the mux, so an unknown path is
+	// tier-classified and refused before routing ever happens. Dropping
+	// "/puppet-ca/v1" from the prefix list would therefore leave every recorded
+	// cell satisfied. This pins existence separately.
+	It("actually registers the prefixed routes", func() {
+		var missing []string
+		for _, route := range routes {
+			req := httptest.NewRequest(route.method, "/puppet-ca/v1"+route.path, strings.NewReader(""))
+			req.TLS = &tls.ConnectionState{}
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+			if rec.Code == http.StatusNotFound {
+				missing = append(missing, "  "+route.method+" /puppet-ca/v1"+route.path)
+			}
+		}
+		Expect(missing).To(BeEmpty(),
+			"these prefixed paths returned 404, so the prefix is no longer registered "+
+				"for them:\n%s", strings.Join(missing, "\n"))
 	})
 
 	It("states an outcome for every route and client class", func() {
@@ -409,7 +616,10 @@ var expectedClientClasses = []string{
 	"own-ca-pp-cli-auth",
 	"own-ca-admin-both",
 	"own-ca-expired",
+	"own-ca-issued",
 	"own-ca-revoked",
+	"own-ca-server-eku",
+	"own-ca-pp-cli-auth-false",
 	"foreign-ca",
 }
 
@@ -417,6 +627,7 @@ var expectedRoutes = []string{
 	"public: fetch the CA certificate",
 	"public: fetch the CRL",
 	"public: submit a CSR",
+	"public: read expiry metadata",
 	"any-client: read a certificate status",
 	"any-client: renew own certificate",
 	"self-or-admin: read own CSR",
@@ -424,6 +635,23 @@ var expectedRoutes = []string{
 	"admin: list all statuses",
 	"admin: sign all pending",
 	"admin: reissue the CRL",
+}
+
+// fingerprintDenied digests a row's recorded outcomes. Sorted so it does not
+// depend on map iteration order, and truncated because it only has to detect a
+// change, not resist an adversary.
+func fingerprintDenied(denied map[string]bool) string {
+	names := make([]string, 0, len(denied))
+	for name := range denied {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	h := sha256.New()
+	for _, name := range names {
+		fmt.Fprintf(h, "%s=%v;", name, denied[name])
+	}
+	return hex.EncodeToString(h.Sum(nil))[:16]
 }
 
 func classNames(classes []clientClass) []string {
@@ -482,6 +710,70 @@ func clientCertFromKey(key *rsa.PrivateKey, cn string, caCert *x509.Certificate,
 	der, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
 	Expect(err).NotTo(HaveOccurred())
 	cert, err := x509.ParseCertificate(der)
+	Expect(err).NotTo(HaveOccurred())
+	return cert
+}
+
+// serverEKUClientCert mints a chain-valid certificate carrying serverAuth EKU
+// only, so it fails the middleware's ExtKeyUsageClientAuth requirement rather
+// than its chain check. Nothing else in the matrix distinguishes those two.
+func serverEKUClientCert(key *rsa.PrivateKey, cn string, caCert *x509.Certificate,
+	caKey *rsa.PrivateKey,
+) *x509.Certificate {
+	GinkgoHelper()
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-1 * time.Hour),
+		NotAfter:     time.Now().Add(1 * time.Hour),
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
+	Expect(err).NotTo(HaveOccurred())
+	cert, err := x509.ParseCertificate(der)
+	Expect(err).NotTo(HaveOccurred())
+	return cert
+}
+
+// ppCliAuthValueCert mints a certificate carrying pp_cli_auth with an arbitrary
+// value, so a change from equality against "true" to a bare presence test is
+// visible. clientCertFromKey can only encode "true".
+func ppCliAuthValueCert(key *rsa.PrivateKey, cn string, caCert *x509.Certificate,
+	caKey *rsa.PrivateKey, value string,
+) *x509.Certificate {
+	GinkgoHelper()
+	extValue, err := asn1.Marshal(value)
+	Expect(err).NotTo(HaveOccurred())
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-1 * time.Hour),
+		NotAfter:     time.Now().Add(1 * time.Hour),
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		ExtraExtensions: []pkix.Extension{{
+			Id:    asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 34380, 1, 3, 39},
+			Value: extValue,
+		}},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
+	Expect(err).NotTo(HaveOccurred())
+	cert, err := x509.ParseCertificate(der)
+	Expect(err).NotTo(HaveOccurred())
+	return cert
+}
+
+// caIssuedClientCert issues a certificate through the CA's real issuance path,
+// so it exists in the inventory and serial records. A fresh subject each time,
+// since Generate refuses to reissue for a subject that already holds a valid
+// certificate.
+func caIssuedClientCert(ctx context.Context, myCA *ca.CA) *x509.Certificate {
+	GinkgoHelper()
+	cn := fmt.Sprintf("issued%d", time.Now().UnixNano())
+	res, err := myCA.Generate(ctx, cn, nil)
+	Expect(err).NotTo(HaveOccurred())
+	block, _ := pem.Decode(res.CertificatePEM)
+	Expect(block).NotTo(BeNil())
+	cert, err := x509.ParseCertificate(block.Bytes)
 	Expect(err).NotTo(HaveOccurred())
 	return cert
 }
@@ -571,10 +863,10 @@ var _ = Describe("Authorisation baseline: configuration axes", Ordered, Continue
 		ctx = context.Background()
 		store := storage.New(GinkgoT().TempDir())
 		myCA = ca.New(store, ca.AutosignConfig{Mode: "off"}, "puppet.test")
-		// The revoked fixture is issued through the CA, so leaf generation is on
-		// the fixture path. Nothing here depends on the leaf algorithm and ECDSA
-		// is an order of magnitude cheaper to generate than RSA.
-		myCA.LeafKeyConfig = ca.KeyConfig{Algo: ca.KeyAlgoECDSA, Size: 256}
+		// No LeafKeyConfig here: this block mints its certificates directly with
+		// issueClientCert and never issues through the CA, so the setting had no
+		// consumer and its rationale described a fixture path this Describe does
+		// not have.
 		Expect(store.EnsureDirs(ctx)).To(Succeed())
 		Expect(store.SaveCAKey(ctx, cachedKeyPEM)).To(Succeed())
 		Expect(store.SaveCACert(ctx, cachedCrtPEM)).To(Succeed())
@@ -603,11 +895,44 @@ var _ = Describe("Authorisation baseline: configuration axes", Ordered, Continue
 		req := httptest.NewRequest(method, path, strings.NewReader(""))
 		if cert != nil {
 			req = withClientCert(req, cert)
+		} else {
+			req.TLS = &tls.ConnectionState{}
 		}
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, req)
-		return middlewareDenied(rec)
+		kind := classify(rec)
+		Expect(kind).NotTo(Equal(unrecognised403),
+			"%s %s: unrecognised 403 body %q; classify it before trusting this result",
+			method, path, strings.TrimSpace(rec.Body.String()))
+		return kind == deniedByMiddleware
 	}
+
+	// The widest branch in auth.go, and the one asserted nowhere in the
+	// repository before this. It matters most on this stack: sub-CA support
+	// restructures AuthConfig for per-issuer trust anchors, and a restructure
+	// that changes what an unpopulated config means — or introduces a path where
+	// cfg is nil where it was not — would move no row in the table above and
+	// fail no spec anywhere.
+	Describe("an absent AuthConfig", func() {
+		It("disables authorisation entirely, admitting an admin route with no certificate", func() {
+			handler := muxWith(nil)
+			Expect(probe(handler, "POST", "/sign/all", nil)).To(BeFalse(),
+				"with no AuthConfig the middleware is not installed at all")
+		})
+
+		It("admits an any-client route with no certificate", func() {
+			handler := muxWith(nil)
+			Expect(probe(handler, "GET", "/certificate_status/somenode", nil)).To(BeFalse())
+		})
+
+		It("admits a self-or-admin route for a foreign certificate", func() {
+			// Not merely "no certificate is enough": a certificate from an
+			// unrelated CA is equally unexamined, because nothing examines it.
+			handler := muxWith(nil)
+			Expect(probe(handler, "GET", "/certificate_request/othernode",
+				foreignClientCert("intruder"))).To(BeFalse())
+		})
+	})
 
 	Describe("allow_public_status", func() {
 		It("denies a client with no certificate when unset", func() {

--- a/internal/api/authbaseline_test.go
+++ b/internal/api/authbaseline_test.go
@@ -25,6 +25,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/asn1"
 	"encoding/pem"
 	"fmt"
 	"math/big"
@@ -43,19 +44,42 @@ import (
 
 // This file is an authorisation *oracle*, not a feature test.
 //
-// It records, exhaustively, which client certificates the middleware admits to
-// which routes as the code stands today. Later work changes that deliberately
-// in a small number of places — scoping identity claims to the issuing CA,
-// gating renewal on our own certificates, moving certificate_status to
-// admin-only — and the value of this table is that it was written and committed
-// *before* those changes, so it says what the behaviour was rather than what
-// someone later believed it should be.
+// It records which client certificates the middleware admits to which routes as
+// the code stands today. Later work changes that deliberately in a small number
+// of places — scoping identity claims to the issuing CA, gating renewal on our
+// own certificates, moving certificate_status to admin-only — and the value of
+// this table is that it was written and committed *before* those changes, so it
+// says what the behaviour was rather than what someone later believed it should
+// be.
 //
-// Every row carries an expectChanged flag, currently false everywhere. A change
-// that intends to alter a row flips the flag in the same commit; a change that
-// alters a row without flipping it fails here. That distinction — deliberate
+// Rows are always asserted. A change that intends to alter one updates the
+// recorded outcome and records why in changedBy, in the same commit; a change
+// that alters one without doing so fails here. That distinction — deliberate
 // versus accidental — is the whole point, and a blanket "nothing changes"
 // assertion could not express it.
+//
+// changedBy is documentation, not an exemption. An earlier draft carried a
+// boolean that skipped assertion for flagged rows, which would have left
+// exactly the rows under active change as the only unasserted ones — and on
+// `GET /certificate_status/{subject}`, where one cell of seven moves, it would
+// have silently retired the foreign-issuer, expired and revoked cells on the
+// very route being restructured.
+//
+// Scope, stated plainly so nobody mistakes this for total coverage:
+//
+//   - 10 of the 19 routes registered by Routes(). The omitted ones are OCSP and
+//     the health probes (public and uninteresting here), and duplicates of a
+//     tier already represented by another row.
+//   - Both the bare and the /puppet-ca/v1-prefixed forms of each path, which
+//     the mux registers separately — see the prefix spec below.
+//   - The default AuthConfig, plus the two flags that move a tier
+//     (AllowPublicStatus, NoPpCliAuth), covered in their own Describe rather
+//     than by multiplying every row.
+//
+// A second, overlapping oracle lives in auth_test.go ("authorisation matrix"),
+// which drives lookupTier directly rather than through the mux. That one pins
+// tier assignment; this one pins the observable HTTP outcome. Keep them in
+// step: a tier change should move a row in both.
 
 // clientClass is one kind of client certificate the middleware might see.
 type clientClass struct {
@@ -71,20 +95,37 @@ type routeCase struct {
 	path   string
 	// denied maps clientClass.name to whether the middleware rejects it.
 	denied map[string]bool
-	// expectChanged marks rows a later change is permitted to alter. Flip it in
-	// the same commit that changes the behaviour, never before and never after.
-	expectChanged bool
+	// changedBy names the change that last altered this row's outcomes, empty
+	// for rows still at their original recorded values. Always asserted either
+	// way; this only says why a value differs from the first recording.
+	changedBy string
 }
 
-// deniedStatus reports whether code is the middleware's rejection.
+// middlewareDenied reports whether the response is the *middleware's* rejection.
 //
-// The middleware answers 403 for every authorisation failure and nothing else
-// does on these routes, so 403 is a reliable signal. Handler-level outcomes
-// (404 for an absent subject, 400 for a malformed body) all mean the request
-// got past authorisation, which is what this table measures.
-func deniedStatus(code int) bool { return code == http.StatusForbidden }
+// Status alone is not enough. Handlers on these routes return 403 of their own —
+// handlePostCertificateRenewal does so twice (handlers.go:903, :955), and
+// handleGetCert once — so a bare code check would record a handler outcome as an
+// authorisation outcome and the table would drift without failing. The
+// middleware's two messages are matched exactly instead. Note "client
+// certificate required" is a strict prefix of the renewal handler's "client
+// certificate required for renewal", so this must not become a prefix match.
+//
+// Every other outcome (404 for an absent subject, 400 for a malformed body)
+// means the request got past authorisation, which is what this table measures.
+func middlewareDenied(rec *httptest.ResponseRecorder) bool {
+	if rec.Code != http.StatusForbidden {
+		return false
+	}
+	switch strings.TrimSpace(rec.Body.String()) {
+	case "client certificate required", "access denied":
+		return true
+	default:
+		return false
+	}
+}
 
-var _ = Describe("Authorisation baseline", Ordered, func() {
+var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 	var (
 		ctx        context.Context
 		myCA       *ca.CA
@@ -102,6 +143,10 @@ var _ = Describe("Authorisation baseline", Ordered, func() {
 
 		store = storage.New(tmpDir)
 		myCA = ca.New(store, ca.AutosignConfig{Mode: "off"}, "puppet.test")
+		// The revoked fixture is issued through the CA, so leaf generation is on
+		// the fixture path. Nothing here depends on the leaf algorithm and ECDSA
+		// is an order of magnitude cheaper to generate than RSA.
+		myCA.LeafKeyConfig = ca.KeyConfig{Algo: ca.KeyAlgoECDSA, Size: 256}
 		Expect(store.EnsureDirs(ctx)).To(Succeed())
 		Expect(store.SaveCAKey(ctx, cachedKeyPEM)).To(Succeed())
 		Expect(store.SaveCACert(ctx, cachedCrtPEM)).To(Succeed())
@@ -132,15 +177,27 @@ var _ = Describe("Authorisation baseline", Ordered, func() {
 		// RevokeOnAutoRenew defaults to true, revokes the one presented. Reusing
 		// certificates across routes therefore makes every later outcome depend
 		// on which earlier routes ran — an oracle that changes its answers based
-		// on evaluation order is worse than no oracle. Minting per route costs a
-		// few key generations and buys independence.
+		// on evaluation order is worse than no oracle.
+		//
+		// The *keys*, though, are generated once and reused. What must be fresh
+		// is the certificate — its serial is what the CRL names — and RSA key
+		// generation is the whole cost of minting one. Re-minting per route with
+		// cached keys keeps the independence and takes the matrix from ~130 key
+		// generations to eight.
+		keyPool := newRSAKeyPool(4)
+
 		newClasses = func() []clientClass {
 			return []clientClass{
 				{name: "none", cert: nil},
-				{name: "own-ca-plain", cert: issueClientCert(selfName, caCert, caKey)},
-				{name: "own-ca-allowlisted", cert: issueClientCert("puppet-server", caCert, caKey)},
-				{name: "own-ca-pp-cli-auth", cert: issueClientCertWithPpCliAuth("cli-user", caCert, caKey)},
-				{name: "own-ca-expired", cert: expiredClientCert("stale", caCert, caKey)},
+				{name: "own-ca-plain", cert: clientCertFromKey(keyPool[0], selfName, caCert, caKey, false, false)},
+				{name: "own-ca-allowlisted", cert: clientCertFromKey(keyPool[1], "puppet-server", caCert, caKey, false, false)},
+				{name: "own-ca-pp-cli-auth", cert: clientCertFromKey(keyPool[2], "cli-user", caCert, caKey, true, false)},
+				// Admin by both routes at once, which is the shipped topology-A
+				// arrangement: the Puppet Server's own CN is allow-listed and it
+				// also presents pp_cli_auth. It exists to catch a change that
+				// makes the two grants exclusive rather than additive.
+				{name: "own-ca-admin-both", cert: clientCertFromKey(keyPool[3], "puppet-server", caCert, caKey, true, false)},
+				{name: "own-ca-expired", cert: clientCertFromKey(keyPool[0], "stale", caCert, caKey, false, true)},
 				{name: "own-ca-revoked", cert: revokedClientCert(ctx, myCA)},
 				{name: "foreign-ca", cert: foreignClientCert(selfName)},
 			}
@@ -154,7 +211,7 @@ var _ = Describe("Authorisation baseline", Ordered, func() {
 			name: "public: fetch the CA certificate", method: "GET", path: "/certificate/ca",
 			denied: map[string]bool{
 				"none": false, "own-ca-plain": false, "own-ca-allowlisted": false,
-				"own-ca-pp-cli-auth": false, "own-ca-expired": false,
+				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-expired": false,
 				"own-ca-revoked": false, "foreign-ca": false,
 			},
 		},
@@ -162,7 +219,7 @@ var _ = Describe("Authorisation baseline", Ordered, func() {
 			name: "public: fetch the CRL", method: "GET", path: "/certificate_revocation_list/ca",
 			denied: map[string]bool{
 				"none": false, "own-ca-plain": false, "own-ca-allowlisted": false,
-				"own-ca-pp-cli-auth": false, "own-ca-expired": false,
+				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-expired": false,
 				"own-ca-revoked": false, "foreign-ca": false,
 			},
 		},
@@ -170,7 +227,7 @@ var _ = Describe("Authorisation baseline", Ordered, func() {
 			name: "public: submit a CSR", method: "PUT", path: "/certificate_request/newnode",
 			denied: map[string]bool{
 				"none": false, "own-ca-plain": false, "own-ca-allowlisted": false,
-				"own-ca-pp-cli-auth": false, "own-ca-expired": false,
+				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-expired": false,
 				"own-ca-revoked": false, "foreign-ca": false,
 			},
 		},
@@ -181,7 +238,7 @@ var _ = Describe("Authorisation baseline", Ordered, func() {
 			name: "any-client: read a certificate status", method: "GET", path: "/certificate_status/somenode",
 			denied: map[string]bool{
 				"none": true, "own-ca-plain": false, "own-ca-allowlisted": false,
-				"own-ca-pp-cli-auth": false, "own-ca-expired": true,
+				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-expired": true,
 				"own-ca-revoked": true, "foreign-ca": true,
 			},
 		},
@@ -189,7 +246,7 @@ var _ = Describe("Authorisation baseline", Ordered, func() {
 			name: "any-client: renew own certificate", method: "POST", path: "/certificate_renewal",
 			denied: map[string]bool{
 				"none": true, "own-ca-plain": false, "own-ca-allowlisted": false,
-				"own-ca-pp-cli-auth": false, "own-ca-expired": true,
+				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-expired": true,
 				"own-ca-revoked": true, "foreign-ca": true,
 			},
 		},
@@ -199,7 +256,7 @@ var _ = Describe("Authorisation baseline", Ordered, func() {
 			name: "self-or-admin: read own CSR", method: "GET", path: "/certificate_request/" + selfName,
 			denied: map[string]bool{
 				"none": true, "own-ca-plain": false, "own-ca-allowlisted": false,
-				"own-ca-pp-cli-auth": false, "own-ca-expired": true,
+				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-expired": true,
 				"own-ca-revoked": true, "foreign-ca": true,
 			},
 		},
@@ -207,7 +264,7 @@ var _ = Describe("Authorisation baseline", Ordered, func() {
 			name: "self-or-admin: read another node's CSR", method: "GET", path: "/certificate_request/othernode",
 			denied: map[string]bool{
 				"none": true, "own-ca-plain": true, "own-ca-allowlisted": false,
-				"own-ca-pp-cli-auth": false, "own-ca-expired": true,
+				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-expired": true,
 				"own-ca-revoked": true, "foreign-ca": true,
 			},
 		},
@@ -215,7 +272,7 @@ var _ = Describe("Authorisation baseline", Ordered, func() {
 			name: "admin: list all statuses", method: "GET", path: "/certificate_statuses/all",
 			denied: map[string]bool{
 				"none": true, "own-ca-plain": true, "own-ca-allowlisted": false,
-				"own-ca-pp-cli-auth": false, "own-ca-expired": true,
+				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-expired": true,
 				"own-ca-revoked": true, "foreign-ca": true,
 			},
 		},
@@ -223,7 +280,7 @@ var _ = Describe("Authorisation baseline", Ordered, func() {
 			name: "admin: sign all pending", method: "POST", path: "/sign/all",
 			denied: map[string]bool{
 				"none": true, "own-ca-plain": true, "own-ca-allowlisted": false,
-				"own-ca-pp-cli-auth": false, "own-ca-expired": true,
+				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-expired": true,
 				"own-ca-revoked": true, "foreign-ca": true,
 			},
 		},
@@ -231,38 +288,79 @@ var _ = Describe("Authorisation baseline", Ordered, func() {
 			name: "admin: reissue the CRL", method: "PUT", path: "/certificate_revocation_list/ca",
 			denied: map[string]bool{
 				"none": true, "own-ca-plain": true, "own-ca-allowlisted": false,
-				"own-ca-pp-cli-auth": false, "own-ca-expired": true,
+				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-expired": true,
 				"own-ca-revoked": true, "foreign-ca": true,
 			},
 		},
 	}
 
-	It("records the outcome of every client class against every route", func() {
-		for _, route := range routes {
+	// probe runs one route against one client class at pathPrefix and reports
+	// whether the middleware rejected it.
+	probe := func(route routeCase, class clientClass, pathPrefix string) bool {
+		req := httptest.NewRequest(route.method, pathPrefix+route.path, strings.NewReader(""))
+		if class.cert != nil {
+			req = withClientCert(req, class.cert)
+		}
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		return middlewareDenied(rec)
+	}
+
+	// One Entry per route rather than a doubly-nested loop inside a single It.
+	// Two reasons, both about what happens when a change lands: Gomega aborts a
+	// spec at the first failed Expect, so a single It would report one moved
+	// cell and stop — defeating the point of a table whose job is to enumerate
+	// everything that moved. And every mismatching cell within a route is
+	// collected before asserting, so one route reports all of its own
+	// disagreements at once.
+	routeEntries := make([]TableEntry, 0, len(routes))
+	for _, route := range routes {
+		routeEntries = append(routeEntries, Entry(route.name, route))
+	}
+
+	DescribeTable("records the outcome of every client class",
+		func(route routeCase) {
+			var mismatches []string
 			for _, class := range newClasses() {
 				want, ok := route.denied[class.name]
 				Expect(ok).To(BeTrue(),
 					"route %q has no recorded outcome for client class %q; every combination must be stated",
 					route.name, class.name)
 
-				req := httptest.NewRequest(route.method, route.path, strings.NewReader(""))
-				if class.cert != nil {
-					req = withClientCert(req, class.cert)
+				if got := probe(route, class, ""); got != want {
+					mismatches = append(mismatches,
+						fmt.Sprintf("  client %q: recorded denied=%v, got denied=%v", class.name, want, got))
 				}
-				rec := httptest.NewRecorder()
-				mux.ServeHTTP(rec, req)
+			}
+			provenance := "still at its originally recorded values"
+			if route.changedBy != "" {
+				provenance = "last changed by: " + route.changedBy
+			}
+			Expect(mismatches).To(BeEmpty(),
+				"route %q no longer matches the recorded baseline:\n%s\n\n"+
+					"This row was %s.\n"+
+					"If this change is intended, update the recorded outcome and set changedBy "+
+					"on the row in the same commit.",
+				route.name, strings.Join(mismatches, "\n"), provenance)
+		},
+		routeEntries,
+	)
 
-				got := deniedStatus(rec.Code)
-				if route.expectChanged {
-					// A row flagged as intentionally changed is exercised but not
-					// asserted here; the commit that flips the flag owns the new
-					// expectation and asserts it directly.
-					continue
-				}
-				Expect(got).To(Equal(want),
-					"route %q, client %q: recorded denied=%v but got denied=%v (HTTP %d).\n"+
-						"If this change is intended, set expectChanged on the row in the same commit.",
-					route.name, class.name, want, got, rec.Code)
+	It("applies the same authorisation at the /puppet-ca/v1 prefix", func() {
+		// Routes() registers every path twice, bare and prefixed, against the
+		// same handler. That is half the registered mux, and nothing else here
+		// touches it: a prefix-sensitive change to lookupTier — which matches on
+		// path prefixes — would move the prefixed surface alone and go unnoticed.
+		//
+		// Compared against the same recorded table rather than a second copy of
+		// it, so the two cannot drift.
+		for _, route := range routes {
+			for _, class := range newClasses() {
+				want := route.denied[class.name]
+				Expect(probe(route, class, "/puppet-ca/v1")).To(Equal(want),
+					"route %q at the /puppet-ca/v1 prefix, client %q: recorded denied=%v but the prefixed "+
+						"path disagrees. Both forms must authorise identically.",
+					route.name, class.name, want)
 			}
 		}
 	})
@@ -271,27 +369,115 @@ var _ = Describe("Authorisation baseline", Ordered, func() {
 		// Guards the table itself: a route added without outcomes, or a client
 		// class added without extending every route, would otherwise silently
 		// test less than it appears to.
-		want := len(newClasses())
+		//
+		// The class list is pinned by name, not merely counted. Counting alone
+		// lets an adversarial fixture be swapped out — delete "foreign-ca", add
+		// a second benign class, and the length still matches while the row that
+		// mattered is gone.
+		Expect(classNames(newClasses())).To(Equal(expectedClientClasses))
+
 		for _, route := range routes {
-			Expect(route.denied).To(HaveLen(want),
+			Expect(route.denied).To(HaveLen(len(expectedClientClasses)),
 				"route %q records %d outcomes but there are %d client classes",
-				route.name, len(route.denied), want)
+				route.name, len(route.denied), len(expectedClientClasses))
+			for _, name := range expectedClientClasses {
+				_, ok := route.denied[name]
+				Expect(ok).To(BeTrue(), "route %q has no recorded outcome for client class %q", route.name, name)
+			}
 		}
+	})
+
+	It("covers the routes it claims to", func() {
+		// Pins the row list for the same reason as the class list: a row
+		// silently dropped is coverage silently lost, and the count alone would
+		// not notice a swap.
+		names := make([]string, 0, len(routes))
+		for _, route := range routes {
+			names = append(names, route.name)
+		}
+		Expect(names).To(Equal(expectedRoutes))
 	})
 })
 
-// expiredClientCert issues a certificate that expired an hour ago.
-func expiredClientCert(cn string, caCert *x509.Certificate, caKey *rsa.PrivateKey) *x509.Certificate {
+// expectedClientClasses and expectedRoutes pin the shape of the matrix. They
+// exist so that removing a fixture is a deliberate edit to a named list rather
+// than an invisible reduction in what the oracle covers.
+var expectedClientClasses = []string{
+	"none",
+	"own-ca-plain",
+	"own-ca-allowlisted",
+	"own-ca-pp-cli-auth",
+	"own-ca-admin-both",
+	"own-ca-expired",
+	"own-ca-revoked",
+	"foreign-ca",
+}
+
+var expectedRoutes = []string{
+	"public: fetch the CA certificate",
+	"public: fetch the CRL",
+	"public: submit a CSR",
+	"any-client: read a certificate status",
+	"any-client: renew own certificate",
+	"self-or-admin: read own CSR",
+	"self-or-admin: read another node's CSR",
+	"admin: list all statuses",
+	"admin: sign all pending",
+	"admin: reissue the CRL",
+}
+
+func classNames(classes []clientClass) []string {
+	names := make([]string, 0, len(classes))
+	for _, c := range classes {
+		names = append(names, c.name)
+	}
+	return names
+}
+
+// newRSAKeyPool generates n reusable client keys.
+//
+// Key generation dominates fixture cost and nothing in the middleware cares
+// which key a certificate binds, so the pool is built once and every minted
+// certificate draws from it.
+func newRSAKeyPool(n int) []*rsa.PrivateKey {
 	GinkgoHelper()
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
-	Expect(err).NotTo(HaveOccurred())
+	pool := make([]*rsa.PrivateKey, n)
+	for i := range pool {
+		key, err := rsa.GenerateKey(rand.Reader, 2048)
+		Expect(err).NotTo(HaveOccurred())
+		pool[i] = key
+	}
+	return pool
+}
+
+// clientCertFromKey mints a client certificate for cn against an existing key,
+// optionally carrying the pp_cli_auth extension or already expired.
+func clientCertFromKey(key *rsa.PrivateKey, cn string, caCert *x509.Certificate, caKey *rsa.PrivateKey,
+	ppCliAuth, expired bool,
+) *x509.Certificate {
+	GinkgoHelper()
+	notBefore, notAfter := time.Now().Add(-1*time.Hour), time.Now().Add(1*time.Hour)
+	if expired {
+		notBefore, notAfter = time.Now().Add(-2*time.Hour), time.Now().Add(-1*time.Hour)
+	}
 
 	template := &x509.Certificate{
 		SerialNumber: big.NewInt(time.Now().UnixNano()),
 		Subject:      pkix.Name{CommonName: cn},
-		NotBefore:    time.Now().Add(-2 * time.Hour),
-		NotAfter:     time.Now().Add(-1 * time.Hour),
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	if ppCliAuth {
+		// ASN.1-encoded, not a bare string: hasPpCliAuth unmarshals the value,
+		// so a raw []byte("true") parses as absent and the certificate silently
+		// stops being an admin — which the oracle catches, being an oracle.
+		extValue, err := asn1.Marshal("true")
+		Expect(err).NotTo(HaveOccurred())
+		template.ExtraExtensions = []pkix.Extension{{
+			Id:    asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 34380, 1, 3, 39},
+			Value: extValue,
+		}}
 	}
 	der, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
 	Expect(err).NotTo(HaveOccurred())
@@ -319,9 +505,16 @@ func revokedClientCert(ctx context.Context, myCA *ca.CA) *x509.Certificate {
 }
 
 // foreignClientCert issues a certificate from an unrelated CA, carrying a CN
-// this CA's own namespace also uses. Today it is rejected because that CA is
-// not a trust anchor; the CN collision is what makes the row meaningful once
-// more than one issuer can be trusted.
+// this CA's own namespace also uses.
+//
+// What this row pins is narrow, and worth stating so it is not mistaken for
+// more: an issuer that is not configured as a trust anchor is rejected. It
+// cannot demonstrate that a *trusted* second issuer fails to inherit identity
+// claims, because this fixture's CA will still be unconfigured after that work
+// lands — the row would keep passing either way. The cross-issuer case needs a
+// certificate from an issuer the server has been told to trust, which is a
+// fixture the change that introduces multiple trust anchors has to bring with
+// it. The CN collision here is deliberate groundwork for that, not the test.
 func foreignClientCert(cn string) *x509.Certificate {
 	GinkgoHelper()
 	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -356,3 +549,109 @@ func foreignClientCert(cn string) *x509.Certificate {
 	Expect(err).NotTo(HaveOccurred())
 	return leaf
 }
+
+// The two AuthConfig flags that move a route between tiers get their own
+// Describe rather than a third dimension on the main table. Multiplying every
+// row by every flag would triple the fixtures to record four cells that
+// actually differ, and would bury them.
+//
+// Both matter to the later work: AllowPublicStatus and the certificate_status
+// tier change touch the same route from opposite directions, and NoPpCliAuth is
+// the one input that *narrows* admin authority, so a restructure that drops it
+// or wires it per-issuer would otherwise be recorded nowhere.
+var _ = Describe("Authorisation baseline: configuration axes", Ordered, ContinueOnFailure, func() {
+	var (
+		ctx    context.Context
+		caCert *x509.Certificate
+		caKey  *rsa.PrivateKey
+		myCA   *ca.CA
+	)
+
+	BeforeAll(func() {
+		ctx = context.Background()
+		store := storage.New(GinkgoT().TempDir())
+		myCA = ca.New(store, ca.AutosignConfig{Mode: "off"}, "puppet.test")
+		// The revoked fixture is issued through the CA, so leaf generation is on
+		// the fixture path. Nothing here depends on the leaf algorithm and ECDSA
+		// is an order of magnitude cheaper to generate than RSA.
+		myCA.LeafKeyConfig = ca.KeyConfig{Algo: ca.KeyAlgoECDSA, Size: 256}
+		Expect(store.EnsureDirs(ctx)).To(Succeed())
+		Expect(store.SaveCAKey(ctx, cachedKeyPEM)).To(Succeed())
+		Expect(store.SaveCACert(ctx, cachedCrtPEM)).To(Succeed())
+		Expect(store.UpdateCRL(ctx, cachedCrlPEM)).To(Succeed())
+		Expect(store.WriteSerial(ctx, "0001")).To(Succeed())
+		Expect(store.TouchInventory(ctx)).To(Succeed())
+		Expect(myCA.Init(ctx)).To(Succeed())
+
+		block, _ := pem.Decode(cachedCrtPEM)
+		var err error
+		caCert, err = x509.ParseCertificate(block.Bytes)
+		Expect(err).NotTo(HaveOccurred())
+		block, _ = pem.Decode(cachedKeyPEM)
+		caKey, err = x509.ParsePKCS1PrivateKey(block.Bytes)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	// muxWith builds a handler under a specific AuthConfig.
+	muxWith := func(cfg *api.AuthConfig) http.Handler {
+		server := api.New(myCA)
+		server.AuthConfig = cfg
+		return server.Routes()
+	}
+
+	probe := func(handler http.Handler, method, path string, cert *x509.Certificate) bool {
+		req := httptest.NewRequest(method, path, strings.NewReader(""))
+		if cert != nil {
+			req = withClientCert(req, cert)
+		}
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		return middlewareDenied(rec)
+	}
+
+	Describe("allow_public_status", func() {
+		It("denies a client with no certificate when unset", func() {
+			handler := muxWith(&api.AuthConfig{CACert: caCert, AllowList: map[string]bool{"puppet-server": true}})
+			Expect(probe(handler, "GET", "/certificate_status/somenode", nil)).To(BeTrue())
+		})
+
+		It("admits a client with no certificate when set", func() {
+			// The flag moves the route to tierPublic outright. Recorded because
+			// the same route is the one moving to admin-only, and the two
+			// changes must not silently cancel out: an operator with this flag
+			// set should still get public status afterwards, or be told plainly
+			// that the flag no longer does anything.
+			handler := muxWith(&api.AuthConfig{
+				CACert:            caCert,
+				AllowList:         map[string]bool{"puppet-server": true},
+				AllowPublicStatus: true,
+			})
+			Expect(probe(handler, "GET", "/certificate_status/somenode", nil)).To(BeFalse())
+		})
+	})
+
+	Describe("no_pp_cli_auth", func() {
+		It("grants admin on the pp_cli_auth extension when unset", func() {
+			handler := muxWith(&api.AuthConfig{CACert: caCert, AllowList: map[string]bool{"puppet-server": true}})
+			cert := issueClientCertWithPpCliAuth("cli-user", caCert, caKey)
+			Expect(probe(handler, "PUT", "/certificate_revocation_list/ca", cert)).To(BeFalse())
+		})
+
+		It("refuses that grant when set, leaving only the CN allow list", func() {
+			// The one input that narrows admin authority. Every cell in the main
+			// table is computed with this false, so without this pair a change
+			// that dropped the flag would move nothing the oracle watches.
+			handler := muxWith(&api.AuthConfig{
+				CACert:      caCert,
+				AllowList:   map[string]bool{"puppet-server": true},
+				NoPpCliAuth: true,
+			})
+			byExtension := issueClientCertWithPpCliAuth("cli-user", caCert, caKey)
+			Expect(probe(handler, "PUT", "/certificate_revocation_list/ca", byExtension)).To(BeTrue())
+
+			byAllowList := issueClientCert("puppet-server", caCert, caKey)
+			Expect(probe(handler, "PUT", "/certificate_revocation_list/ca", byAllowList)).To(BeFalse(),
+				"the CN allow list must still grant admin when the extension does not")
+		})
+	})
+})

--- a/internal/api/authbaseline_test.go
+++ b/internal/api/authbaseline_test.go
@@ -171,8 +171,22 @@ const (
 //
 // Every other outcome (404 for an absent subject, 400 for a malformed body)
 // means the request got past authorisation, which is what this table measures.
+//
+// One dimension remains open, deliberately and stated here rather than
+// discovered later: a middleware denial that used some *other* status is still
+// bucketed as admitted. 401 and 407 are treated as denials below because they
+// are unambiguous and this package emits neither today. A narrowing that hid a
+// resource behind 404 — the standard anti-enumeration response, and a plausible
+// shape for the certificate_status change, given lookupTier's own comment cites
+// enumeration as the reason that route is gated — would be invisible here,
+// because 404 is also what the handlers return for an absent subject. A change
+// of that shape needs its own anchor.
 func classify(rec *httptest.ResponseRecorder) denialKind {
-	if rec.Code != http.StatusForbidden {
+	switch rec.Code {
+	case http.StatusUnauthorized, http.StatusProxyAuthRequired:
+		return deniedByMiddleware
+	case http.StatusForbidden:
+	default:
 		return admitted
 	}
 	body := strings.TrimSpace(rec.Body.String())
@@ -204,10 +218,11 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 
 		store = storage.New(tmpDir)
 		myCA = ca.New(store, ca.AutosignConfig{Mode: "off"}, "puppet.test")
-		// No LeafKeyConfig here: this block mints its certificates directly with
-		// issueClientCert and never issues through the CA, so the setting had no
-		// consumer and its rationale described a fixture path this Describe does
-		// not have.
+		// caIssuedClientCert and revokedClientCert both issue through the CA, so
+		// leaf generation is on the fixture path here and runs twice per class
+		// set. Without this the CA falls back to DefaultLeafKeyConfig, which is
+		// RSA-2048, and the matrix pays for ~46 of them.
+		myCA.LeafKeyConfig = ca.KeyConfig{Algo: ca.KeyAlgoECDSA, Size: 256}
 		Expect(store.EnsureDirs(ctx)).To(Succeed())
 		Expect(store.SaveCAKey(ctx, cachedKeyPEM)).To(Succeed())
 		Expect(store.SaveCACert(ctx, cachedCrtPEM)).To(Succeed())
@@ -244,9 +259,10 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 		// is the certificate — its serial is what the CRL names — and RSA key
 		// generation is the whole cost of minting one. Re-minting per route with
 		// cached keys keeps the independence and takes the matrix from ~250
-		// RSA-2048 generations to four. The revoked, CA-issued and foreign
-		// fixtures still generate a P-256 key each per call, which is cheap
-		// enough not to be worth pooling.
+		// RSA-2048 generations to four. The CA-issued and revoked fixtures go
+		// through myCA.Generate, so they are ECDSA P-256 by virtue of the
+		// LeafKeyConfig set above; the foreign fixture generates its own CA and
+		// leaf, also P-256. None is worth pooling at that cost.
 		keyPool := newRSAKeyPool(4)
 
 		newClasses = func() []clientClass {
@@ -323,12 +339,13 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 			fingerprint: "20efd5d41098722c",
 		},
 		{
-			// Its own branch in the classifier, and the only genuinely
-			// uncovered route among those omitted. It returns certificate
-			// expiry metadata to any caller with no client certificate, and it
-			// is the obvious sibling question when certificate_status narrows
-			// to admin-only — so a change that tightens, loosens or reorders
-			// this case relative to the one above it should move a cell here.
+			// Has its own branch in the classifier rather than sharing one with
+			// a covered route, which is why it earns a row of its own. It
+			// returns certificate expiry metadata to any caller with no client
+			// certificate, and it is the obvious sibling question when
+			// certificate_status narrows to admin-only — so a change that
+			// tightens, loosens or reorders this case relative to the one above
+			// it moves a cell here.
 			name: "public: read expiry metadata", method: "GET", path: "/expirations",
 			denied: map[string]bool{
 				"none": false, "own-ca-plain": false, "own-ca-allowlisted": false,
@@ -556,16 +573,61 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 	// tier-classified and refused before routing ever happens. Dropping
 	// "/puppet-ca/v1" from the prefix list would therefore leave every recorded
 	// cell satisfied. This pins existence separately.
+	//
+	// It presents the allow-listed admin certificate, because with no
+	// certificate only the four public rows reach the mux at all — the other
+	// seven are refused at auth.go before routing, so a 404 could never be
+	// observed for them and those iterations would assert nothing. That was the
+	// first version of this spec, and dropping the prefix still failed it, which
+	// is how the gap survived: the failure came from the public rows alone.
+	//
+	// Its own server and store, because admission has side effects: POST
+	// /sign/all signs pending CSRs, PUT /certificate_revocation_list/ca
+	// reissues, and POST /certificate_renewal reaches AutoRenew.
 	It("actually registers the prefixed routes", func() {
+		store := storage.New(GinkgoT().TempDir())
+		scratchCA := ca.New(store, ca.AutosignConfig{Mode: "off"}, "puppet.test")
+		scratchCA.LeafKeyConfig = ca.KeyConfig{Algo: ca.KeyAlgoECDSA, Size: 256}
+		Expect(store.EnsureDirs(ctx)).To(Succeed())
+		Expect(store.SaveCAKey(ctx, cachedKeyPEM)).To(Succeed())
+		Expect(store.SaveCACert(ctx, cachedCrtPEM)).To(Succeed())
+		Expect(store.UpdateCRL(ctx, cachedCrlPEM)).To(Succeed())
+		Expect(store.WriteSerial(ctx, "0001")).To(Succeed())
+		Expect(store.TouchInventory(ctx)).To(Succeed())
+		Expect(scratchCA.Init(ctx)).To(Succeed())
+
+		scratch := api.New(scratchCA)
+		scratch.AuthConfig = &api.AuthConfig{
+			CACert:    caCert,
+			AllowList: map[string]bool{"puppet-server": true},
+		}
+		scratchMux := scratch.Routes()
+		// A fresh admin certificate per route, for the reason the class fixtures
+		// give: POST /certificate_renewal succeeds here and, with
+		// RevokeOnAutoRenew defaulting to true, revokes the certificate it was
+		// shown. Reusing one across the loop revoked it midway and every later
+		// route came back "access denied" from the CRL check — which looked
+		// exactly like an authorisation failure.
+		adminKey := newRSAKeyPool(1)[0]
+
 		var missing []string
 		for _, route := range routes {
 			req := httptest.NewRequest(route.method, "/puppet-ca/v1"+route.path, strings.NewReader(""))
-			req.TLS = &tls.ConnectionState{}
+			req = withClientCert(req, clientCertFromKey(adminKey, "puppet-server", caCert, caKey, false, false))
 			rec := httptest.NewRecorder()
-			mux.ServeHTTP(rec, req)
-			if rec.Code == http.StatusNotFound {
+			scratchMux.ServeHTTP(rec, req)
+			// A bare 404 is ambiguous: the handlers return one for an absent
+			// subject, which several of these routes legitimately do against a
+			// scratch store. Go's ServeMux writes its own body for a path it has
+			// no pattern for, and that is the one that means "unregistered".
+			if rec.Code == http.StatusNotFound &&
+				strings.Contains(rec.Body.String(), "404 page not found") {
 				missing = append(missing, "  "+route.method+" /puppet-ca/v1"+route.path)
 			}
+			Expect(classify(rec)).NotTo(Equal(deniedByMiddleware),
+				"%s %s: the admin certificate should reach the mux, so a denial here means this "+
+					"spec has stopped testing registration (code=%d body=%q)",
+				route.method, route.path, rec.Code, strings.TrimSpace(rec.Body.String()))
 		}
 		Expect(missing).To(BeEmpty(),
 			"these prefixed paths returned 404, so the prefix is no longer registered "+

--- a/internal/api/authbaseline_test.go
+++ b/internal/api/authbaseline_test.go
@@ -105,8 +105,11 @@ import (
 //
 // Keep them in step: a tier change should move a row in both, for the routes
 // both cover. /expirations, /certificate_renewal, /certificate_statuses and
-// POST /ocsp have a row here and no entry there, so for those four this file is
-// the only anchor.
+// POST /ocsp have a row here and no entry in that table. /certificate_statuses
+// is still anchored elsewhere in the same file, by an admin-tier 403 spec; for
+// the other three this file is the only authorisation anchor in the repo. The
+// functional suites that exercise those paths (api_test.go, ocsp_test.go)
+// install no AuthConfig, so no middleware runs in them.
 //
 // docs/api.md#authorization-tiers publishes the *tier assignment* to operators.
 // It is a four-row tier table, not this matrix: a change that moves a route

--- a/internal/api/authbaseline_test.go
+++ b/internal/api/authbaseline_test.go
@@ -316,7 +316,7 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				"own-ca-expired": false, "own-ca-revoked": false, "own-ca-server-eku": false,
 				"own-ca-pp-cli-auth-false": false, "foreign-ca": false,
 			},
-			fingerprint: "20efd5d41098722c",
+			fingerprint: "3bcba69ca8f399d0",
 		},
 		{
 			name: "public: fetch the CRL", method: "GET", path: "/certificate_revocation_list/ca",
@@ -326,7 +326,7 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				"own-ca-expired": false, "own-ca-revoked": false, "own-ca-server-eku": false,
 				"own-ca-pp-cli-auth-false": false, "foreign-ca": false,
 			},
-			fingerprint: "20efd5d41098722c",
+			fingerprint: "3bcba69ca8f399d0",
 		},
 		{
 			name: "public: submit a CSR", method: "PUT", path: "/certificate_request/newnode",
@@ -336,7 +336,7 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				"own-ca-expired": false, "own-ca-revoked": false, "own-ca-server-eku": false,
 				"own-ca-pp-cli-auth-false": false, "foreign-ca": false,
 			},
-			fingerprint: "20efd5d41098722c",
+			fingerprint: "3bcba69ca8f399d0",
 		},
 		{
 			// Has its own branch in the classifier rather than sharing one with
@@ -353,7 +353,7 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				"own-ca-expired": false, "own-ca-revoked": false, "own-ca-server-eku": false,
 				"own-ca-pp-cli-auth-false": false, "foreign-ca": false,
 			},
-			fingerprint: "20efd5d41098722c",
+			fingerprint: "3bcba69ca8f399d0",
 		},
 		{
 			// Any certificate that chains to our trust anchor is admitted, with
@@ -366,7 +366,7 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				"own-ca-expired": true, "own-ca-revoked": true, "own-ca-server-eku": true,
 				"own-ca-pp-cli-auth-false": false, "foreign-ca": true,
 			},
-			fingerprint: "bca6da2164bcceeb",
+			fingerprint: "7b88a295696eaeb4",
 		},
 		{
 			name: "any-client: renew own certificate", method: "POST", path: "/certificate_renewal",
@@ -376,7 +376,7 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				"own-ca-expired": true, "own-ca-revoked": true, "own-ca-server-eku": true,
 				"own-ca-pp-cli-auth-false": false, "foreign-ca": true,
 			},
-			fingerprint: "bca6da2164bcceeb",
+			fingerprint: "7b88a295696eaeb4",
 		},
 		{
 			// Self-match: the CN must equal the path subject, or the caller must
@@ -388,7 +388,7 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				"own-ca-expired": true, "own-ca-revoked": true, "own-ca-server-eku": true,
 				"own-ca-pp-cli-auth-false": true, "foreign-ca": true,
 			},
-			fingerprint: "97f9f0c0deb8b53d",
+			fingerprint: "b4ffeb18bcb22e6c",
 		},
 		{
 			name: "self-or-admin: read another node's CSR", method: "GET", path: "/certificate_request/othernode",
@@ -398,7 +398,7 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				"own-ca-expired": true, "own-ca-revoked": true, "own-ca-server-eku": true,
 				"own-ca-pp-cli-auth-false": true, "foreign-ca": true,
 			},
-			fingerprint: "a5e45fefd4a8d0ef",
+			fingerprint: "6c242f7acc06b28c",
 		},
 		{
 			name: "admin: list all statuses", method: "GET", path: "/certificate_statuses/all",
@@ -408,7 +408,7 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				"own-ca-expired": true, "own-ca-revoked": true, "own-ca-server-eku": true,
 				"own-ca-pp-cli-auth-false": true, "foreign-ca": true,
 			},
-			fingerprint: "a5e45fefd4a8d0ef",
+			fingerprint: "6c242f7acc06b28c",
 		},
 		{
 			name: "admin: sign all pending", method: "POST", path: "/sign/all",
@@ -418,7 +418,7 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				"own-ca-expired": true, "own-ca-revoked": true, "own-ca-server-eku": true,
 				"own-ca-pp-cli-auth-false": true, "foreign-ca": true,
 			},
-			fingerprint: "a5e45fefd4a8d0ef",
+			fingerprint: "6c242f7acc06b28c",
 		},
 		{
 			name: "admin: reissue the CRL", method: "PUT", path: "/certificate_revocation_list/ca",
@@ -428,7 +428,7 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				"own-ca-expired": true, "own-ca-revoked": true, "own-ca-server-eku": true,
 				"own-ca-pp-cli-auth-false": true, "foreign-ca": true,
 			},
-			fingerprint: "a5e45fefd4a8d0ef",
+			fingerprint: "6c242f7acc06b28c",
 		},
 	}
 
@@ -533,39 +533,32 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 	// Without this, editing a recorded cell and leaving changedBy empty was a
 	// green suite: nothing retained the original values, so no assertion could
 	// tell a deliberate change from a silent one. The digest is that retained
-	// copy, in one line per row.
+	// copy, in one line per row, and it covers changedBy as well as the outcomes
+	// so that re-attributing a later change to an earlier one also fails.
+	//
+	// Note that adding a client class changes every row's digest, because every
+	// row then records one more outcome. That is intended — each row genuinely
+	// carries new information — so such a commit updates all of them, and one
+	// changedBy naming the class is the right entry.
 	It("requires a changed row to say what changed it", func() {
-		var undocumented []string
+		var drifted []string
 		for _, route := range routes {
-			got := fingerprintDenied(route.denied)
+			got := fingerprintRow(route)
 			if got == route.fingerprint {
 				continue
 			}
+			what := "its recorded outcomes have been edited"
 			if route.changedBy == "" {
-				undocumented = append(undocumented, fmt.Sprintf(
-					"  %q: recorded outcomes have been edited but changedBy is empty.\n"+
-						"    Set changedBy to the change that did it, and update fingerprint to %q.",
-					route.name, got))
+				what += " and changedBy is empty"
 			}
+			drifted = append(drifted, fmt.Sprintf(
+				"  %q: %s.\n    Set changedBy to the change responsible; with the changedBy you have "+
+					"now, fingerprint should be %q.", route.name, what, got))
 		}
-		Expect(undocumented).To(BeEmpty(),
-			"the recorded baseline was edited without saying why:\n%s\n\n"+
+		Expect(drifted).To(BeEmpty(),
+			"the recorded baseline drifted from its provenance:\n%s\n\n"+
 				"That distinction — deliberate versus accidental — is what this table is for.",
-			strings.Join(undocumented, "\n"))
-	})
-
-	It("keeps every fingerprint in step with the row it digests", func() {
-		// The other half: a row whose fingerprint is stale (updated outcomes,
-		// updated changedBy, forgotten digest) would silently stop enforcing.
-		var stale []string
-		for _, route := range routes {
-			if got := fingerprintDenied(route.denied); got != route.fingerprint && route.changedBy != "" {
-				stale = append(stale, fmt.Sprintf("  %q: set fingerprint to %q", route.name, got))
-			}
-		}
-		Expect(stale).To(BeEmpty(),
-			"these rows changed and were documented, but their fingerprints were not "+
-				"updated, so the next edit would go unnoticed:\n%s", strings.Join(stale, "\n"))
+			strings.Join(drifted, "\n"))
 	})
 
 	// The table above cannot tell "denied by the middleware" from "this path is
@@ -616,13 +609,22 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 			req = withClientCert(req, clientCertFromKey(adminKey, "puppet-server", caCert, caKey, false, false))
 			rec := httptest.NewRecorder()
 			scratchMux.ServeHTTP(rec, req)
-			// A bare 404 is ambiguous: the handlers return one for an absent
-			// subject, which several of these routes legitimately do against a
-			// scratch store. Go's ServeMux writes its own body for a path it has
-			// no pattern for, and that is the one that means "unregistered".
-			if rec.Code == http.StatusNotFound &&
-				strings.Contains(rec.Body.String(), "404 page not found") {
-				missing = append(missing, "  "+route.method+" /puppet-ca/v1"+route.path)
+			// Two ways the mux reports "no such registration", and both matter.
+			// A bare 404 is ambiguous, because the handlers return one for an
+			// absent subject, which several of these routes legitimately do
+			// against a scratch store — so only Go's own mux body counts. And
+			// since Go 1.22 a path that matches some pattern but not for this
+			// method yields 405, not 404. Seven of these rows share a path with
+			// another method, so without the 405 clause dropping one of them
+			// from Routes() would be invisible: non-admins are denied before
+			// routing and admins get a non-403 that classify reads as admitted.
+			switch {
+			case rec.Code == http.StatusMethodNotAllowed:
+				missing = append(missing,
+					"  "+route.method+" /puppet-ca/v1"+route.path+" (path registered, method is not)")
+			case rec.Code == http.StatusNotFound &&
+				strings.Contains(rec.Body.String(), "404 page not found"):
+				missing = append(missing, "  "+route.method+" /puppet-ca/v1"+route.path+" (path not registered)")
 			}
 			Expect(classify(rec)).NotTo(Equal(deniedByMiddleware),
 				"%s %s: the admin certificate should reach the mux, so a denial here means this "+
@@ -702,7 +704,11 @@ var expectedRoutes = []string{
 // fingerprintDenied digests a row's recorded outcomes. Sorted so it does not
 // depend on map iteration order, and truncated because it only has to detect a
 // change, not resist an adversary.
-func fingerprintDenied(denied map[string]bool) string {
+func fingerprintRow(r routeCase) string {
+	return fingerprintDenied(r.denied, r.changedBy)
+}
+
+func fingerprintDenied(denied map[string]bool, changedBy string) string {
 	names := make([]string, 0, len(denied))
 	for name := range denied {
 		names = append(names, name)
@@ -713,6 +719,12 @@ func fingerprintDenied(denied map[string]bool) string {
 	for _, name := range names {
 		fmt.Fprintf(h, "%s=%v;", name, denied[name])
 	}
+	// changedBy is part of the digest, not checked separately against "". If it
+	// were separate, the gate would only ever catch a row's *first* undocumented
+	// edit: once any provenance was recorded, a later change could edit outcomes,
+	// leave the stale attribution in place, refresh the digest as the failure
+	// message instructs, and go green — crediting the new change to the old one.
+	fmt.Fprintf(h, "by=%s", changedBy)
 	return hex.EncodeToString(h.Sum(nil))[:16]
 }
 

--- a/internal/api/authbaseline_test.go
+++ b/internal/api/authbaseline_test.go
@@ -659,9 +659,15 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				// reason the rest of this rests on — a blanked baseline: line is
 				// exactly as loud in a diff as a replaced one, and no honest
 				// change to an existing row produces either.
+				// Computed with changedBy cleared, because that is the state the
+				// message tells the author to arrive at. Printing a fingerprint
+				// that folds in a changedBy they are about to remove would hand
+				// them a value that stops matching the moment they comply.
+				fresh := route
+				fresh.changedBy = ""
 				unrecorded = append(unrecorded, fmt.Sprintf(
 					"  %q:\n\t\t\tfingerprint: %q,\n\t\t\tbaseline:    %q,",
-					route.name, rowDigest(route, true), rowDigest(route, false)))
+					route.name, rowDigest(fresh, true), rowDigest(fresh, false)))
 			case rowDigest(route, false) != route.baseline && route.changedBy == "":
 				unattributed = append(unattributed, fmt.Sprintf(
 					"  %q: its recorded outcomes differ from the originally committed ones, "+
@@ -685,6 +691,13 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 		// also trips it.
 		var drifted []string
 		for _, route := range routes {
+			if route.baseline == "" {
+				// A brand-new row. The spec above owns that case and prints both
+				// literals; without this arm the two specs disagree, and this
+				// one's "set changedBy first" is precisely what the other exists
+				// to talk an author out of.
+				continue
+			}
 			got := rowDigest(route, true)
 			if got == route.fingerprint {
 				continue
@@ -856,8 +869,9 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				unexpired(c)
 				clientAuth(c)
 				noPpCliAuth(c)
-				Expect(adminAllowList).To(HaveKey(c.Subject.CommonName),
-					"admin by allow-list alone, so the CN must be in the allow list")
+				Expect(adminAllowList).To(HaveKeyWithValue(c.Subject.CommonName, true),
+					"admin by allow-list alone, so the CN must be allow-listed with a true value — "+
+						"isAdmin reads the value, not just the key")
 			},
 			"own-ca-pp-cli-auth": func(c *x509.Certificate) {
 				ours(c)
@@ -876,7 +890,7 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				value, present := ppCliAuthValue(c)
 				Expect(present).To(BeTrue())
 				Expect(value).To(Equal("true"))
-				Expect(adminAllowList).To(HaveKey(c.Subject.CommonName),
+				Expect(adminAllowList).To(HaveKeyWithValue(c.Subject.CommonName, true),
 					"admin by both routes at once is the point of this class")
 			},
 			"own-ca-expired": func(c *x509.Certificate) {
@@ -995,9 +1009,6 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 	})
 })
 
-// expectedClientClasses and expectedRoutes pin the shape of the matrix. They
-// exist so that removing a fixture is a deliberate edit to a named list rather
-// than an invisible reduction in what the oracle covers.
 // adminAllowList is the allow list every server in this file is configured
 // with. Shared so the fixture-property spec can assert membership of the same
 // map the middleware consults, rather than of a repeated literal — the two
@@ -1005,6 +1016,9 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 // Read-only; nothing here mutates it.
 var adminAllowList = map[string]bool{"puppet-server": true}
 
+// expectedClientClasses and expectedRoutes pin the shape of the matrix. They
+// exist so that removing a fixture is a deliberate edit to a named list rather
+// than an invisible reduction in what the oracle covers.
 var expectedClientClasses = []string{
 	"none",
 	"own-ca-plain",

--- a/internal/api/authbaseline_test.go
+++ b/internal/api/authbaseline_test.go
@@ -1,0 +1,358 @@
+// Copyright (C) 2026 Chris Boot
+// Copyright (C) 2026 Vox Pupuli and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package api_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/voxpupuli/openvox-ca/internal/api"
+	"github.com/voxpupuli/openvox-ca/internal/ca"
+	"github.com/voxpupuli/openvox-ca/internal/storage"
+)
+
+// This file is an authorisation *oracle*, not a feature test.
+//
+// It records, exhaustively, which client certificates the middleware admits to
+// which routes as the code stands today. Later work changes that deliberately
+// in a small number of places — scoping identity claims to the issuing CA,
+// gating renewal on our own certificates, moving certificate_status to
+// admin-only — and the value of this table is that it was written and committed
+// *before* those changes, so it says what the behaviour was rather than what
+// someone later believed it should be.
+//
+// Every row carries an expectChanged flag, currently false everywhere. A change
+// that intends to alter a row flips the flag in the same commit; a change that
+// alters a row without flipping it fails here. That distinction — deliberate
+// versus accidental — is the whole point, and a blanket "nothing changes"
+// assertion could not express it.
+
+// clientClass is one kind of client certificate the middleware might see.
+type clientClass struct {
+	name string
+	// cert is nil for "no client certificate at all".
+	cert *x509.Certificate
+}
+
+// routeCase is one endpoint, with the outcome expected for each client class.
+type routeCase struct {
+	name   string
+	method string
+	path   string
+	// denied maps clientClass.name to whether the middleware rejects it.
+	denied map[string]bool
+	// expectChanged marks rows a later change is permitted to alter. Flip it in
+	// the same commit that changes the behaviour, never before and never after.
+	expectChanged bool
+}
+
+// deniedStatus reports whether code is the middleware's rejection.
+//
+// The middleware answers 403 for every authorisation failure and nothing else
+// does on these routes, so 403 is a reliable signal. Handler-level outcomes
+// (404 for an absent subject, 400 for a malformed body) all mean the request
+// got past authorisation, which is what this table measures.
+func deniedStatus(code int) bool { return code == http.StatusForbidden }
+
+var _ = Describe("Authorisation baseline", Ordered, func() {
+	var (
+		ctx        context.Context
+		myCA       *ca.CA
+		store      *storage.StorageService
+		mux        http.Handler
+		caCert     *x509.Certificate
+		caKey      *rsa.PrivateKey
+		newClasses func() []clientClass
+		selfName   = "agent1"
+	)
+
+	BeforeAll(func() {
+		ctx = context.Background()
+		tmpDir := GinkgoT().TempDir()
+
+		store = storage.New(tmpDir)
+		myCA = ca.New(store, ca.AutosignConfig{Mode: "off"}, "puppet.test")
+		Expect(store.EnsureDirs(ctx)).To(Succeed())
+		Expect(store.SaveCAKey(ctx, cachedKeyPEM)).To(Succeed())
+		Expect(store.SaveCACert(ctx, cachedCrtPEM)).To(Succeed())
+		Expect(store.UpdateCRL(ctx, cachedCrlPEM)).To(Succeed())
+		Expect(store.WriteSerial(ctx, "0001")).To(Succeed())
+		Expect(store.TouchInventory(ctx)).To(Succeed())
+		Expect(myCA.Init(ctx)).To(Succeed())
+
+		block, _ := pem.Decode(cachedCrtPEM)
+		var err error
+		caCert, err = x509.ParseCertificate(block.Bytes)
+		Expect(err).NotTo(HaveOccurred())
+		block, _ = pem.Decode(cachedKeyPEM)
+		caKey, err = x509.ParsePKCS1PrivateKey(block.Bytes)
+		Expect(err).NotTo(HaveOccurred())
+
+		server := api.New(myCA)
+		server.AuthConfig = &api.AuthConfig{
+			CACert:    caCert,
+			AllowList: map[string]bool{"puppet-server": true},
+		}
+		mux = server.Routes()
+
+		// Fresh certificates per route, not one shared set.
+		//
+		// Some routes mutate CA state as a side effect of succeeding: POST
+		// /certificate_renewal reissues the caller's certificate and, because
+		// RevokeOnAutoRenew defaults to true, revokes the one presented. Reusing
+		// certificates across routes therefore makes every later outcome depend
+		// on which earlier routes ran — an oracle that changes its answers based
+		// on evaluation order is worse than no oracle. Minting per route costs a
+		// few key generations and buys independence.
+		newClasses = func() []clientClass {
+			return []clientClass{
+				{name: "none", cert: nil},
+				{name: "own-ca-plain", cert: issueClientCert(selfName, caCert, caKey)},
+				{name: "own-ca-allowlisted", cert: issueClientCert("puppet-server", caCert, caKey)},
+				{name: "own-ca-pp-cli-auth", cert: issueClientCertWithPpCliAuth("cli-user", caCert, caKey)},
+				{name: "own-ca-expired", cert: expiredClientCert("stale", caCert, caKey)},
+				{name: "own-ca-revoked", cert: revokedClientCert(ctx, myCA)},
+				{name: "foreign-ca", cert: foreignClientCert(selfName)},
+			}
+		}
+	})
+
+	// The recorded outcomes. Reading a column top to bottom describes what one
+	// kind of client may do; reading a row describes who may reach one endpoint.
+	routes := []routeCase{
+		{
+			name: "public: fetch the CA certificate", method: "GET", path: "/certificate/ca",
+			denied: map[string]bool{
+				"none": false, "own-ca-plain": false, "own-ca-allowlisted": false,
+				"own-ca-pp-cli-auth": false, "own-ca-expired": false,
+				"own-ca-revoked": false, "foreign-ca": false,
+			},
+		},
+		{
+			name: "public: fetch the CRL", method: "GET", path: "/certificate_revocation_list/ca",
+			denied: map[string]bool{
+				"none": false, "own-ca-plain": false, "own-ca-allowlisted": false,
+				"own-ca-pp-cli-auth": false, "own-ca-expired": false,
+				"own-ca-revoked": false, "foreign-ca": false,
+			},
+		},
+		{
+			name: "public: submit a CSR", method: "PUT", path: "/certificate_request/newnode",
+			denied: map[string]bool{
+				"none": false, "own-ca-plain": false, "own-ca-allowlisted": false,
+				"own-ca-pp-cli-auth": false, "own-ca-expired": false,
+				"own-ca-revoked": false, "foreign-ca": false,
+			},
+		},
+		{
+			// Any certificate that chains to our trust anchor is admitted, with
+			// no check that the subject matches the caller. Scoped to our own CA
+			// only because ours is the only issuer configured today.
+			name: "any-client: read a certificate status", method: "GET", path: "/certificate_status/somenode",
+			denied: map[string]bool{
+				"none": true, "own-ca-plain": false, "own-ca-allowlisted": false,
+				"own-ca-pp-cli-auth": false, "own-ca-expired": true,
+				"own-ca-revoked": true, "foreign-ca": true,
+			},
+		},
+		{
+			name: "any-client: renew own certificate", method: "POST", path: "/certificate_renewal",
+			denied: map[string]bool{
+				"none": true, "own-ca-plain": false, "own-ca-allowlisted": false,
+				"own-ca-pp-cli-auth": false, "own-ca-expired": true,
+				"own-ca-revoked": true, "foreign-ca": true,
+			},
+		},
+		{
+			// Self-match: the CN must equal the path subject, or the caller must
+			// be an admin.
+			name: "self-or-admin: read own CSR", method: "GET", path: "/certificate_request/" + selfName,
+			denied: map[string]bool{
+				"none": true, "own-ca-plain": false, "own-ca-allowlisted": false,
+				"own-ca-pp-cli-auth": false, "own-ca-expired": true,
+				"own-ca-revoked": true, "foreign-ca": true,
+			},
+		},
+		{
+			name: "self-or-admin: read another node's CSR", method: "GET", path: "/certificate_request/othernode",
+			denied: map[string]bool{
+				"none": true, "own-ca-plain": true, "own-ca-allowlisted": false,
+				"own-ca-pp-cli-auth": false, "own-ca-expired": true,
+				"own-ca-revoked": true, "foreign-ca": true,
+			},
+		},
+		{
+			name: "admin: list all statuses", method: "GET", path: "/certificate_statuses/all",
+			denied: map[string]bool{
+				"none": true, "own-ca-plain": true, "own-ca-allowlisted": false,
+				"own-ca-pp-cli-auth": false, "own-ca-expired": true,
+				"own-ca-revoked": true, "foreign-ca": true,
+			},
+		},
+		{
+			name: "admin: sign all pending", method: "POST", path: "/sign/all",
+			denied: map[string]bool{
+				"none": true, "own-ca-plain": true, "own-ca-allowlisted": false,
+				"own-ca-pp-cli-auth": false, "own-ca-expired": true,
+				"own-ca-revoked": true, "foreign-ca": true,
+			},
+		},
+		{
+			name: "admin: reissue the CRL", method: "PUT", path: "/certificate_revocation_list/ca",
+			denied: map[string]bool{
+				"none": true, "own-ca-plain": true, "own-ca-allowlisted": false,
+				"own-ca-pp-cli-auth": false, "own-ca-expired": true,
+				"own-ca-revoked": true, "foreign-ca": true,
+			},
+		},
+	}
+
+	It("records the outcome of every client class against every route", func() {
+		for _, route := range routes {
+			for _, class := range newClasses() {
+				want, ok := route.denied[class.name]
+				Expect(ok).To(BeTrue(),
+					"route %q has no recorded outcome for client class %q; every combination must be stated",
+					route.name, class.name)
+
+				req := httptest.NewRequest(route.method, route.path, strings.NewReader(""))
+				if class.cert != nil {
+					req = withClientCert(req, class.cert)
+				}
+				rec := httptest.NewRecorder()
+				mux.ServeHTTP(rec, req)
+
+				got := deniedStatus(rec.Code)
+				if route.expectChanged {
+					// A row flagged as intentionally changed is exercised but not
+					// asserted here; the commit that flips the flag owns the new
+					// expectation and asserts it directly.
+					continue
+				}
+				Expect(got).To(Equal(want),
+					"route %q, client %q: recorded denied=%v but got denied=%v (HTTP %d).\n"+
+						"If this change is intended, set expectChanged on the row in the same commit.",
+					route.name, class.name, want, got, rec.Code)
+			}
+		}
+	})
+
+	It("states an outcome for every route and client class", func() {
+		// Guards the table itself: a route added without outcomes, or a client
+		// class added without extending every route, would otherwise silently
+		// test less than it appears to.
+		want := len(newClasses())
+		for _, route := range routes {
+			Expect(route.denied).To(HaveLen(want),
+				"route %q records %d outcomes but there are %d client classes",
+				route.name, len(route.denied), want)
+		}
+	})
+})
+
+// expiredClientCert issues a certificate that expired an hour ago.
+func expiredClientCert(cn string, caCert *x509.Certificate, caKey *rsa.PrivateKey) *x509.Certificate {
+	GinkgoHelper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	Expect(err).NotTo(HaveOccurred())
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-2 * time.Hour),
+		NotAfter:     time.Now().Add(-1 * time.Hour),
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
+	Expect(err).NotTo(HaveOccurred())
+	cert, err := x509.ParseCertificate(der)
+	Expect(err).NotTo(HaveOccurred())
+	return cert
+}
+
+// revokedClientCert issues a certificate through the CA and then revokes it, so
+// it is genuinely present in the CRL rather than merely absent from storage.
+func revokedClientCert(ctx context.Context, myCA *ca.CA) *x509.Certificate {
+	GinkgoHelper()
+	// A distinct subject each time: Generate refuses to reissue for a subject
+	// that already holds a valid certificate.
+	cn := fmt.Sprintf("revoked%d", time.Now().UnixNano())
+	res, err := myCA.Generate(ctx, cn, nil)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(myCA.Revoke(ctx, cn)).To(Succeed())
+
+	block, _ := pem.Decode(res.CertificatePEM)
+	Expect(block).NotTo(BeNil())
+	cert, err := x509.ParseCertificate(block.Bytes)
+	Expect(err).NotTo(HaveOccurred())
+	return cert
+}
+
+// foreignClientCert issues a certificate from an unrelated CA, carrying a CN
+// this CA's own namespace also uses. Today it is rejected because that CA is
+// not a trust anchor; the CN collision is what makes the row meaningful once
+// more than one issuer can be trusted.
+func foreignClientCert(cn string) *x509.Certificate {
+	GinkgoHelper()
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	Expect(err).NotTo(HaveOccurred())
+
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Unrelated CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	Expect(err).NotTo(HaveOccurred())
+	foreignCA, err := x509.ParseCertificate(caDER)
+	Expect(err).NotTo(HaveOccurred())
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	Expect(err).NotTo(HaveOccurred())
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, foreignCA, &leafKey.PublicKey, caKey)
+	Expect(err).NotTo(HaveOccurred())
+	leaf, err := x509.ParseCertificate(leafDER)
+	Expect(err).NotTo(HaveOccurred())
+	return leaf
+}

--- a/internal/api/authbaseline_test.go
+++ b/internal/api/authbaseline_test.go
@@ -65,9 +65,9 @@ import (
 // changedBy is documentation, not an exemption. An earlier draft carried a
 // boolean that skipped assertion for flagged rows, which would have left
 // exactly the rows under active change as the only unasserted ones — and on
-// `GET /certificate_status/{subject}`, where one cell of seven moves, it would
-// have silently retired the foreign-issuer, expired and revoked cells on the
-// very route being restructured.
+// `GET /certificate_status/{subject}`, where three cells of eleven move, it
+// would have silently retired the foreign-issuer, expired and revoked cells on
+// the very route being restructured.
 //
 // Scope, stated plainly so nobody mistakes this for total coverage:
 //
@@ -82,7 +82,9 @@ import (
 //   - Only denials emitted by the *middleware*. A handler that refuses with its
 //     own 403 is recorded as "got past authorisation", because that is what it
 //     is. Of the three changes named above, that makes certificate_status
-//     unconditionally observable here; renewal gating only if it lands in the
+//     observable here if it lands as a tier change — but not if it lands as a
+//     404, for which see the status-code dimension left open at classify;
+//     renewal gating only if it lands in the
 //     middleware rather than in handlePostCertificateRenewal, where the route's
 //     existing refusals live; and issuer-scoping not at all through the
 //     foreign-CA row, since this fixture's CA stays unconfigured as a second
@@ -113,17 +115,38 @@ type routeCase struct {
 	path   string
 	// denied maps clientClass.name to whether the middleware rejects it.
 	denied map[string]bool
-	// fingerprint is a digest of the denied map as first recorded. It is what
-	// makes changedBy enforceable rather than advisory: editing a cell changes
-	// the digest, and the spec then requires changedBy to be set in the same
-	// commit. Without it nothing distinguished a deliberate change from a
-	// silent one, because no copy of the original values was retained
-	// anywhere — the header claimed that distinction was "the whole point"
-	// while nothing implemented it.
+	// fingerprint is a digest of the denied map and changedBy as last recorded.
+	// It is the retained copy that lets the suite tell a deliberate change from
+	// a silent one; without it nothing distinguished them, because no record of
+	// the previous values existed anywhere.
+	//
+	// Be precise about what the pair does, because two earlier versions of this
+	// comment claimed more than the code delivered.
+	//
+	// Enforced, permanently: a row whose outcomes have ever moved from the
+	// originally committed ones must name a responsible change. baseline is
+	// never refreshed, so there is no literal to edit that discharges this —
+	// unlike the first attempt, where refreshing the digest silenced it.
+	//
+	// Enforced, per commit: no cell moves without a second, deliberate edit to
+	// the fingerprint line, which is visible in the diff. Provenance is inside
+	// that digest, so re-attributing a later change to an earlier one trips it
+	// too, rather than going inert once a row has changed once.
+	//
+	// Not enforced: whether the changedBy text is *accurate*. Nothing can tell
+	// that a row now names the wrong change. That is a review obligation, and
+	// the point of these two is to put it in front of a reviewer.
 	fingerprint string
 	// changedBy names the change that last altered this row's outcomes, empty
 	// for rows still at their originally recorded values.
 	changedBy string
+	// baseline digests the endpoint and outcomes as first committed, without
+	// provenance. It is never refreshed — that is the point. Any row whose
+	// outcomes have ever moved therefore differs from it permanently, so the
+	// requirement to name a responsible change cannot be discharged by editing a
+	// literal. fingerprint answers "was this edit deliberate"; baseline answers
+	// "has this row ever moved", and only the second can be asked forever.
+	baseline string
 }
 
 // handler403Bodies are the 403s the *handlers* emit, as opposed to the
@@ -258,8 +281,9 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 		// The *keys*, though, are generated once and reused. What must be fresh
 		// is the certificate — its serial is what the CRL names — and RSA key
 		// generation is the whole cost of minting one. Re-minting per route with
-		// cached keys keeps the independence and takes the matrix from ~250
-		// RSA-2048 generations to four. The CA-issued and revoked fixtures go
+		// cached keys keeps the independence and takes the matrix from ~160
+		// RSA-2048 generations to four (seven of the eleven classes draw from
+		// the pool; the other four are keyless or ECDSA). The CA-issued and revoked fixtures go
 		// through myCA.Generate, so they are ECDSA P-256 by virtue of the
 		// LeafKeyConfig set above; the foreign fixture generates its own CA and
 		// leaf, also P-256. None is worth pooling at that cost.
@@ -316,7 +340,8 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				"own-ca-expired": false, "own-ca-revoked": false, "own-ca-server-eku": false,
 				"own-ca-pp-cli-auth-false": false, "foreign-ca": false,
 			},
-			fingerprint: "3bcba69ca8f399d0",
+			fingerprint: "23628229767a2378",
+			baseline:    "8afc7a5fa37545dc",
 		},
 		{
 			name: "public: fetch the CRL", method: "GET", path: "/certificate_revocation_list/ca",
@@ -326,7 +351,8 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				"own-ca-expired": false, "own-ca-revoked": false, "own-ca-server-eku": false,
 				"own-ca-pp-cli-auth-false": false, "foreign-ca": false,
 			},
-			fingerprint: "3bcba69ca8f399d0",
+			fingerprint: "312c3e08f991cd3c",
+			baseline:    "0764b50dcaf3e3a4",
 		},
 		{
 			name: "public: submit a CSR", method: "PUT", path: "/certificate_request/newnode",
@@ -336,7 +362,8 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				"own-ca-expired": false, "own-ca-revoked": false, "own-ca-server-eku": false,
 				"own-ca-pp-cli-auth-false": false, "foreign-ca": false,
 			},
-			fingerprint: "3bcba69ca8f399d0",
+			fingerprint: "d02baba4850135c7",
+			baseline:    "9f56b7fa5cfd0a0b",
 		},
 		{
 			// Has its own branch in the classifier rather than sharing one with
@@ -353,7 +380,8 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				"own-ca-expired": false, "own-ca-revoked": false, "own-ca-server-eku": false,
 				"own-ca-pp-cli-auth-false": false, "foreign-ca": false,
 			},
-			fingerprint: "3bcba69ca8f399d0",
+			fingerprint: "0383bfa6921981a9",
+			baseline:    "b77de287975a13ee",
 		},
 		{
 			// Any certificate that chains to our trust anchor is admitted, with
@@ -366,7 +394,8 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				"own-ca-expired": true, "own-ca-revoked": true, "own-ca-server-eku": true,
 				"own-ca-pp-cli-auth-false": false, "foreign-ca": true,
 			},
-			fingerprint: "7b88a295696eaeb4",
+			fingerprint: "50f0635abf97ff03",
+			baseline:    "ceb90b2e2a7b4481",
 		},
 		{
 			name: "any-client: renew own certificate", method: "POST", path: "/certificate_renewal",
@@ -376,7 +405,8 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				"own-ca-expired": true, "own-ca-revoked": true, "own-ca-server-eku": true,
 				"own-ca-pp-cli-auth-false": false, "foreign-ca": true,
 			},
-			fingerprint: "7b88a295696eaeb4",
+			fingerprint: "f8ccf600945d4713",
+			baseline:    "fb886df81021f5dc",
 		},
 		{
 			// Self-match: the CN must equal the path subject, or the caller must
@@ -388,7 +418,8 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				"own-ca-expired": true, "own-ca-revoked": true, "own-ca-server-eku": true,
 				"own-ca-pp-cli-auth-false": true, "foreign-ca": true,
 			},
-			fingerprint: "b4ffeb18bcb22e6c",
+			fingerprint: "9ed2a7448b79fd43",
+			baseline:    "1e5309144d9f7eb5",
 		},
 		{
 			name: "self-or-admin: read another node's CSR", method: "GET", path: "/certificate_request/othernode",
@@ -398,7 +429,8 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				"own-ca-expired": true, "own-ca-revoked": true, "own-ca-server-eku": true,
 				"own-ca-pp-cli-auth-false": true, "foreign-ca": true,
 			},
-			fingerprint: "6c242f7acc06b28c",
+			fingerprint: "b0ab430df60f9374",
+			baseline:    "b00be875b450b375",
 		},
 		{
 			name: "admin: list all statuses", method: "GET", path: "/certificate_statuses/all",
@@ -408,7 +440,8 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				"own-ca-expired": true, "own-ca-revoked": true, "own-ca-server-eku": true,
 				"own-ca-pp-cli-auth-false": true, "foreign-ca": true,
 			},
-			fingerprint: "6c242f7acc06b28c",
+			fingerprint: "86782f93aa9620d3",
+			baseline:    "3c6c2b41a06a003d",
 		},
 		{
 			name: "admin: sign all pending", method: "POST", path: "/sign/all",
@@ -418,7 +451,8 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				"own-ca-expired": true, "own-ca-revoked": true, "own-ca-server-eku": true,
 				"own-ca-pp-cli-auth-false": true, "foreign-ca": true,
 			},
-			fingerprint: "6c242f7acc06b28c",
+			fingerprint: "aa15b530c895d58e",
+			baseline:    "dafb6d11e0b2bd1b",
 		},
 		{
 			name: "admin: reissue the CRL", method: "PUT", path: "/certificate_revocation_list/ca",
@@ -428,7 +462,8 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				"own-ca-expired": true, "own-ca-revoked": true, "own-ca-server-eku": true,
 				"own-ca-pp-cli-auth-false": true, "foreign-ca": true,
 			},
-			fingerprint: "6c242f7acc06b28c",
+			fingerprint: "eab32b2174903242",
+			baseline:    "2429990f643028ba",
 		},
 	}
 
@@ -540,25 +575,51 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 	// row then records one more outcome. That is intended — each row genuinely
 	// carries new information — so such a commit updates all of them, and one
 	// changedBy naming the class is the right entry.
-	It("requires a changed row to say what changed it", func() {
+
+	It("will not let a moved row go unattributed", func() {
+		// baseline is never refreshed, so this holds for the life of the row: if
+		// its outcomes have ever moved from what was first committed, it must
+		// name the change responsible. Unlike the fingerprint below, there is no
+		// literal to update that would discharge it.
+		var unattributed []string
+		for _, route := range routes {
+			if rowDigest(route, false) != route.baseline && route.changedBy == "" {
+				unattributed = append(unattributed, fmt.Sprintf(
+					"  %q: its recorded outcomes differ from the originally committed ones, "+
+						"but changedBy is empty.", route.name))
+			}
+		}
+		Expect(unattributed).To(BeEmpty(),
+			"a row moved without saying what moved it:\n%s\n\n"+
+				"Set changedBy to the change responsible. Do not update baseline — it is the "+
+				"record of where the row started.", strings.Join(unattributed, "\n"))
+	})
+
+	It("catches any edit to a recorded outcome or its attribution", func() {
+		// The tripwire: no cell moves without a second, deliberate edit to the
+		// fingerprint line in the same commit, visible in the diff. Provenance is
+		// inside this digest so re-attributing a later change to an earlier one
+		// also trips it.
 		var drifted []string
 		for _, route := range routes {
-			got := fingerprintRow(route)
+			got := rowDigest(route, true)
 			if got == route.fingerprint {
 				continue
 			}
-			what := "its recorded outcomes have been edited"
 			if route.changedBy == "" {
-				what += " and changedBy is empty"
+				// Withholding the digest deliberately: printing the value
+				// computed from an empty changedBy would be describing how to
+				// bypass the spec above.
+				drifted = append(drifted, fmt.Sprintf(
+					"  %q: edited, and changedBy is empty. Set changedBy first.", route.name))
+				continue
 			}
 			drifted = append(drifted, fmt.Sprintf(
-				"  %q: %s.\n    Set changedBy to the change responsible; with the changedBy you have "+
-					"now, fingerprint should be %q.", route.name, what, got))
+				"  %q: edited. With the changedBy now on the row, set fingerprint to %q.",
+				route.name, got))
 		}
 		Expect(drifted).To(BeEmpty(),
-			"the recorded baseline drifted from its provenance:\n%s\n\n"+
-				"That distinction — deliberate versus accidental — is what this table is for.",
-			strings.Join(drifted, "\n"))
+			"the recorded baseline drifted from its provenance:\n%s", strings.Join(drifted, "\n"))
 	})
 
 	// The table above cannot tell "denied by the middleware" from "this path is
@@ -701,30 +762,32 @@ var expectedRoutes = []string{
 	"admin: reissue the CRL",
 }
 
-// fingerprintDenied digests a row's recorded outcomes. Sorted so it does not
-// depend on map iteration order, and truncated because it only has to detect a
-// change, not resist an adversary.
-func fingerprintRow(r routeCase) string {
-	return fingerprintDenied(r.denied, r.changedBy)
-}
-
-func fingerprintDenied(denied map[string]bool, changedBy string) string {
-	names := make([]string, 0, len(denied))
-	for name := range denied {
+// rowDigest hashes what a row records. Sorted so it does not depend on map
+// iteration order, and truncated because it only has to detect a change, not
+// resist an adversary. withProvenance selects the two uses:
+// fingerprint covers changedBy so provenance and outcomes cannot drift apart,
+// while baseline omits it so it stays fixed at the originally recorded values
+// however many times the row is later attributed.
+//
+// The endpoint is included because it is part of what the row records. Without
+// it, repointing a row at a different endpoint in the same tier left every cell
+// and the digest valid — so a route could leave the matrix silently while its
+// pinned name stayed put.
+func rowDigest(r routeCase, withProvenance bool) string {
+	names := make([]string, 0, len(r.denied))
+	for name := range r.denied {
 		names = append(names, name)
 	}
 	sort.Strings(names)
 
 	h := sha256.New()
+	fmt.Fprintf(h, "%s %s;", r.method, r.path)
 	for _, name := range names {
-		fmt.Fprintf(h, "%s=%v;", name, denied[name])
+		fmt.Fprintf(h, "%s=%v;", name, r.denied[name])
 	}
-	// changedBy is part of the digest, not checked separately against "". If it
-	// were separate, the gate would only ever catch a row's *first* undocumented
-	// edit: once any provenance was recorded, a later change could edit outcomes,
-	// leave the stale attribution in place, refresh the digest as the failure
-	// message instructs, and go green — crediting the new change to the old one.
-	fmt.Fprintf(h, "by=%s", changedBy)
+	if withProvenance {
+		fmt.Fprintf(h, "by=%s", r.changedBy)
+	}
 	return hex.EncodeToString(h.Sum(nil))[:16]
 }
 

--- a/internal/api/authbaseline_test.go
+++ b/internal/api/authbaseline_test.go
@@ -96,12 +96,17 @@ import (
 //     narrowing admin authority — covered in their own Describe rather than by
 //     multiplying every row.
 //
-// A second, overlapping oracle lives in auth_test.go ("lookupTier classification"),
-// which drives lookupTier directly rather than through the mux. That one pins
-// tier assignment; this one pins the observable HTTP outcome. Keep them in
-// step: a tier change should move a row in both, for the routes both cover —
-// /expirations, /certificate_renewal and /certificate_statuses have a row here
-// and no entry there.
+// A second, overlapping oracle lives in auth_test.go ("lookupTier classification").
+// Both probe the mux — lookupTier is unexported, so neither can call it — but
+// that one infers a route's *tier* from the shape of three probe responses,
+// while this one asserts one recorded cell per client class. Their independence
+// is therefore partial: a change to how the middleware signals refusal blinds
+// both at once, which is what classify's status-code caveat below is about.
+//
+// Keep them in step: a tier change should move a row in both, for the routes
+// both cover. /expirations, /certificate_renewal, /certificate_statuses and
+// POST /ocsp have a row here and no entry there, so for those four this file is
+// the only anchor.
 //
 // docs/api.md#authorization-tiers publishes the *tier assignment* to operators.
 // It is a four-row tier table, not this matrix: a change that moves a route
@@ -138,9 +143,11 @@ type routeCase struct {
 	// failure withholds the computed digest while changedBy is empty, the value
 	// you need cannot be read out of the failure you are trying to silence.
 	//
-	// Enforced against a determined editor: getting a green suite with an empty
-	// changedBy takes recomputing *both* digests offline and pasting two opaque
-	// hex literals. No legitimate change does that.
+	// Enforced against a determined editor: moving a cell and keeping changedBy
+	// empty means replacing *both* hex literals on that row. The only legitimate
+	// reason to write both at once is a brand-new row, which is a visibly
+	// different diff — a row appearing, not a row's outcomes changing, and the
+	// unattributed spec prints both values for exactly that case.
 	//
 	// Not a mechanism, though an earlier version of this comment called it one:
 	// baseline is "never refreshed" by convention. It is a string literal like
@@ -242,8 +249,9 @@ func classify(rec *httptest.ResponseRecorder) denialKind {
 	}
 }
 
-// Ordered/BeforeAll is the only such container in the repo, against the
-// BeforeEach convention in AGENTS.md, and is deliberate on both counts: the
+// The repo's only two Ordered/BeforeAll containers are both in this file (the
+// other is the configuration-axes Describe below), against the
+// BeforeEach convention in AGENTS.md, and are deliberate on both counts: the
 // shared CA and RSA key pool are built once in BeforeAll because rebuilding
 // them per spec costs minutes, and ContinueOnFailure (which requires Ordered)
 // is what makes a change that moves several cells report all of them rather
@@ -291,7 +299,7 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 		server := api.New(myCA)
 		server.AuthConfig = &api.AuthConfig{
 			CACert:    caCert,
-			AllowList: map[string]bool{"puppet-server": true},
+			AllowList: adminAllowList,
 		}
 		mux = server.Routes()
 
@@ -634,14 +642,36 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 		// its outcomes have ever moved from what was first committed, it must
 		// name the change responsible. Unlike the fingerprint below, no ordinary
 		// edit updates it, so a diff that does is the signal.
-		var unattributed []string
+		var unattributed, unrecorded []string
 		for _, route := range routes {
-			if rowDigest(route, false) != route.baseline && route.changedBy == "" {
+			switch {
+			case route.baseline == "":
+				// A brand-new row, not a moved one. Without this branch the only
+				// way to learn a new row's digests was to set changedBy and read
+				// the fingerprint out of the other spec's failure — which
+				// attributes the row from birth and so retires its baseline layer
+				// permanently, the one thing this pair exists to prevent.
+				// Printing both here makes leaving changedBy empty the easy path
+				// as well as the correct one.
+				//
+				// It does also hand an editor a shortcut: blank a baseline, read
+				// both values back, paste them. That is acceptable for the same
+				// reason the rest of this rests on — a blanked baseline: line is
+				// exactly as loud in a diff as a replaced one, and no honest
+				// change to an existing row produces either.
+				unrecorded = append(unrecorded, fmt.Sprintf(
+					"  %q:\n\t\t\tfingerprint: %q,\n\t\t\tbaseline:    %q,",
+					route.name, rowDigest(route, true), rowDigest(route, false)))
+			case rowDigest(route, false) != route.baseline && route.changedBy == "":
 				unattributed = append(unattributed, fmt.Sprintf(
 					"  %q: its recorded outcomes differ from the originally committed ones, "+
 						"but changedBy is empty.", route.name))
 			}
 		}
+		Expect(unrecorded).To(BeEmpty(),
+			"a new row records no baseline. Paste both literals below and leave changedBy "+
+				"empty — the row has not moved, it has only just been written:\n%s",
+			strings.Join(unrecorded, "\n"))
 		Expect(unattributed).To(BeEmpty(),
 			"a row moved without saying what moved it:\n%s\n\n"+
 				"Set changedBy to the change responsible. Do not update baseline — it is the "+
@@ -706,7 +736,7 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 		scratch := api.New(scratchCA)
 		scratch.AuthConfig = &api.AuthConfig{
 			CACert:    caCert,
-			AllowList: map[string]bool{"puppet-server": true},
+			AllowList: adminAllowList,
 		}
 		scratchMux := scratch.Routes()
 		// A fresh admin certificate per route, for the reason the class fixtures
@@ -816,7 +846,7 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				clientAuth(c)
 				noPpCliAuth(c)
 				Expect(c.Subject.CommonName).To(Equal(selfName), "the self-match row turns on this")
-				Expect(c.Subject.CommonName).NotTo(Equal("puppet-server"), "must not be allow-listed")
+				Expect(adminAllowList).NotTo(HaveKey(c.Subject.CommonName), "must not be allow-listed")
 				Expect(inventoryHas(c)).To(BeFalse(),
 					"minted from a template, so its serial must be unknown to the CA — "+
 						"that is what separates it from own-ca-issued")
@@ -826,8 +856,8 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				unexpired(c)
 				clientAuth(c)
 				noPpCliAuth(c)
-				Expect(c.Subject.CommonName).To(Equal("puppet-server"),
-					"admin by allow-list alone, so the CN must be the allow-listed one")
+				Expect(adminAllowList).To(HaveKey(c.Subject.CommonName),
+					"admin by allow-list alone, so the CN must be in the allow list")
 			},
 			"own-ca-pp-cli-auth": func(c *x509.Certificate) {
 				ours(c)
@@ -836,7 +866,7 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				value, present := ppCliAuthValue(c)
 				Expect(present).To(BeTrue())
 				Expect(value).To(Equal("true"))
-				Expect(c.Subject.CommonName).NotTo(Equal("puppet-server"),
+				Expect(adminAllowList).NotTo(HaveKey(c.Subject.CommonName),
 					"admin by extension alone, so the CN must not also be allow-listed")
 			},
 			"own-ca-admin-both": func(c *x509.Certificate) {
@@ -846,14 +876,20 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				value, present := ppCliAuthValue(c)
 				Expect(present).To(BeTrue())
 				Expect(value).To(Equal("true"))
-				Expect(c.Subject.CommonName).To(Equal("puppet-server"),
+				Expect(adminAllowList).To(HaveKey(c.Subject.CommonName),
 					"admin by both routes at once is the point of this class")
 			},
 			"own-ca-expired": func(c *x509.Certificate) {
 				ours(c)
 				clientAuth(c)
-				Expect(c.NotAfter).To(BeTemporally("<", time.Now()),
-					"expiry must be the reason it is denied")
+				Expect(c.NotAfter).To(BeTemporally("<", time.Now()))
+				// The mirror of own-ca-revoked's unexpired() below, and for the
+				// same reason: with two denial reasons at once, relaxing either
+				// check would move no cell. Template-minted serials are unknown
+				// to the CRL today, but that is what this keeps true.
+				revoked, err := myCA.IsRevokedSerial(ctx, c.SerialNumber)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(revoked).To(BeFalse(), "expiry must be the only reason it is denied")
 			},
 			"own-ca-issued": func(c *x509.Certificate) {
 				ours(c)
@@ -892,7 +928,7 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 					"the extension must be present — an absent one would make this a duplicate of own-ca-plain")
 				Expect(value).NotTo(Equal("true"),
 					"present-but-not-true is what distinguishes an equality check from a presence check")
-				Expect(c.Subject.CommonName).NotTo(Equal("puppet-server"),
+				Expect(adminAllowList).NotTo(HaveKey(c.Subject.CommonName),
 					"must not be admin by the allow-list route either")
 			},
 			"foreign-ca": func(c *x509.Certificate) {
@@ -962,6 +998,13 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 // expectedClientClasses and expectedRoutes pin the shape of the matrix. They
 // exist so that removing a fixture is a deliberate edit to a named list rather
 // than an invisible reduction in what the oracle covers.
+// adminAllowList is the allow list every server in this file is configured
+// with. Shared so the fixture-property spec can assert membership of the same
+// map the middleware consults, rather than of a repeated literal — the two
+// drifting apart is exactly how a class stops meaning what it is called.
+// Read-only; nothing here mutates it.
+var adminAllowList = map[string]bool{"puppet-server": true}
+
 var expectedClientClasses = []string{
 	"none",
 	"own-ca-plain",
@@ -1333,7 +1376,7 @@ var _ = Describe("Authorisation baseline: configuration axes", Ordered, Continue
 
 	Describe("allow_public_status", func() {
 		It("denies a client with no certificate when unset", func() {
-			handler := muxWith(&api.AuthConfig{CACert: caCert, AllowList: map[string]bool{"puppet-server": true}})
+			handler := muxWith(&api.AuthConfig{CACert: caCert, AllowList: adminAllowList})
 			Expect(probe(handler, "GET", "/certificate_status/somenode", nil)).To(BeTrue())
 		})
 
@@ -1345,7 +1388,7 @@ var _ = Describe("Authorisation baseline: configuration axes", Ordered, Continue
 			// that the flag no longer does anything.
 			handler := muxWith(&api.AuthConfig{
 				CACert:            caCert,
-				AllowList:         map[string]bool{"puppet-server": true},
+				AllowList:         adminAllowList,
 				AllowPublicStatus: true,
 			})
 			Expect(probe(handler, "GET", "/certificate_status/somenode", nil)).To(BeFalse())
@@ -1354,7 +1397,7 @@ var _ = Describe("Authorisation baseline: configuration axes", Ordered, Continue
 
 	Describe("no_pp_cli_auth", func() {
 		It("grants admin on the pp_cli_auth extension when unset", func() {
-			handler := muxWith(&api.AuthConfig{CACert: caCert, AllowList: map[string]bool{"puppet-server": true}})
+			handler := muxWith(&api.AuthConfig{CACert: caCert, AllowList: adminAllowList})
 			cert := issueClientCertWithPpCliAuth("cli-user", caCert, caKey)
 			Expect(probe(handler, "PUT", "/certificate_revocation_list/ca", cert)).To(BeFalse())
 		})
@@ -1365,7 +1408,7 @@ var _ = Describe("Authorisation baseline: configuration axes", Ordered, Continue
 			// that dropped the flag would move nothing the oracle watches.
 			handler := muxWith(&api.AuthConfig{
 				CACert:      caCert,
-				AllowList:   map[string]bool{"puppet-server": true},
+				AllowList:   adminAllowList,
 				NoPpCliAuth: true,
 			})
 			byExtension := issueClientCertWithPpCliAuth("cli-user", caCert, caKey)

--- a/internal/api/authbaseline_test.go
+++ b/internal/api/authbaseline_test.go
@@ -71,12 +71,13 @@ import (
 //
 // Scope, stated plainly so nobody mistakes this for total coverage:
 //
-//   - 11 rows over 10 of the 19 protocol routes registered by Routes().
+//   - 12 rows over 11 of the 19 protocol routes registered by Routes().
 //     GET /certificate_request/{subject} gets two rows because the self-match is
 //     the only signal separating tierSelfOrAdmin from tierAdminOnly. The three
 //     /healthz/ probes are registered separately and are not among the 19. The
-//     omitted protocol routes are the two OCSP entries and duplicates of a tier
-//     already represented by another row.
+//     eight omitted are GET /ocsp/{request}, which shares its classifier arm
+//     with the POST form covered here, and seven duplicates of tierAdminOnly,
+//     a tier three rows already pin.
 //   - Both the bare and the /puppet-ca/v1-prefixed forms of each path, which
 //     the mux registers separately — see the prefix spec below.
 //   - Only denials emitted by the *middleware*. A handler that refuses with its
@@ -90,16 +91,23 @@ import (
 //     foreign-CA row, since this fixture's CA stays unconfigured as a second
 //     trust anchor (see foreignClientCert). Anything landing in a handler needs
 //     its own anchor in that handler's tests.
-//   - The default AuthConfig, an absent one, plus the two flags that move a tier
-//     (AllowPublicStatus, NoPpCliAuth), covered in their own Describe rather
-//     than by multiplying every row.
+//   - The default AuthConfig, an absent one, plus the two flags that change who
+//     reaches a route — AllowPublicStatus by moving a tier, NoPpCliAuth by
+//     narrowing admin authority — covered in their own Describe rather than by
+//     multiplying every row.
 //
 // A second, overlapping oracle lives in auth_test.go ("lookupTier classification"),
-// which drives lookupTier directly rather than through the mux. The same matrix
-// is published for operators at docs/api.md#authorization-tiers; a row that
-// moves here moves there too. That one pins
+// which drives lookupTier directly rather than through the mux. That one pins
 // tier assignment; this one pins the observable HTTP outcome. Keep them in
-// step: a tier change should move a row in both.
+// step: a tier change should move a row in both, for the routes both cover —
+// /expirations, /certificate_renewal and /certificate_statuses have a row here
+// and no entry there.
+//
+// docs/api.md#authorization-tiers publishes the *tier assignment* to operators.
+// It is a four-row tier table, not this matrix: a change that moves a route
+// between tiers must update it, but most of what moves here — an EKU or
+// pp_cli_auth predicate, an expiry or revocation check — has no counterpart
+// there and needs prose instead.
 
 // clientClass is one kind of client certificate the middleware might see.
 type clientClass struct {
@@ -123,29 +131,40 @@ type routeCase struct {
 	// Be precise about what the pair does, because two earlier versions of this
 	// comment claimed more than the code delivered.
 	//
-	// Enforced, permanently: a row whose outcomes have ever moved from the
-	// originally committed ones must name a responsible change. baseline is
-	// never refreshed, so there is no literal to edit that discharges this —
-	// unlike the first attempt, where refreshing the digest silenced it.
+	// Enforced: no cell moves without a second, deliberate edit to the
+	// fingerprint line, which is visible in the diff. Provenance is inside that
+	// digest, so re-attributing a later change to an earlier one trips it too,
+	// rather than going inert once a row has changed once. And because the
+	// failure withholds the computed digest while changedBy is empty, the value
+	// you need cannot be read out of the failure you are trying to silence.
 	//
-	// Enforced, per commit: no cell moves without a second, deliberate edit to
-	// the fingerprint line, which is visible in the diff. Provenance is inside
-	// that digest, so re-attributing a later change to an earlier one trips it
-	// too, rather than going inert once a row has changed once.
+	// Enforced against a determined editor: getting a green suite with an empty
+	// changedBy takes recomputing *both* digests offline and pasting two opaque
+	// hex literals. No legitimate change does that.
 	//
-	// Not enforced: whether the changedBy text is *accurate*. Nothing can tell
-	// that a row now names the wrong change. That is a review obligation, and
-	// the point of these two is to put it in front of a reviewer.
+	// Not a mechanism, though an earlier version of this comment called it one:
+	// baseline is "never refreshed" by convention. It is a string literal like
+	// any other, and no in-repo literal can be tamper-proof — editing it to the
+	// new rowDigest(route, false) discharges the unattributed spec exactly as
+	// refreshing fingerprint once discharged the round-one gate. What it buys is
+	// that no honest change ever touches a baseline: line, so one in a diff is
+	// worth stopping on.
+	//
+	// Not enforced at all: whether the changedBy text is *accurate*, and whether
+	// each fixture still means what its class name says (see the fixture-property
+	// spec, which pins the latter at one further remove). Those are review
+	// obligations, and the point of all of this is to put them in front of a
+	// reviewer.
 	fingerprint string
 	// changedBy names the change that last altered this row's outcomes, empty
 	// for rows still at their originally recorded values.
 	changedBy string
 	// baseline digests the endpoint and outcomes as first committed, without
-	// provenance. It is never refreshed — that is the point. Any row whose
-	// outcomes have ever moved therefore differs from it permanently, so the
-	// requirement to name a responsible change cannot be discharged by editing a
-	// literal. fingerprint answers "was this edit deliberate"; baseline answers
-	// "has this row ever moved", and only the second can be asked forever.
+	// provenance, and is never refreshed. fingerprint answers "was this edit
+	// deliberate"; baseline answers "has this row ever moved", and only the
+	// second can still be asked once a row has been attributed. Editing it does
+	// silence that question — it is an ordinary literal — but no legitimate
+	// change has any reason to, which is what makes the edit conspicuous.
 	baseline string
 }
 
@@ -223,6 +242,13 @@ func classify(rec *httptest.ResponseRecorder) denialKind {
 	}
 }
 
+// Ordered/BeforeAll is the only such container in the repo, against the
+// BeforeEach convention in AGENTS.md, and is deliberate on both counts: the
+// shared CA and RSA key pool are built once in BeforeAll because rebuilding
+// them per spec costs minutes, and ContinueOnFailure (which requires Ordered)
+// is what makes a change that moves several cells report all of them rather
+// than the first. Specs stay independent regardless — every certificate is
+// re-minted per route, for the reason set out above the key pool.
 var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 	var (
 		ctx        context.Context
@@ -244,7 +270,7 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 		// caIssuedClientCert and revokedClientCert both issue through the CA, so
 		// leaf generation is on the fixture path here and runs twice per class
 		// set. Without this the CA falls back to DefaultLeafKeyConfig, which is
-		// RSA-2048, and the matrix pays for ~46 of them.
+		// RSA-2048, and the matrix pays for ~52 of them.
 		myCA.LeafKeyConfig = ca.KeyConfig{Algo: ca.KeyAlgoECDSA, Size: 256}
 		Expect(store.EnsureDirs(ctx)).To(Succeed())
 		Expect(store.SaveCAKey(ctx, cachedKeyPEM)).To(Succeed())
@@ -281,10 +307,11 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 		// The *keys*, though, are generated once and reused. What must be fresh
 		// is the certificate — its serial is what the CRL names — and RSA key
 		// generation is the whole cost of minting one. Re-minting per route with
-		// cached keys keeps the independence and takes the matrix from ~160
+		// cached keys keeps the independence and takes the matrix from ~180
 		// RSA-2048 generations to four (seven of the eleven classes draw from
-		// the pool; the other four are keyless or ECDSA). The CA-issued and revoked fixtures go
-		// through myCA.Generate, so they are ECDSA P-256 by virtue of the
+		// the pool; the other four are keyless or ECDSA). The CA-issued and
+		// revoked fixtures go through myCA.Generate, so they are ECDSA P-256 by
+		// virtue of the
 		// LeafKeyConfig set above; the foreign fixture generates its own CA and
 		// leaf, also P-256. None is worth pooling at that cost.
 		keyPool := newRSAKeyPool(4)
@@ -295,10 +322,12 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				{name: "own-ca-plain", cert: clientCertFromKey(keyPool[0], selfName, caCert, caKey, false, false)},
 				{name: "own-ca-allowlisted", cert: clientCertFromKey(keyPool[1], "puppet-server", caCert, caKey, false, false)},
 				{name: "own-ca-pp-cli-auth", cert: clientCertFromKey(keyPool[2], "cli-user", caCert, caKey, true, false)},
-				// Admin by both routes at once, which is the shipped topology-A
-				// arrangement: the Puppet Server's own CN is allow-listed and it
-				// also presents pp_cli_auth. It exists to catch a change that
-				// makes the two grants exclusive rather than additive.
+				// Admin by both routes at once, which is the arrangement OpenVox
+				// Server ships with: its own CN is allow-listed and its
+				// certificate also carries pp_cli_auth (see
+				// docs/api.md#admin-credential-resolution). It exists to catch a
+				// change that makes the two grants exclusive rather than
+				// additive.
 				{name: "own-ca-admin-both", cert: clientCertFromKey(keyPool[3], "puppet-server", caCert, caKey, true, false)},
 				{name: "own-ca-expired", cert: clientCertFromKey(keyPool[0], "stale", caCert, caKey, false, true)},
 				// Chain-valid *and* recorded in the CA's inventory, unlike every
@@ -382,6 +411,30 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 			},
 			fingerprint: "0383bfa6921981a9",
 			baseline:    "b77de287975a13ee",
+		},
+		{
+			// OCSP is the one lookupTier arm with no coverage anywhere else, and
+			// the only one that grants a tier without looking at the method, so
+			// the reason the other omissions are safe does not apply: those all
+			// fall through to tierAdminOnly, a tier three rows already pin, and
+			// so cannot move undetected. Drop or reorder this case and both OCSP
+			// entries land in the default arm, locking out every OCSP client —
+			// with, before this row, an entirely green repository. The same
+			// reasoning already earns /expirations a row above.
+			//
+			// An empty body is deliberate: this pins who may reach the handler,
+			// not what it answers, and a malformed request gets there just as a
+			// well-formed one does. ocsp_test.go covers the responses, with no
+			// AuthConfig and so no middleware at all.
+			name: "public: query OCSP", method: "POST", path: "/ocsp",
+			denied: map[string]bool{
+				"none": false, "own-ca-plain": false, "own-ca-allowlisted": false,
+				"own-ca-pp-cli-auth": false, "own-ca-admin-both": false, "own-ca-issued": false,
+				"own-ca-expired": false, "own-ca-revoked": false, "own-ca-server-eku": false,
+				"own-ca-pp-cli-auth-false": false, "foreign-ca": false,
+			},
+			fingerprint: "b8f39578c7d8c805",
+			baseline:    "262bb3133fe936c2",
 		},
 		{
 			// Any certificate that chains to our trust anchor is admitted, with
@@ -577,10 +630,10 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 	// changedBy naming the class is the right entry.
 
 	It("will not let a moved row go unattributed", func() {
-		// baseline is never refreshed, so this holds for the life of the row: if
+		// baseline is not refreshed, so this holds for the life of the row: if
 		// its outcomes have ever moved from what was first committed, it must
-		// name the change responsible. Unlike the fingerprint below, there is no
-		// literal to update that would discharge it.
+		// name the change responsible. Unlike the fingerprint below, no ordinary
+		// edit updates it, so a diff that does is the signal.
 		var unattributed []string
 		for _, route := range routes {
 			if rowDigest(route, false) != route.baseline && route.changedBy == "" {
@@ -629,7 +682,7 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 	// cell satisfied. This pins existence separately.
 	//
 	// It presents the allow-listed admin certificate, because with no
-	// certificate only the four public rows reach the mux at all — the other
+	// certificate only the five public rows reach the mux at all — the other
 	// seven are refused at auth.go before routing, so a 404 could never be
 	// observed for them and those iterations would assert nothing. That was the
 	// first version of this spec, and dropping the prefix still failed it, which
@@ -687,7 +740,12 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 				strings.Contains(rec.Body.String(), "404 page not found"):
 				missing = append(missing, "  "+route.method+" /puppet-ca/v1"+route.path+" (path not registered)")
 			}
-			Expect(classify(rec)).NotTo(Equal(deniedByMiddleware),
+			// Positively admitted, not merely "not a middleware denial": the
+			// latter is also satisfied by unrecognised403, so a change that
+			// added a new middleware denial message would leave every request
+			// here refused and this spec green, testing nothing about
+			// registration — which is the very rot its message claims to catch.
+			Expect(classify(rec)).To(Equal(admitted),
 				"%s %s: the admin certificate should reach the mux, so a denial here means this "+
 					"spec has stopped testing registration (code=%d body=%q)",
 				route.method, route.path, rec.Code, strings.TrimSpace(rec.Body.String()))
@@ -695,6 +753,176 @@ var _ = Describe("Authorisation baseline", Ordered, ContinueOnFailure, func() {
 		Expect(missing).To(BeEmpty(),
 			"these prefixed paths returned 404, so the prefix is no longer registered "+
 				"for them:\n%s", strings.Join(missing, "\n"))
+	})
+
+	It("pins what each client class is, not merely what it is called", func() {
+		// The digests bind what a row *records*. Nothing in them binds the
+		// certificate that produced the recording, and that gap is wide: the
+		// eleven classes collapse into only four distinct outcome columns, so
+		// ten of them are indistinguishable from a sibling by recorded outcome
+		// alone. own-ca-pp-cli-auth-false's column is identical to
+		// own-ca-issued's; own-ca-server-eku's is identical to own-ca-expired's.
+		//
+		// So a one-line argument swap — handing own-ca-pp-cli-auth-false an
+		// ordinary CA-issued certificate — reproduces its column exactly on
+		// every row, leaving every digest, every pinned list and every changedBy
+		// byte-identical. Relaxing isAdmin to a presence test could then land
+		// green, and the two classes that exist solely as tripwires for a silent
+		// relaxation are the repo's only coverage of what they guard. Worse, the
+		// dishonest edit is *cheaper* than the honest one (five cells, five
+		// fingerprints, five attributions), which puts the incentive gradient
+		// the wrong way round.
+		//
+		// This spec closes that by asserting what each fixture is, against the
+		// parsed certificate. It is not itself digest-protected — no assertion
+		// in a repository can be — but neutralising a class now means editing an
+		// explicit, self-describing claim about it, rather than swapping one
+		// argument and leaving the file's own account of itself intact.
+		// Mint first, then snapshot: newClasses issues own-ca-issued and
+		// own-ca-revoked through the CA, so an inventory read taken before the
+		// call cannot contain them.
+		classes := newClasses()
+		inventory, err := store.ReadInventory(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		// By serial, not by subject: the renewal probes issue genuine
+		// certificates for these CNs as they run, so a name says nothing about
+		// where *this* certificate came from. A template-minted serial is never
+		// recorded, however often its subject is later issued.
+		inventoryHas := func(c *x509.Certificate) bool {
+			return strings.Contains(string(inventory), fmt.Sprintf("%X", c.SerialNumber))
+		}
+
+		ours := func(c *x509.Certificate) {
+			Expect(c.Issuer.String()).To(Equal(caCert.Subject.String()), "should chain to our CA")
+			Expect(c.CheckSignatureFrom(caCert)).To(Succeed(), "should be signed by our CA")
+		}
+		unexpired := func(c *x509.Certificate) {
+			Expect(c.NotAfter).To(BeTemporally(">", time.Now()), "should still be within its validity window")
+		}
+		clientAuth := func(c *x509.Certificate) {
+			Expect(c.ExtKeyUsage).To(ContainElement(x509.ExtKeyUsageClientAuth))
+		}
+		noPpCliAuth := func(c *x509.Certificate) {
+			_, present := ppCliAuthValue(c)
+			Expect(present).To(BeFalse(), "should carry no pp_cli_auth extension at all")
+		}
+
+		props := map[string]func(c *x509.Certificate){
+			// The absence of a certificate is the whole property.
+			"none": nil,
+			"own-ca-plain": func(c *x509.Certificate) {
+				ours(c)
+				unexpired(c)
+				clientAuth(c)
+				noPpCliAuth(c)
+				Expect(c.Subject.CommonName).To(Equal(selfName), "the self-match row turns on this")
+				Expect(c.Subject.CommonName).NotTo(Equal("puppet-server"), "must not be allow-listed")
+				Expect(inventoryHas(c)).To(BeFalse(),
+					"minted from a template, so its serial must be unknown to the CA — "+
+						"that is what separates it from own-ca-issued")
+			},
+			"own-ca-allowlisted": func(c *x509.Certificate) {
+				ours(c)
+				unexpired(c)
+				clientAuth(c)
+				noPpCliAuth(c)
+				Expect(c.Subject.CommonName).To(Equal("puppet-server"),
+					"admin by allow-list alone, so the CN must be the allow-listed one")
+			},
+			"own-ca-pp-cli-auth": func(c *x509.Certificate) {
+				ours(c)
+				unexpired(c)
+				clientAuth(c)
+				value, present := ppCliAuthValue(c)
+				Expect(present).To(BeTrue())
+				Expect(value).To(Equal("true"))
+				Expect(c.Subject.CommonName).NotTo(Equal("puppet-server"),
+					"admin by extension alone, so the CN must not also be allow-listed")
+			},
+			"own-ca-admin-both": func(c *x509.Certificate) {
+				ours(c)
+				unexpired(c)
+				clientAuth(c)
+				value, present := ppCliAuthValue(c)
+				Expect(present).To(BeTrue())
+				Expect(value).To(Equal("true"))
+				Expect(c.Subject.CommonName).To(Equal("puppet-server"),
+					"admin by both routes at once is the point of this class")
+			},
+			"own-ca-expired": func(c *x509.Certificate) {
+				ours(c)
+				clientAuth(c)
+				Expect(c.NotAfter).To(BeTemporally("<", time.Now()),
+					"expiry must be the reason it is denied")
+			},
+			"own-ca-issued": func(c *x509.Certificate) {
+				ours(c)
+				unexpired(c)
+				clientAuth(c)
+				noPpCliAuth(c)
+				Expect(inventoryHas(c)).To(BeTrue(),
+					"its serial must be recorded in the CA inventory — being genuinely issued is the property")
+				revoked, err := myCA.IsRevokedSerial(ctx, c.SerialNumber)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(revoked).To(BeFalse())
+			},
+			"own-ca-revoked": func(c *x509.Certificate) {
+				ours(c)
+				clientAuth(c)
+				// Unexpired on purpose: if it were also expired, the row could
+				// not tell revocation checking from expiry checking.
+				unexpired(c)
+				revoked, err := myCA.IsRevokedSerial(ctx, c.SerialNumber)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(revoked).To(BeTrue(), "revocation must be the only reason it is denied")
+			},
+			"own-ca-server-eku": func(c *x509.Certificate) {
+				ours(c)
+				unexpired(c)
+				Expect(c.ExtKeyUsage).To(ContainElement(x509.ExtKeyUsageServerAuth))
+				Expect(c.ExtKeyUsage).NotTo(ContainElement(x509.ExtKeyUsageClientAuth),
+					"the missing clientAuth EKU must be the only reason it is denied")
+			},
+			"own-ca-pp-cli-auth-false": func(c *x509.Certificate) {
+				ours(c)
+				unexpired(c)
+				clientAuth(c)
+				value, present := ppCliAuthValue(c)
+				Expect(present).To(BeTrue(),
+					"the extension must be present — an absent one would make this a duplicate of own-ca-plain")
+				Expect(value).NotTo(Equal("true"),
+					"present-but-not-true is what distinguishes an equality check from a presence check")
+				Expect(c.Subject.CommonName).NotTo(Equal("puppet-server"),
+					"must not be admin by the allow-list route either")
+			},
+			"foreign-ca": func(c *x509.Certificate) {
+				unexpired(c)
+				clientAuth(c)
+				Expect(c.Issuer.String()).NotTo(Equal(caCert.Subject.String()),
+					"a different issuer is the property")
+				Expect(c.CheckSignatureFrom(caCert)).NotTo(Succeed())
+				Expect(c.Subject.CommonName).To(Equal(selfName),
+					"the CN collision with our own namespace is deliberate groundwork")
+			},
+		}
+
+		// Every class needs a claim, and every claim needs a class: adding a
+		// fixture without saying what it is, or leaving a claim behind after
+		// removing one, both fail here.
+		Expect(mapKeys(props)).To(ConsistOf(expectedClientClasses))
+
+		for _, class := range classes {
+			assert, ok := props[class.name]
+			Expect(ok).To(BeTrue(), "no recorded property for client class %q", class.name)
+			By(class.name, func() {
+				if assert == nil {
+					Expect(class.cert).To(BeNil(), "%q must present no certificate", class.name)
+					return
+				}
+				Expect(class.cert).NotTo(BeNil(), "%q must present a certificate", class.name)
+				assert(class.cert)
+			})
+		}
 	})
 
 	It("states an outcome for every route and client class", func() {
@@ -753,6 +981,7 @@ var expectedRoutes = []string{
 	"public: fetch the CRL",
 	"public: submit a CSR",
 	"public: read expiry metadata",
+	"public: query OCSP",
 	"any-client: read a certificate status",
 	"any-client: renew own certificate",
 	"self-or-admin: read own CSR",
@@ -789,6 +1018,35 @@ func rowDigest(r routeCase, withProvenance bool) string {
 		fmt.Fprintf(h, "by=%s", r.changedBy)
 	}
 	return hex.EncodeToString(h.Sum(nil))[:16]
+}
+
+// ppCliAuthValue returns the decoded pp_cli_auth extension value and whether
+// the extension is present at all.
+//
+// The middleware's own helper answers only "is it exactly true", which cannot
+// tell absent from present-and-false — precisely the distinction own-ca-plain
+// and own-ca-pp-cli-auth-false exist to draw, and the one a presence-test
+// regression would erase.
+func ppCliAuthValue(cert *x509.Certificate) (string, bool) {
+	for _, ext := range cert.Extensions {
+		if !ext.Id.Equal(ca.OIDPpCliAuth) {
+			continue
+		}
+		var value string
+		if rest, err := asn1.Unmarshal(ext.Value, &value); err == nil && len(rest) == 0 {
+			return value, true
+		}
+		return "", true
+	}
+	return "", false
+}
+
+func mapKeys(m map[string]func(c *x509.Certificate)) []string {
+	names := make([]string, 0, len(m))
+	for name := range m {
+		names = append(names, name)
+	}
+	return names
 }
 
 func classNames(classes []clientClass) []string {
@@ -979,8 +1237,10 @@ func foreignClientCert(cn string) *x509.Certificate {
 	return leaf
 }
 
-// The two AuthConfig flags that move a route between tiers get their own
-// Describe rather than a third dimension on the main table. Multiplying every
+// The two AuthConfig flags that change who reaches a route get their own
+// Describe rather than a third dimension on the main table. Only
+// AllowPublicStatus moves a tier; NoPpCliAuth is read by isAdmin, not by
+// lookupTier, and narrows who counts as an admin without moving any route. Multiplying every
 // row by every flag would triple the fixtures to record four cells that
 // actually differ, and would bury them.
 //


### PR DESCRIPTION
The intermediate-CA work changes who counts as an admin, in three places: scoping
identity claims to the issuing CA, gating renewal on our own certificates, and
moving `certificate_status` to admin-only. The design calls the first of those
"the change that can silently widen who is an admin", and there was no artefact
recording what the answers are *now*.

This is that artefact, committed before any of those changes so it says what the
behaviour was rather than what someone later believed it should be. It is a test
plus documentation; no production code moves.

### Dependencies and merge order

This branch is based directly on `main` and depends on nothing else. It should
merge before #164 (renewal issuer gates) and #166 (client trust domains), both of
which build on it — each of those changes moves cells recorded here, and the
point of the oracle is to be in place first.

### What is recorded

Eleven client classes against twelve rows covering eleven of the nineteen
protocol routes, driven through the real mux:

| | |
|---|---|
| `none` | no client certificate |
| `own-ca-plain` | ordinary agent certificate from this CA |
| `own-ca-allowlisted` | CN in the admin allow list |
| `own-ca-pp-cli-auth` | carries `pp_cli_auth` with value `true` |
| `own-ca-pp-cli-auth-false` | carries `pp_cli_auth` with a value that is *not* `true` |
| `own-ca-admin-both` | admin by allow list *and* extension — how OpenVox Server ships |
| `own-ca-expired` | issued by this CA, past `notAfter` |
| `own-ca-issued` | genuinely issued through the CA, so recorded in the inventory |
| `own-ca-revoked` | issued by this CA, then genuinely revoked into the CRL |
| `own-ca-server-eku` | chain-valid but carrying only `serverAuth` EKU |
| `foreign-ca` | an unrelated CA, using a CN this CA's namespace also uses |

Every cell is asserted every run. A change that intends to move one updates the
recorded outcome and says why in `changedBy`, in the same commit; a change that
moves one without doing so fails here.

### How a moved cell is made to declare itself

Each row carries two digests. `fingerprint` covers the endpoint, the recorded
outcomes *and* `changedBy`, so no cell moves without a second deliberate edit
that is visible in the diff, and re-attributing a later change to an earlier one
trips it too. `baseline` covers the endpoint and outcomes as first committed and
is never refreshed, so "has this row ever moved" can still be asked after a row
has been attributed.

Neither is tamper-proof — no literal in a repository can be. What the pair buys
is that moving a cell silently requires replacing two opaque hex literals that no
honest change touches, and the file says so in those terms rather than claiming
an enforcement it does not have.

### What the digests do not cover

The digests bind what a row *records*, not the certificate that produced the
recording. That gap is wide: the eleven classes collapse into only four distinct
outcome columns, so ten of them are indistinguishable from a sibling by outcome
alone. Handing `own-ca-pp-cli-auth-false` an ordinary CA-issued certificate
reproduces its column exactly on every row — so relaxing `isAdmin` to a presence
test could have landed with every digest, every pinned list and every `changedBy`
byte-identical. The same swap hides an `ExtKeyUsageAny` relaxation behind
`own-ca-expired`'s column. Both bypasses were *cheaper* than the honest path,
which had the incentive gradient backwards.

A fixture-property spec now asserts what each class is, against the parsed
certificate: CN, allow-list membership, `pp_cli_auth` presence and value, EKU,
validity window, issuer, CRL membership, and presence in the CA inventory by
serial. Both attacks were carried out to confirm each now fails naming exactly
what was done.

### Coverage the omissions argument did not actually cover

`POST /ocsp` had no assertion anywhere in the repository. It is the only
`lookupTier` arm that grants a tier without inspecting the method, so the reason
the other omissions are safe — they fall through to `tierAdminOnly`, which three
rows pin — did not apply to it. Deleting the arm now fails a row in both the bare
and `/puppet-ca/v1`-prefixed forms.

### Documentation

`docs/api.md` gained the `clientAuth` EKU requirement, which the tier table
omitted, and had two security claims corrected. Revoking an agent's certificate
does not cut off its access to the CA API: the public tier examines no
certificate at all, so a revoked agent keeps the CA certificate, the CRL,
`/expirations`, OCSP and CSR submission. And neither revocation form prevents
re-enrolment under the same subject, because `SaveRequest` evicts a revoked
certificate for that subject before saving — so the containment levers are
autosign policy, network blocking and a forced CRL re-sign on every replica,
not the choice between revoke and clean.

`AGENTS.md` records the obligation on anyone editing the table, including the two
cases that are easy to get wrong: a new row needs both digests (write
`baseline: ""` and the suite prints a paste-ready pair), and adding a client class
re-digests every row.

### Notes from review

Five review rounds; each of the first four introduced at least one comment or
document claim the code had already outgrown, which the next round caught. That
pattern is itself the argument for the file's habit of stating what is *not*
enforced alongside what is.

Two recommendations were not taken as given. `Ordered` is not gratuitous —
`BeforeAll` requires it — so the fix was `Ordered, ContinueOnFailure` plus one
`Entry` per route rather than dropping `Ordered`. And the `baseline` gate was
left as a convention backed by diff visibility rather than made "mechanical",
because no in-repo literal can be made unforgeable and claiming otherwise was the
original defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
