### PR TITLE
feat: systemd notify (sd_notify) support, reload, and a shipped unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ wire-compatible with your existing Puppet/OpenVox fleet.
 - **Prometheus exporter:** optional `/metrics` listener (`--metrics-listen`) exposing Go runtime/process and HTTP metrics plus CA certificate, CRL, and per–leaf-certificate expiry and issuance-status series; ships with a [Jsonnet alerting mixin](mixin/). See [metrics & monitoring](docs/metrics.md)
 - **Kubernetes export (opt-in):** publish the CA certificate and/or CRL into any number of Kubernetes Secrets and ConfigMaps via in-cluster server-side apply, with configurable names, namespaces, data keys, labels, annotations, and Secret `type`; CRL-bearing objects are refreshed whenever the CRL changes. See [Kubernetes export](docs/kubernetes-export.md)
 - **Graceful shutdown:** `SIGTERM`/`SIGINT` drains in-flight requests with a configurable window (25s default) before exiting; deferred storage and signer cleanup always runs
+- **systemd integration:** `Type=notify` readiness (`systemctl start` returns once the listener is actually accepting), a live status line covering the listener, CA expiry and CRL freshness, watchdog keep-alives, and `systemctl reload` for TLS certificate renewal and admin allow-list changes; ships a hardened [unit file](packaging/systemd/openvox-ca.service). See [running under systemd](docs/systemd.md)
 - **FIPS-compatible:** the core CA uses the standard library only (`crypto/x509`, `net/http`); no CGO by default; FIPS build available via `GOEXPERIMENT=boringcrypto` (the optional Kubernetes export adds the `client-go` dependency)
 - **`openvox-ca-ctl`:** operator CLI matching `puppetserver ca` subcommands. See the [operator CLI reference](docs/operator-cli.md)
 
@@ -118,6 +119,7 @@ The complete flag, environment-variable, and config-file reference is in
 | [OpenBao Transit-engine CA key](docs/openbao-transit.md) | Delegating CA key custody to OpenBao |
 | [Kubernetes export](docs/kubernetes-export.md) | Publishing the CA cert/CRL into Secrets and ConfigMaps |
 | [Metrics & monitoring](docs/metrics.md) | The Prometheus exporter and the alerting [mixin](mixin/) |
+| [Running under systemd](docs/systemd.md) | The `Type=notify` unit, status text, `systemctl reload`, watchdog, and hardening |
 | [Container images](docs/container-images.md) | Pulling and running the published images |
 | [Migration guide](docs/migrating-from-puppet-server.md) | Replacing an OpenVox/Puppet Server built-in CA |
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The complete flag, environment-variable, and config-file reference is in
 
 | Guide | What it covers |
 | --- | --- |
-| [Configuring the server](docs/configuration.md) | Every flag, environment variable, config-file key; autosigning; directory layout; graceful shutdown |
+| [Configuring the server](docs/configuration.md) | Every flag, environment variable, config-file key; autosigning; directory layout; graceful shutdown; reloading configuration |
 | [HTTP API reference](docs/api.md) | All endpoints, authorization tiers, and admin credential resolution |
 | [Operator CLI (`openvox-ca-ctl`)](docs/operator-cli.md) | The `openvox-ca-ctl` command reference |
 | [Storage backends](docs/storage-backends.md) | filesystem, SQLite, PostgreSQL, MySQL, etcd, Redis/Valkey; migrating between them |

--- a/cmd/openvox-ca/launcher.go
+++ b/cmd/openvox-ca/launcher.go
@@ -77,8 +77,13 @@ const (
 // deliberately comes from the frontend child instead, since only it knows when
 // the listener is actually accepting — which is why units must set
 // NotifyAccess=all (see docs/systemd.md).
+//
+// hupCh delivers reload requests, which the service manager sends to this
+// process because it is the unit's main PID. It is registered by the caller
+// before any startup work begins, so a reload arriving early is queued rather
+// than fatal — SIGHUP's default disposition would otherwise kill the launcher.
 // NIST 800-53: SC-3 (Security Function Isolation), SC-4 (Information in Shared System Resources)
-func runLauncher(drain time.Duration, notify *sdnotify.Notifier) error {
+func runLauncher(drain time.Duration, notify *sdnotify.Notifier, hupCh <-chan os.Signal) error {
 	gracefulShutdownTimeout := drain + launcherShutdownHeadroom
 
 	// Create the socketpair for signer ↔ frontend communication.
@@ -169,14 +174,6 @@ func runLauncher(drain time.Duration, notify *sdnotify.Notifier) error {
 	sigCh := make(chan os.Signal, 2)
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
 
-	// Reload requests arrive here because the service manager signals the
-	// unit's main PID, but the configuration they affect (the TLS keypair, the
-	// admin allow list) belongs to the frontend, so they are forwarded to it.
-	// Registering the handler also stops SIGHUP from doing what it does by
-	// default, which is kill this process.
-	hupCh := make(chan os.Signal, 1)
-	signal.Notify(hupCh, syscall.SIGHUP)
-
 	// Wait for either child to exit.
 	type childResult struct {
 		name string
@@ -201,6 +198,9 @@ func runLauncher(drain time.Duration, notify *sdnotify.Notifier) error {
 	for {
 		select {
 		case <-hupCh:
+			// The configuration a reload affects (the TLS keypair, the admin
+			// allow list) belongs to the frontend, so the signal is forwarded
+			// there rather than acted on here.
 			slog.Info("Forwarding reload signal to the frontend process")
 			frontendCmd.Process.Signal(syscall.SIGHUP)
 			continue

--- a/cmd/openvox-ca/launcher.go
+++ b/cmd/openvox-ca/launcher.go
@@ -29,6 +29,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/voxpupuli/openvox-ca/internal/sdnotify"
 	"github.com/voxpupuli/openvox-ca/internal/signer"
 )
 
@@ -70,8 +71,14 @@ const (
 // for both children to exit after forwarding SIGTERM before hard-killing them,
 // so the frontend always gets its full drain even though the launcher's timer
 // starts first.
+//
+// notify carries the launcher's own service-manager notifications: the status
+// text while the children come up, and STOPPING=1 once teardown begins. READY=1
+// deliberately comes from the frontend child instead, since only it knows when
+// the listener is actually accepting — which is why units must set
+// NotifyAccess=all (see docs/systemd.md).
 // NIST 800-53: SC-3 (Security Function Isolation), SC-4 (Information in Shared System Resources)
-func runLauncher(drain time.Duration) error {
+func runLauncher(drain time.Duration, notify *sdnotify.Notifier) error {
 	gracefulShutdownTimeout := drain + launcherShutdownHeadroom
 
 	// Create the socketpair for signer ↔ frontend communication.
@@ -98,6 +105,7 @@ func runLauncher(drain time.Duration) error {
 	}
 
 	slog.Info("Starting isolated CA processes")
+	notify.Status("Starting the isolated signer and frontend processes")
 
 	// Build base environment: strip role/daemon vars to prevent inheritance loops.
 	// Clip to len==cap so each append below allocates a fresh backing array,
@@ -105,9 +113,17 @@ func runLauncher(drain time.Duration) error {
 	baseEnv := filterEnv(os.Environ(), "PUPPET_CA_ROLE", "PUPPET_CA_DAEMON", "PUPPET_CA_SIGNER_PSK")
 	baseEnv = baseEnv[:len(baseEnv):len(baseEnv)]
 
+	// The signer holds the CA key and talks to nothing but the frontend, so it
+	// has no state a service manager wants to hear about. Withholding
+	// $NOTIFY_SOCKET keeps the notification channel to exactly the two
+	// processes that use it (this launcher and the frontend) even under
+	// NotifyAccess=all.
+	signerEnv := filterEnv(baseEnv, "NOTIFY_SOCKET")
+	signerEnv = signerEnv[:len(signerEnv):len(signerEnv)]
+
 	// Spawn signer child.
 	signerCmd := exec.Command(exe, os.Args[1:]...) //nolint:gosec // G204: re-execs this same binary (os.Executable) with the operator's own os.Args
-	signerCmd.Env = append(baseEnv,
+	signerCmd.Env = append(signerEnv,
 		"PUPPET_CA_ROLE=signer",
 		"PUPPET_CA_DAEMON=1",
 		"PUPPET_CA_SIGNER_PSK="+pskHex,
@@ -142,6 +158,9 @@ func runLauncher(drain time.Duration) error {
 		"signer_pid", signerCmd.Process.Pid,
 		"frontend_pid", frontendCmd.Process.Pid,
 	)
+	// The frontend takes it from here: it reports readiness once its listener
+	// is up, and owns the status text from that point on.
+	notify.Status("Waiting for the frontend process to become ready")
 
 	// Forward termination signals to children. The buffer matches the
 	// number of registered signals so a coincident SIGTERM+SIGINT (e.g.
@@ -174,11 +193,17 @@ func runLauncher(drain time.Duration) error {
 	select {
 	case sig := <-sigCh:
 		slog.Info("Received signal, shutting down CA processes", "signal", sig)
+		notify.Stopping(fmt.Sprintf("Shutting down on %s (up to %s for the children to exit)",
+			sig, gracefulShutdownTimeout))
 		shutdown()
 		return nil
 
 	case result := <-exitCh:
 		slog.Error("CA child process exited unexpectedly", "process", result.name, "error", result.err)
+		// Report the cause before tearing the rest down: the status text
+		// outlives the process and is what `systemctl status` shows next to
+		// the failure.
+		notify.Stopping(fmt.Sprintf("The %s process exited unexpectedly (%v); stopping", result.name, result.err))
 		// Shut down the surviving child.
 		frontendCmd.Process.Signal(syscall.SIGTERM)
 		signerCmd.Process.Signal(syscall.SIGTERM)

--- a/cmd/openvox-ca/launcher.go
+++ b/cmd/openvox-ca/launcher.go
@@ -169,6 +169,14 @@ func runLauncher(drain time.Duration, notify *sdnotify.Notifier) error {
 	sigCh := make(chan os.Signal, 2)
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
 
+	// Reload requests arrive here because the service manager signals the
+	// unit's main PID, but the configuration they affect (the TLS keypair, the
+	// admin allow list) belongs to the frontend, so they are forwarded to it.
+	// Registering the handler also stops SIGHUP from doing what it does by
+	// default, which is kill this process.
+	hupCh := make(chan os.Signal, 1)
+	signal.Notify(hupCh, syscall.SIGHUP)
+
 	// Wait for either child to exit.
 	type childResult struct {
 		name string
@@ -190,30 +198,37 @@ func runLauncher(drain time.Duration, notify *sdnotify.Notifier) error {
 		timer.Stop()
 	}
 
-	select {
-	case sig := <-sigCh:
-		slog.Info("Received signal, shutting down CA processes", "signal", sig)
-		notify.Stopping(fmt.Sprintf("Shutting down on %s (up to %s for the children to exit)",
-			sig, gracefulShutdownTimeout))
-		shutdown()
-		return nil
+	for {
+		select {
+		case <-hupCh:
+			slog.Info("Forwarding reload signal to the frontend process")
+			frontendCmd.Process.Signal(syscall.SIGHUP)
+			continue
 
-	case result := <-exitCh:
-		slog.Error("CA child process exited unexpectedly", "process", result.name, "error", result.err)
-		// Report the cause before tearing the rest down: the status text
-		// outlives the process and is what `systemctl status` shows next to
-		// the failure.
-		notify.Stopping(fmt.Sprintf("The %s process exited unexpectedly (%v); stopping", result.name, result.err))
-		// Shut down the surviving child.
-		frontendCmd.Process.Signal(syscall.SIGTERM)
-		signerCmd.Process.Signal(syscall.SIGTERM)
-		timer := time.AfterFunc(crashShutdownTimeout, func() {
-			frontendCmd.Process.Kill()
-			signerCmd.Process.Kill()
-		})
-		<-exitCh // wait for the other child
-		timer.Stop()
-		return fmt.Errorf("%s process exited unexpectedly: %w", result.name, result.err)
+		case sig := <-sigCh:
+			slog.Info("Received signal, shutting down CA processes", "signal", sig)
+			notify.Stopping(fmt.Sprintf("Shutting down on %s (up to %s for the children to exit)",
+				sig, gracefulShutdownTimeout))
+			shutdown()
+			return nil
+
+		case result := <-exitCh:
+			slog.Error("CA child process exited unexpectedly", "process", result.name, "error", result.err)
+			// Report the cause before tearing the rest down: the status text
+			// outlives the process and is what `systemctl status` shows next to
+			// the failure.
+			notify.Stopping(fmt.Sprintf("The %s process exited unexpectedly (%v); stopping", result.name, result.err))
+			// Shut down the surviving child.
+			frontendCmd.Process.Signal(syscall.SIGTERM)
+			signerCmd.Process.Signal(syscall.SIGTERM)
+			timer := time.AfterFunc(crashShutdownTimeout, func() {
+				frontendCmd.Process.Kill()
+				signerCmd.Process.Kill()
+			})
+			<-exitCh // wait for the other child
+			timer.Stop()
+			return fmt.Errorf("%s process exited unexpectedly: %w", result.name, result.err)
+		}
 	}
 }
 

--- a/cmd/openvox-ca/main.go
+++ b/cmd/openvox-ca/main.go
@@ -226,6 +226,18 @@ func newRootCmd() *cobra.Command {
 			ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGTERM, syscall.SIGINT)
 			defer stop()
 
+			// SIGHUP means "reload" for this service, but its default
+			// disposition is to terminate. Claim it here, before any of the
+			// slow startup work below — opening storage, waiting for the
+			// signer to bootstrap a CA key, binding the listener — so a reload
+			// that arrives while the CA is still coming up cannot kill it. The
+			// channel is handed to whichever role can act on it; a signal that
+			// arrives before then waits in the buffer rather than being fatal.
+			// (The signer overrides this with signal.Ignore; see runSignerMode.)
+			hupCh := make(chan os.Signal, 1)
+			signal.Notify(hupCh, syscall.SIGHUP)
+			defer signal.Stop(hupCh)
+
 			// Service-manager notifications (sd_notify). Inert unless started
 			// by a service manager that asked to be notified, so no
 			// configuration or branching is needed anywhere below.
@@ -363,7 +375,9 @@ func newRootCmd() *cobra.Command {
 				c := exec.Command(exe, os.Args[1:]...) //nolint:gosec // G204: re-execs this same binary (os.Executable) with the operator's own os.Args to daemonize
 				// Strip internal role/PSK vars to prevent stale values from a
 				// previous run from confusing the daemon child.
-				daemonEnv := filterEnv(os.Environ(), "PUPPET_CA_ROLE", "PUPPET_CA_DAEMON", "PUPPET_CA_SIGNER_PSK")
+				// NOTIFY_SOCKET goes too: the child would otherwise report
+				// readiness for a unit whose main process has just exited.
+				daemonEnv := filterEnv(os.Environ(), "PUPPET_CA_ROLE", "PUPPET_CA_DAEMON", "PUPPET_CA_SIGNER_PSK", "NOTIFY_SOCKET")
 				c.Env = append(daemonEnv, "PUPPET_CA_DAEMON=1")
 				c.Stdin = nil
 				c.Stdout = nil
@@ -385,7 +399,7 @@ func newRootCmd() *cobra.Command {
 
 			// Launcher mode (default): spawn isolated signer + frontend children.
 			if role == "" && !singleProcess {
-				return runLauncher(cfg.shutdownDrain(), notifier)
+				return runLauncher(cfg.shutdownDrain(), notifier, hupCh)
 			}
 
 			// Frontend mode (role=frontend) or single-process mode: run HTTP server.
@@ -444,11 +458,7 @@ func newRootCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("invalid storage backend config: %w", err)
 			}
-			backendKind := backendSpec.Kind
-			if backendKind == "" {
-				backendKind = storage.BackendFilesystem
-			}
-			notifier.Status(fmt.Sprintf("Opening the %s storage backend", backendKind))
+			notifier.Status(fmt.Sprintf("Opening the %s storage backend", backendSpec.Kind))
 			store, err := storage.NewServiceFromSpec(backendSpec)
 			if err != nil {
 				return fmt.Errorf("failed to initialise storage backend: %w", err)
@@ -655,7 +665,7 @@ func newRootCmd() *cobra.Command {
 			if cfg.TLSCert != "" && cfg.TLSKey != "" {
 				certs, err = newCertReloader(cfg.TLSCert, cfg.TLSKey)
 				if err != nil {
-					return fmt.Errorf("failed to load TLS cert/key: %w", err)
+					return err
 				}
 
 				caCertPEM, err := myCA.Storage.GetCACert(ctx)
@@ -783,7 +793,7 @@ func newRootCmd() *cobra.Command {
 
 			// Both jobs are bound to ctx, so they stop on shutdown.
 			go runNotifyHeartbeat(ctx, notifier, heartbeatInterval(notifier), status)
-			go runReloadWatcher(ctx, notifier, reloader, status)
+			go runReloadWatcher(ctx, hupCh, notifier, reloader, status)
 
 			var serveErr error
 			if cfg.TLSCert != "" && cfg.TLSKey != "" {

--- a/cmd/openvox-ca/main.go
+++ b/cmd/openvox-ca/main.go
@@ -34,7 +34,6 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
-	"strings"
 	"syscall"
 	"time"
 
@@ -587,19 +586,9 @@ func newRootCmd() *cobra.Command {
 
 			// Wire mTLS auth middleware when TLS is configured.
 			if cfg.TLSCert != "" && cfg.TLSKey != "" {
-				allowList := map[string]bool{}
-				for _, cn := range strings.Split(cfg.PuppetServer, ",") {
-					cn = strings.TrimSpace(cn)
-					if cn != "" {
-						allowList[cn] = true
-					}
-				}
-				fileCNs, err := loadPuppetServerFile(cfg.PuppetServerFile)
+				allowList, err := buildAdminAllowList(cfg.PuppetServer, cfg.PuppetServerFile)
 				if err != nil {
 					return err
-				}
-				for _, cn := range fileCNs {
-					allowList[cn] = true
 				}
 				srv.AuthConfig = &api.AuthConfig{
 					CACert:            myCA.CACert,
@@ -659,10 +648,14 @@ func newRootCmd() *cobra.Command {
 				}()
 			}
 
+			// certs holds the server's TLS keypair, or stays nil without TLS.
+			// It is reachable by the reload handler below so a renewed server
+			// certificate can be picked up without a restart.
+			var certs *certReloader
 			if cfg.TLSCert != "" && cfg.TLSKey != "" {
-				serverCert, err := tls.LoadX509KeyPair(cfg.TLSCert, cfg.TLSKey)
+				certs, err = newCertReloader(cfg.TLSCert, cfg.TLSKey)
 				if err != nil {
-					return fmt.Errorf("failed to load TLS cert/key (cert %s, key %s): %w", cfg.TLSCert, cfg.TLSKey, err)
+					return fmt.Errorf("failed to load TLS cert/key: %w", err)
 				}
 
 				caCertPEM, err := myCA.Storage.GetCACert(ctx)
@@ -681,13 +674,15 @@ func newRootCmd() *cobra.Command {
 				// RequestClientCert allows public endpoints to work without a
 				// client cert while the auth middleware enforces cert requirements
 				// per-tier. MinVersion TLS 1.2 blocks legacy protocol downgrades.
+				// The certificate comes from a callback rather than a fixed
+				// list so it can be replaced on reload when it is renewed.
 				// NIST 800-53: SC-8 (Transmission Confidentiality and Integrity),
 				//              SC-23 (Session Authenticity), IA-3 (Device Identification)
 				server.TLSConfig = &tls.Config{
-					Certificates: []tls.Certificate{serverCert},
-					ClientCAs:    caPool,
-					ClientAuth:   tls.RequestClientCert,
-					MinVersion:   tls.VersionTLS12,
+					GetCertificate: certs.GetCertificate,
+					ClientCAs:      caPool,
+					ClientAuth:     tls.RequestClientCert,
+					MinVersion:     tls.VersionTLS12,
 				}
 
 				slog.Info("TLS enabled", "cert", cfg.TLSCert)
@@ -771,9 +766,24 @@ func newRootCmd() *cobra.Command {
 				return fmt.Errorf("failed to listen on %s: %w", addr, err)
 			}
 
-			status := func() string { return newStatusReport(myCA, addr, tlsConfigured).line(time.Now()) }
+			// SIGHUP re-reads the file-backed configuration: the TLS keypair
+			// (so a renewed server certificate does not need a restart) and
+			// the admin allow list.
+			reloader := &configReloader{
+				certs:     certs,
+				auth:      srv.AuthConfig,
+				staticCNs: cfg.PuppetServer,
+				cnFile:    cfg.PuppetServerFile,
+			}
+
+			status := func() string {
+				return newStatusReport(myCA, addr, tlsConfigured).line(time.Now()) + reloader.statusSuffix()
+			}
 			notifier.Ready(status())
+
+			// Both jobs are bound to ctx, so they stop on shutdown.
 			go runNotifyHeartbeat(ctx, notifier, heartbeatInterval(notifier), status)
+			go runReloadWatcher(ctx, notifier, reloader, status)
 
 			var serveErr error
 			if cfg.TLSCert != "" && cfg.TLSKey != "" {
@@ -924,6 +934,12 @@ func runSignerMode(ctx context.Context, cfg *serverConfig, absCADir string) erro
 			}
 		}()
 	}
+
+	// The signer holds no reloadable configuration, but SIGHUP's default
+	// action is to terminate. Ignoring it means a reload signal delivered to
+	// the process group (rather than to the launcher alone) cannot take the CA
+	// key holder down and force a full restart.
+	signal.Ignore(syscall.SIGHUP)
 
 	slog.Info("Starting CA signer process",
 		"cadir", absCADir,

--- a/cmd/openvox-ca/main.go
+++ b/cmd/openvox-ca/main.go
@@ -44,6 +44,7 @@ import (
 	"github.com/voxpupuli/openvox-ca/internal/ca"
 	"github.com/voxpupuli/openvox-ca/internal/k8sexport"
 	"github.com/voxpupuli/openvox-ca/internal/metrics"
+	"github.com/voxpupuli/openvox-ca/internal/sdnotify"
 	"github.com/voxpupuli/openvox-ca/internal/signer"
 	"github.com/voxpupuli/openvox-ca/internal/storage"
 )
@@ -226,6 +227,13 @@ func newRootCmd() *cobra.Command {
 			ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGTERM, syscall.SIGINT)
 			defer stop()
 
+			// Service-manager notifications (sd_notify). Inert unless started
+			// by a service manager that asked to be notified, so no
+			// configuration or branching is needed anywhere below.
+			notifier := sdnotify.New()
+			defer func() { _ = notifier.Close() }()
+			notifier.Status("Loading configuration")
+
 			// --- Config loading (file → env → CLI flags) ---
 			resolved := resolveConfigFile(configFile, "PUPPET_CA_CONFIG", "/etc/puppet-ca/config.yaml")
 			cfg, err := loadServerConfig(resolved)
@@ -342,6 +350,13 @@ func newRootCmd() *cobra.Command {
 			// Note: --daemon is intentionally excluded from config file / env var support
 			// because PUPPET_CA_DAEMON is used internally as the fork signal.
 			if daemon && os.Getenv("PUPPET_CA_DAEMON") != "1" {
+				// A service manager tracks the process it started; forking and
+				// exiting makes the service look like it died the moment it
+				// started. Under systemd, drop --daemon and use Type=notify.
+				if notifier.Enabled() {
+					slog.Warn("--daemon is incompatible with a service manager that expects notifications; " +
+						"run in the foreground (Type=notify) instead")
+				}
 				exe, err := os.Executable()
 				if err != nil {
 					return fmt.Errorf("failed to determine executable: %w", err)
@@ -371,7 +386,7 @@ func newRootCmd() *cobra.Command {
 
 			// Launcher mode (default): spawn isolated signer + frontend children.
 			if role == "" && !singleProcess {
-				return runLauncher(cfg.shutdownDrain())
+				return runLauncher(cfg.shutdownDrain(), notifier)
 			}
 
 			// Frontend mode (role=frontend) or single-process mode: run HTTP server.
@@ -430,6 +445,11 @@ func newRootCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("invalid storage backend config: %w", err)
 			}
+			backendKind := backendSpec.Kind
+			if backendKind == "" {
+				backendKind = storage.BackendFilesystem
+			}
+			notifier.Status(fmt.Sprintf("Opening the %s storage backend", backendKind))
 			store, err := storage.NewServiceFromSpec(backendSpec)
 			if err != nil {
 				return fmt.Errorf("failed to initialise storage backend: %w", err)
@@ -445,6 +465,11 @@ func newRootCmd() *cobra.Command {
 			// handshake blocks until the signer finishes Init/bootstrap, so
 			// store.GetCACert is guaranteed to succeed after it returns.
 			if role == "frontend" {
+				// This handshake blocks until the signer has finished
+				// bootstrapping, which on a first run means waiting for a CA
+				// key pair to be generated — worth saying out loud, since it
+				// is the longest a cold start ever takes.
+				notifier.Status("Waiting for the signer process to initialise the CA")
 				conn, err := signer.DialConn()
 				if err != nil {
 					return fmt.Errorf("connecting to signer process: %w", err)
@@ -534,6 +559,7 @@ func newRootCmd() *cobra.Command {
 				myCA.KeyProvider = provider
 			}
 
+			notifier.Status("Initialising the CA")
 			if err := myCA.Init(ctx); err != nil {
 				return fmt.Errorf("failed to initialise CA: %w", err)
 			}
@@ -716,8 +742,13 @@ func newRootCmd() *cobra.Command {
 			shutdownDone := make(chan struct{})
 			go func() {
 				<-ctx.Done()
+				drain := cfg.shutdownDrain()
 				slog.Info("Shutting down")
-				shutdownCtx, cancel := context.WithTimeout(context.Background(), cfg.shutdownDrain())
+				// Tell the service manager this is a deliberate teardown, not
+				// a crash, and how long it may take — so it waits for the
+				// drain instead of killing connections mid-flight.
+				notifier.Stopping(fmt.Sprintf("Shutting down: draining connections (up to %s)", drain))
+				shutdownCtx, cancel := context.WithTimeout(context.Background(), drain)
 				defer cancel()
 				if metricsServer != nil {
 					if err := metricsServer.Shutdown(shutdownCtx); err != nil {
@@ -730,11 +761,25 @@ func newRootCmd() *cobra.Command {
 				close(shutdownDone)
 			}()
 
+			// Bind the listener explicitly rather than letting ListenAndServe
+			// do it, so readiness can be announced at the point the socket is
+			// actually accepting connections. Anything ordered after this
+			// service can then connect on its first attempt.
+			notifier.Status("Starting the HTTP server")
+			ln, err := net.Listen("tcp", addr)
+			if err != nil {
+				return fmt.Errorf("failed to listen on %s: %w", addr, err)
+			}
+
+			status := func() string { return newStatusReport(myCA, addr, tlsConfigured).line(time.Now()) }
+			notifier.Ready(status())
+			go runNotifyHeartbeat(ctx, notifier, heartbeatInterval(notifier), status)
+
 			var serveErr error
 			if cfg.TLSCert != "" && cfg.TLSKey != "" {
-				serveErr = server.ListenAndServeTLS("", "")
+				serveErr = server.ServeTLS(ln, "", "")
 			} else {
-				serveErr = server.ListenAndServe()
+				serveErr = server.Serve(ln)
 			}
 			if serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
 				return fmt.Errorf("server failed: %w", serveErr)

--- a/cmd/openvox-ca/notify.go
+++ b/cmd/openvox-ca/notify.go
@@ -35,13 +35,16 @@ import (
 // costs one datagram.
 const defaultStatusRefresh = time.Minute
 
-// minHeartbeat floors the derived heartbeat interval so a pathologically short
-// WatchdogSec= cannot have the CA spinning on a ticker. It is well under a
-// second because the floor must never exceed the deadline it is beating: at
-// WatchdogSec=1s a one-second floor would send exactly one keep-alive per
-// interval and the service manager would kill the CA on the first tick that
-// drifted.
+// minHeartbeat is the interval below which a WatchdogSec= is reported as
+// suspiciously short. It is not a hard floor: clamping to it would mean
+// returning an interval longer than the deadline it feeds, which guarantees the
+// kill it exists to prevent. See heartbeatInterval.
 const minHeartbeat = 100 * time.Millisecond
+
+// absoluteMinHeartbeat bounds the ticker for a WatchdogSec= so short that even
+// half of it is sub-millisecond. Nobody configures this deliberately; the point
+// is only that the CA neither spins nor silently misses the deadline.
+const absoluteMinHeartbeat = 10 * time.Millisecond
 
 // statusReport is the state summarised into the service manager's status text.
 // It is captured as plain values so the rendering below is a pure function of
@@ -142,15 +145,18 @@ func heartbeatInterval(n *sdnotify.Notifier) time.Duration {
 	if watchdog <= 0 {
 		return defaultStatusRefresh
 	}
-	if half := watchdog / 2; half > minHeartbeat {
+	half := watchdog / 2
+	if half >= minHeartbeat {
 		return half
 	}
-	// Below 2*minHeartbeat the floor takes over. Say so: a WatchdogSec= this
-	// short is almost always a typo, and the symptom otherwise is a service
-	// that systemd kills and restarts with nothing to explain why.
-	slog.Warn("WatchdogSec is very short; the CA will feed the watchdog at the minimum interval",
-		"watchdog", watchdog, "heartbeat", minHeartbeat)
-	return minHeartbeat
+	// Half the deadline is still the right answer — an interval longer than the
+	// deadline would guarantee the kill this is meant to prevent — but a
+	// WatchdogSec= this short is almost always a typo, and the symptom
+	// otherwise is a service systemd kills and restarts with nothing to
+	// explain why.
+	slog.Warn("WatchdogSec is very short; the CA will feed the watchdog at half that interval",
+		"watchdog", watchdog, "heartbeat", max(half, absoluteMinHeartbeat))
+	return max(half, absoluteMinHeartbeat)
 }
 
 // runNotifyHeartbeat keeps the service manager's view of the CA current: it
@@ -158,10 +164,13 @@ func heartbeatInterval(n *sdnotify.Notifier) time.Duration {
 // text so its countdowns do not go stale. It returns when ctx is cancelled.
 //
 // The keep-alive is deliberately sent from the process that serves the API
-// rather than the launcher, so a frontend wedged on a stuck backend stops
-// feeding the watchdog and gets restarted — which is the failure the watchdog
-// exists to catch. A launcher-side ping would only prove the supervisor is
-// alive, which it always is.
+// rather than the launcher, which would only ever prove the supervisor is
+// alive. Be precise about what that buys: it proves this process and this
+// goroutine are still scheduling, so it catches death, a runtime deadlock, and
+// a stall behind the CA's write lock (composing the status text takes the
+// matching read lock). It does not catch an API that is unresponsive for a
+// reason that leaves this goroutine running — handlers blocked on a read-only
+// backend call, say. That is what /healthz/ready is for; see docs/systemd.md.
 func runNotifyHeartbeat(ctx context.Context, n *sdnotify.Notifier, interval time.Duration, status func() string) {
 	if !n.Enabled() {
 		return

--- a/cmd/openvox-ca/notify.go
+++ b/cmd/openvox-ca/notify.go
@@ -35,9 +35,13 @@ import (
 // costs one datagram.
 const defaultStatusRefresh = time.Minute
 
-// minHeartbeat floors the derived heartbeat interval. A pathologically short
-// WatchdogSec= would otherwise have the CA spinning on a ticker.
-const minHeartbeat = time.Second
+// minHeartbeat floors the derived heartbeat interval so a pathologically short
+// WatchdogSec= cannot have the CA spinning on a ticker. It is well under a
+// second because the floor must never exceed the deadline it is beating: at
+// WatchdogSec=1s a one-second floor would send exactly one keep-alive per
+// interval and the service manager would kill the CA on the first tick that
+// drifted.
+const minHeartbeat = 100 * time.Millisecond
 
 // statusReport is the state summarised into the service manager's status text.
 // It is captured as plain values so the rendering below is a pure function of
@@ -141,6 +145,11 @@ func heartbeatInterval(n *sdnotify.Notifier) time.Duration {
 	if half := watchdog / 2; half > minHeartbeat {
 		return half
 	}
+	// Below 2*minHeartbeat the floor takes over. Say so: a WatchdogSec= this
+	// short is almost always a typo, and the symptom otherwise is a service
+	// that systemd kills and restarts with nothing to explain why.
+	slog.Warn("WatchdogSec is very short; the CA will feed the watchdog at the minimum interval",
+		"watchdog", watchdog, "heartbeat", minHeartbeat)
 	return minHeartbeat
 }
 

--- a/cmd/openvox-ca/notify.go
+++ b/cmd/openvox-ca/notify.go
@@ -1,0 +1,174 @@
+// Copyright (C) 2026 Chris Boot
+// Copyright (C) 2026 Vox Pupuli and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/voxpupuli/openvox-ca/internal/ca"
+	"github.com/voxpupuli/openvox-ca/internal/sdnotify"
+)
+
+// defaultStatusRefresh is how often the service manager's status text is
+// refreshed when the unit has no watchdog configured. The text embeds
+// countdowns ("expires in 12d"), so it has to be re-sent to stay true; a
+// minute is frequent enough for an operator reading `systemctl status` and
+// costs one datagram.
+const defaultStatusRefresh = time.Minute
+
+// minHeartbeat floors the derived heartbeat interval. A pathologically short
+// WatchdogSec= would otherwise have the CA spinning on a ticker.
+const minHeartbeat = time.Second
+
+// statusReport is the state summarised into the service manager's status text.
+// It is captured as plain values so the rendering below is a pure function of
+// the snapshot and the current time — the CA is read once, under its own
+// locks, by newStatusReport.
+type statusReport struct {
+	addr    string // the API listener's address
+	tls     bool   // whether the API listener speaks HTTPS
+	caCN    string // CA certificate common name; empty if the CA is not loaded
+	caUntil time.Time
+	crl     ca.CRLSnapshot
+	crlOK   bool // whether the CA has a CRL in memory at all
+}
+
+// newStatusReport samples the CA's live state. Everything it reads is held in
+// memory by the CA (the certificate it loaded at startup and its cached CRL),
+// so this is cheap enough to call on a timer. Counting certificates
+// deliberately does not appear here: that means listing the inventory in the
+// storage backend, which is a scrape-weight operation and not something to do
+// every heartbeat.
+func newStatusReport(c *ca.CA, addr string, tlsEnabled bool) statusReport {
+	r := statusReport{addr: addr, tls: tlsEnabled}
+	if cert := c.CACert; cert != nil {
+		r.caCN = cert.Subject.CommonName
+		r.caUntil = cert.NotAfter
+	}
+	r.crl, r.crlOK = c.CRLSnapshot()
+	return r
+}
+
+// line renders the report as a single-line status suitable for `systemctl
+// status`. It leads with what the service is doing, then the two pieces of
+// state that silently stop a CA from being useful: an expiring CA certificate
+// and a lapsing CRL.
+func (r statusReport) line(now time.Time) string {
+	scheme := "HTTP"
+	if r.tls {
+		scheme = "HTTPS"
+	}
+	parts := []string{fmt.Sprintf("Serving %s on %s", scheme, r.addr)}
+
+	if r.caCN != "" {
+		// Quoted because a Puppet CA's common name conventionally contains a
+		// colon ("Puppet CA: puppet.example.com"), which otherwise runs into
+		// the phrase that follows it.
+		parts = append(parts, fmt.Sprintf("CA %q %s", r.caCN, deadlinePhrase(r.caUntil, now)))
+	}
+
+	switch {
+	case !r.crlOK:
+		parts = append(parts, "CRL not loaded")
+	default:
+		crl := "CRL"
+		if r.crl.Number != nil {
+			crl += " #" + r.crl.Number.String()
+		}
+		parts = append(parts, fmt.Sprintf("%s (%d revoked) %s",
+			crl, r.crl.Revoked, deadlinePhrase(r.crl.NextUpdate, now)))
+	}
+
+	return strings.Join(parts, " | ")
+}
+
+// deadlinePhrase renders how long is left until deadline, or how long ago it
+// passed. An elapsed deadline is spelled in capitals so it stands out in
+// `systemctl status` output, which is the point of putting it there at all.
+func deadlinePhrase(deadline, now time.Time) string {
+	if deadline.IsZero() {
+		return "expiry unknown"
+	}
+	if remaining := deadline.Sub(now); remaining > 0 {
+		return "expires in " + humanDuration(remaining)
+	}
+	return "EXPIRED " + humanDuration(now.Sub(deadline)) + " ago"
+}
+
+// humanDuration renders d at a single, coarse unit. Status text is read at a
+// glance, so "42d" is more useful than a precise but unreadable breakdown.
+func humanDuration(d time.Duration) string {
+	switch {
+	case d >= 48*time.Hour:
+		return fmt.Sprintf("%dd", int64(d/(24*time.Hour)))
+	case d >= 2*time.Hour:
+		return fmt.Sprintf("%dh", int64(d/time.Hour))
+	case d >= time.Minute:
+		return fmt.Sprintf("%dm", int64(d/time.Minute))
+	default:
+		return fmt.Sprintf("%ds", int64(d/time.Second))
+	}
+}
+
+// heartbeatInterval derives how often to feed the watchdog and refresh the
+// status text. sd_watchdog_enabled(3) advises notifying at least twice per
+// WatchdogSec= interval, so half of it leaves a full interval of slack for a
+// momentarily busy process before the service manager declares the CA hung.
+func heartbeatInterval(n *sdnotify.Notifier) time.Duration {
+	watchdog := n.WatchdogInterval()
+	if watchdog <= 0 {
+		return defaultStatusRefresh
+	}
+	if half := watchdog / 2; half > minHeartbeat {
+		return half
+	}
+	return minHeartbeat
+}
+
+// runNotifyHeartbeat keeps the service manager's view of the CA current: it
+// feeds the watchdog (when the unit enables one) and re-publishes the status
+// text so its countdowns do not go stale. It returns when ctx is cancelled.
+//
+// The keep-alive is deliberately sent from the process that serves the API
+// rather than the launcher, so a frontend wedged on a stuck backend stops
+// feeding the watchdog and gets restarted — which is the failure the watchdog
+// exists to catch. A launcher-side ping would only prove the supervisor is
+// alive, which it always is.
+func runNotifyHeartbeat(ctx context.Context, n *sdnotify.Notifier, interval time.Duration, status func() string) {
+	if !n.Enabled() {
+		return
+	}
+	slog.Debug("Starting service manager heartbeat",
+		"interval", interval, "watchdog", n.WatchdogInterval())
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			n.Watchdog()
+			n.Status(status())
+		}
+	}
+}

--- a/cmd/openvox-ca/notify.go
+++ b/cmd/openvox-ca/notify.go
@@ -35,15 +35,19 @@ import (
 // costs one datagram.
 const defaultStatusRefresh = time.Minute
 
-// minHeartbeat is the interval below which a WatchdogSec= is reported as
-// suspiciously short. It is not a hard floor: clamping to it would mean
-// returning an interval longer than the deadline it feeds, which guarantees the
-// kill it exists to prevent. See heartbeatInterval.
-const minHeartbeat = 100 * time.Millisecond
+// shortWatchdogWarnBelow is the heartbeat interval below which a WatchdogSec=
+// is reported as suspiciously short. It is a warning threshold, not a floor:
+// clamping up to it would mean returning an interval longer than the deadline
+// being fed, which guarantees the kill the watchdog exists to prevent.
+const shortWatchdogWarnBelow = 100 * time.Millisecond
 
-// absoluteMinHeartbeat bounds the ticker for a WatchdogSec= so short that even
-// half of it is sub-millisecond. Nobody configures this deliberately; the point
-// is only that the CA neither spins nor silently misses the deadline.
+// absoluteMinHeartbeat stops the ticker being shortened without limit for an
+// absurd WatchdogSec=. This is a deliberate trade, and it is the one place the
+// deadline is not honoured: below a 20ms WatchdogSec= the CA feeds slower than
+// half the deadline, and below 10ms slower than the deadline itself, so the
+// service manager will kill it. Spinning a sub-millisecond ticker to chase a
+// deadline nobody configures on purpose is the worse failure, and the warning
+// says which one is happening.
 const absoluteMinHeartbeat = 10 * time.Millisecond
 
 // statusReport is the state summarised into the service manager's status text.
@@ -146,17 +150,19 @@ func heartbeatInterval(n *sdnotify.Notifier) time.Duration {
 		return defaultStatusRefresh
 	}
 	half := watchdog / 2
-	if half >= minHeartbeat {
+	if half >= shortWatchdogWarnBelow {
 		return half
 	}
-	// Half the deadline is still the right answer — an interval longer than the
-	// deadline would guarantee the kill this is meant to prevent — but a
-	// WatchdogSec= this short is almost always a typo, and the symptom
-	// otherwise is a service systemd kills and restarts with nothing to
-	// explain why.
-	slog.Warn("WatchdogSec is very short; the CA will feed the watchdog at half that interval",
-		"watchdog", watchdog, "heartbeat", max(half, absoluteMinHeartbeat))
-	return max(half, absoluteMinHeartbeat)
+	// Half the deadline is still the right answer wherever it is achievable —
+	// an interval longer than the deadline guarantees the kill this is meant to
+	// prevent — but a WatchdogSec= this short is almost always a typo, and the
+	// symptom otherwise is a service the manager kills and restarts with
+	// nothing to explain why. Report the interval actually chosen, which below
+	// a 20ms deadline is the floor rather than half.
+	interval := max(half, absoluteMinHeartbeat)
+	slog.Warn("WatchdogSec is very short; the watchdog may not be fed in time",
+		"watchdog", watchdog, "heartbeat", interval)
+	return interval
 }
 
 // runNotifyHeartbeat keeps the service manager's view of the CA current: it

--- a/cmd/openvox-ca/notify_test.go
+++ b/cmd/openvox-ca/notify_test.go
@@ -1,0 +1,267 @@
+// Copyright (C) 2026 Chris Boot
+// Copyright (C) 2026 Vox Pupuli and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package main
+
+import (
+	"context"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/voxpupuli/openvox-ca/internal/ca"
+	"github.com/voxpupuli/openvox-ca/internal/sdnotify"
+)
+
+// notifyRecorder stands in for a service manager listening on $NOTIFY_SOCKET,
+// recording every notification the process under test sends.
+type notifyRecorder struct {
+	msgs chan string
+}
+
+// startNotifyRecorder binds a datagram socket, points $NOTIFY_SOCKET at it and
+// drains messages until the spec ends. The socket, the temporary directory and
+// the environment variables are all restored on cleanup so specs stay isolated.
+func startNotifyRecorder(env map[string]string) *notifyRecorder {
+	dir, err := os.MkdirTemp("", "notify")
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(func() { Expect(os.RemoveAll(dir)).To(Succeed()) })
+
+	path := filepath.Join(dir, "notify.sock")
+	conn, err := net.ListenUnixgram("unixgram", &net.UnixAddr{Name: path, Net: "unixgram"})
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(func() { conn.Close() })
+
+	r := &notifyRecorder{msgs: make(chan string, 64)}
+	go func() {
+		buf := make([]byte, 8192)
+		for {
+			n, err := conn.Read(buf)
+			if err != nil {
+				close(r.msgs)
+				return
+			}
+			r.msgs <- string(buf[:n])
+		}
+	}()
+
+	setSpecEnv("NOTIFY_SOCKET", path)
+	for k, v := range env {
+		setSpecEnv(k, v)
+	}
+	return r
+}
+
+// setSpecEnv sets an environment variable for the duration of the current
+// spec. Ginkgo nodes cannot use testing.T.Setenv, so the previous value (or
+// its absence) is restored explicitly.
+func setSpecEnv(key, value string) {
+	prev, had := os.LookupEnv(key)
+	ExpectWithOffset(1, os.Setenv(key, value)).To(Succeed())
+	DeferCleanup(func() {
+		if had {
+			Expect(os.Setenv(key, prev)).To(Succeed())
+			return
+		}
+		Expect(os.Unsetenv(key)).To(Succeed())
+	})
+}
+
+var _ = Describe("Service manager status text", func() {
+	// A fixed "now" keeps the rendered countdowns deterministic.
+	now := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+
+	Describe("humanDuration", func() {
+		DescribeTable("renders a single coarse unit",
+			func(d time.Duration, expected string) {
+				Expect(humanDuration(d)).To(Equal(expected))
+			},
+			Entry("years become days", 1794*24*time.Hour, "1794d"),
+			Entry("days", 72*time.Hour, "3d"),
+			Entry("just under two days falls back to hours", 47*time.Hour, "47h"),
+			Entry("hours", 5*time.Hour, "5h"),
+			Entry("just under two hours falls back to minutes", 119*time.Minute, "119m"),
+			Entry("minutes", 90*time.Second, "1m"),
+			Entry("seconds", 30*time.Second, "30s"),
+			Entry("sub-second", 100*time.Millisecond, "0s"),
+		)
+	})
+
+	Describe("deadlinePhrase", func() {
+		It("counts down to a future deadline", func() {
+			Expect(deadlinePhrase(now.Add(72*time.Hour), now)).To(Equal("expires in 3d"))
+		})
+
+		It("shouts about a deadline that has passed", func() {
+			// Capitalised on purpose: this is the line an operator should
+			// notice in `systemctl status`.
+			Expect(deadlinePhrase(now.Add(-48*time.Hour), now)).To(Equal("EXPIRED 2d ago"))
+		})
+
+		It("admits when it does not know", func() {
+			Expect(deadlinePhrase(time.Time{}, now)).To(Equal("expiry unknown"))
+		})
+	})
+
+	Describe("statusReport", func() {
+		var report statusReport
+
+		BeforeEach(func() {
+			report = statusReport{
+				addr:    "0.0.0.0:8140",
+				tls:     true,
+				caCN:    "puppet.example.com",
+				caUntil: now.Add(1794 * 24 * time.Hour),
+				crlOK:   true,
+				crl: ca.CRLSnapshot{
+					Number:     big.NewInt(7),
+					NextUpdate: now.Add(29 * 24 * time.Hour),
+					Revoked:    3,
+				},
+			}
+		})
+
+		It("summarises the listener, the CA and the CRL", func() {
+			Expect(report.line(now)).To(Equal(
+				`Serving HTTPS on 0.0.0.0:8140 | CA "puppet.example.com" expires in 1794d | CRL #7 (3 revoked) expires in 29d`))
+		})
+
+		It("distinguishes a plain HTTP listener", func() {
+			report.tls = false
+			Expect(report.line(now)).To(HavePrefix("Serving HTTP on 0.0.0.0:8140 |"))
+		})
+
+		It("omits the CA when it is not loaded", func() {
+			report.caCN = ""
+			Expect(report.line(now)).NotTo(ContainSubstring("CA \""))
+			Expect(report.line(now)).To(ContainSubstring("CRL #7"))
+		})
+
+		It("says so when no CRL has been loaded", func() {
+			report.crlOK = false
+			Expect(report.line(now)).To(HaveSuffix("| CRL not loaded"))
+		})
+
+		It("copes with a CRL that has no number", func() {
+			report.crl.Number = nil
+			Expect(report.line(now)).To(ContainSubstring("| CRL (3 revoked) expires in 29d"))
+		})
+
+		It("surfaces an expired CA certificate", func() {
+			report.caUntil = now.Add(-24 * time.Hour)
+			Expect(report.line(now)).To(ContainSubstring(`CA "puppet.example.com" EXPIRED 24h ago`))
+		})
+
+		It("surfaces a lapsed CRL", func() {
+			report.crl.NextUpdate = now.Add(-72 * time.Hour)
+			Expect(report.line(now)).To(ContainSubstring("CRL #7 (3 revoked) EXPIRED 3d ago"))
+		})
+	})
+
+	Describe("newStatusReport", func() {
+		It("reads the CA's certificate and cached CRL", func() {
+			// A CA that has never been initialised still has to produce a
+			// status line rather than panic: the heartbeat runs regardless.
+			report := newStatusReport(ca.New(nil, ca.AutosignConfig{}, "host"), "127.0.0.1:8140", false)
+			Expect(report.caCN).To(BeEmpty())
+			Expect(report.crlOK).To(BeFalse())
+			Expect(report.line(now)).To(Equal("Serving HTTP on 127.0.0.1:8140 | CRL not loaded"))
+		})
+	})
+})
+
+var _ = Describe("Service manager heartbeat", func() {
+	Describe("heartbeatInterval", func() {
+		It("refreshes the status text once a minute without a watchdog", func() {
+			startNotifyRecorder(nil)
+			n := sdnotify.New()
+			DeferCleanup(func() { Expect(n.Close()).To(Succeed()) })
+
+			Expect(heartbeatInterval(n)).To(Equal(defaultStatusRefresh))
+		})
+
+		It("beats twice per watchdog interval", func() {
+			startNotifyRecorder(map[string]string{"WATCHDOG_USEC": "30000000"})
+			n := sdnotify.New()
+			DeferCleanup(func() { Expect(n.Close()).To(Succeed()) })
+
+			Expect(heartbeatInterval(n)).To(Equal(15 * time.Second))
+		})
+
+		It("never beats faster than the floor", func() {
+			// A 100ms WatchdogSec would otherwise have the CA spinning.
+			startNotifyRecorder(map[string]string{"WATCHDOG_USEC": "100000"})
+			n := sdnotify.New()
+			DeferCleanup(func() { Expect(n.Close()).To(Succeed()) })
+
+			Expect(heartbeatInterval(n)).To(Equal(minHeartbeat))
+		})
+	})
+
+	Describe("runNotifyHeartbeat", func() {
+		It("returns immediately when there is no service manager", func() {
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				runNotifyHeartbeat(context.Background(), sdnotify.New(), time.Hour, func() string { return "x" })
+			}()
+			Eventually(done).Should(BeClosed())
+		})
+
+		It("feeds the watchdog and republishes the status", func() {
+			rec := startNotifyRecorder(map[string]string{"WATCHDOG_USEC": "30000000"})
+			n := sdnotify.New()
+			DeferCleanup(func() { Expect(n.Close()).To(Succeed()) })
+
+			ctx, cancel := context.WithCancel(context.Background())
+			DeferCleanup(cancel)
+
+			calls := make(chan struct{}, 16)
+			go runNotifyHeartbeat(ctx, n, 10*time.Millisecond, func() string {
+				select {
+				case calls <- struct{}{}:
+				default:
+				}
+				return "still here"
+			})
+
+			Eventually(calls).Should(Receive())
+			Eventually(rec.msgs).Should(Receive(Equal("WATCHDOG=1")))
+			Eventually(rec.msgs).Should(Receive(Equal("STATUS=still here\n")))
+		})
+
+		It("stops when the context is cancelled", func() {
+			startNotifyRecorder(nil)
+			n := sdnotify.New()
+			DeferCleanup(func() { Expect(n.Close()).To(Succeed()) })
+
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				runNotifyHeartbeat(ctx, n, time.Millisecond, func() string { return "x" })
+			}()
+
+			cancel()
+			Eventually(done).Should(BeClosed())
+		})
+	})
+})

--- a/cmd/openvox-ca/notify_test.go
+++ b/cmd/openvox-ca/notify_test.go
@@ -63,26 +63,12 @@ func startNotifyRecorder(env map[string]string) *notifyRecorder {
 		}
 	}()
 
-	setSpecEnv("NOTIFY_SOCKET", path)
+	// setEnv is the package's existing save/restore helper (config_test.go).
+	setEnv("NOTIFY_SOCKET", path)
 	for k, v := range env {
-		setSpecEnv(k, v)
+		setEnv(k, v)
 	}
 	return r
-}
-
-// setSpecEnv sets an environment variable for the duration of the current
-// spec. Ginkgo nodes cannot use testing.T.Setenv, so the previous value (or
-// its absence) is restored explicitly.
-func setSpecEnv(key, value string) {
-	prev, had := os.LookupEnv(key)
-	ExpectWithOffset(1, os.Setenv(key, value)).To(Succeed())
-	DeferCleanup(func() {
-		if had {
-			Expect(os.Setenv(key, prev)).To(Succeed())
-			return
-		}
-		Expect(os.Unsetenv(key)).To(Succeed())
-	})
 }
 
 var _ = Describe("Service manager status text", func() {
@@ -95,8 +81,10 @@ var _ = Describe("Service manager status text", func() {
 				Expect(humanDuration(d)).To(Equal(expected))
 			},
 			Entry("years become days", 1794*24*time.Hour, "1794d"),
+			Entry("exactly two days", 48*time.Hour, "2d"),
 			Entry("days", 72*time.Hour, "3d"),
 			Entry("just under two days falls back to hours", 47*time.Hour, "47h"),
+			Entry("exactly two hours", 2*time.Hour, "2h"),
 			Entry("hours", 5*time.Hour, "5h"),
 			Entry("just under two hours falls back to minutes", 119*time.Minute, "119m"),
 			Entry("minutes", 90*time.Second, "1m"),
@@ -207,12 +195,25 @@ var _ = Describe("Service manager heartbeat", func() {
 		})
 
 		It("never beats faster than the floor", func() {
-			// A 100ms WatchdogSec would otherwise have the CA spinning.
-			startNotifyRecorder(map[string]string{"WATCHDOG_USEC": "100000"})
+			// A 10ms WatchdogSec would otherwise have the CA spinning.
+			startNotifyRecorder(map[string]string{"WATCHDOG_USEC": "10000"})
 			n := sdnotify.New()
 			DeferCleanup(func() { Expect(n.Close()).To(Succeed()) })
 
 			Expect(heartbeatInterval(n)).To(Equal(minHeartbeat))
+		})
+
+		It("keeps the floor below the shortest watchdog it will honour", func() {
+			// The floor must never exceed the deadline it is beating: at
+			// WatchdogSec=1s a one-second floor would send exactly one
+			// keep-alive per interval and systemd would kill the CA on the
+			// first tick that drifted.
+			startNotifyRecorder(map[string]string{"WATCHDOG_USEC": "1000000"})
+			n := sdnotify.New()
+			DeferCleanup(func() { Expect(n.Close()).To(Succeed()) })
+
+			Expect(heartbeatInterval(n)).To(Equal(500 * time.Millisecond))
+			Expect(heartbeatInterval(n)).To(BeNumerically("<", n.WatchdogInterval()))
 		})
 	})
 
@@ -244,7 +245,7 @@ var _ = Describe("Service manager heartbeat", func() {
 			})
 
 			Eventually(calls).Should(Receive())
-			Eventually(rec.msgs).Should(Receive(Equal("WATCHDOG=1")))
+			Eventually(rec.msgs).Should(Receive(Equal("WATCHDOG=1\n")))
 			Eventually(rec.msgs).Should(Receive(Equal("STATUS=still here\n")))
 		})
 

--- a/cmd/openvox-ca/notify_test.go
+++ b/cmd/openvox-ca/notify_test.go
@@ -18,7 +18,9 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"math/big"
 	"net"
 	"os"
@@ -214,11 +216,13 @@ var _ = Describe("Service manager heartbeat", func() {
 			Expect(heartbeatInterval(n)).To(Equal(absoluteMinHeartbeat))
 		})
 
-		DescribeTable("always beats strictly inside the deadline",
+		DescribeTable("beats strictly inside every deadline it can honour",
 			func(usec string) {
-				// The invariant that matters: whatever WatchdogSec is, the
-				// keep-alive must be sent more often than the deadline, or
-				// systemd kills a perfectly healthy CA.
+				// The invariant that matters: for any WatchdogSec an operator
+				// might realistically set, the keep-alive goes out more often
+				// than the deadline, or systemd kills a healthy CA. Below 20ms
+				// the ticker floor wins instead — deliberately, and loudly; see
+				// the spec above.
 				startNotifyRecorder(map[string]string{"WATCHDOG_USEC": usec})
 				n := sdnotify.New()
 				DeferCleanup(func() { Expect(n.Close()).To(Succeed()) })
@@ -231,7 +235,39 @@ var _ = Describe("Service manager heartbeat", func() {
 			Entry("200ms", "200000"),
 			Entry("150ms", "150000"),
 			Entry("30ms", "30000"),
+			Entry("21ms, just above where the floor takes over", "21000"),
 		)
+
+		It("warns when the watchdog is too short to be fed reliably", func() {
+			// The operator-facing half of the trade-off: the CA does not
+			// silently accept a deadline it cannot meet.
+			var buf bytes.Buffer
+			orig := slog.Default()
+			slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+			defer slog.SetDefault(orig)
+
+			startNotifyRecorder(map[string]string{"WATCHDOG_USEC": "5000"}) // 5ms
+			n := sdnotify.New()
+			DeferCleanup(func() { Expect(n.Close()).To(Succeed()) })
+
+			Expect(heartbeatInterval(n)).To(Equal(absoluteMinHeartbeat))
+			Expect(buf.String()).To(ContainSubstring("WatchdogSec is very short"))
+			Expect(buf.String()).To(ContainSubstring("heartbeat=10ms"))
+		})
+
+		It("says nothing about a watchdog it can honour", func() {
+			var buf bytes.Buffer
+			orig := slog.Default()
+			slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+			defer slog.SetDefault(orig)
+
+			startNotifyRecorder(map[string]string{"WATCHDOG_USEC": "60000000"})
+			n := sdnotify.New()
+			DeferCleanup(func() { Expect(n.Close()).To(Succeed()) })
+
+			Expect(heartbeatInterval(n)).To(Equal(30 * time.Second))
+			Expect(buf.String()).To(BeEmpty())
+		})
 	})
 
 	Describe("runNotifyHeartbeat", func() {

--- a/cmd/openvox-ca/notify_test.go
+++ b/cmd/openvox-ca/notify_test.go
@@ -194,27 +194,44 @@ var _ = Describe("Service manager heartbeat", func() {
 			Expect(heartbeatInterval(n)).To(Equal(15 * time.Second))
 		})
 
-		It("never beats faster than the floor", func() {
-			// A 10ms WatchdogSec would otherwise have the CA spinning.
-			startNotifyRecorder(map[string]string{"WATCHDOG_USEC": "10000"})
+		It("still halves a watchdog short enough to warn about", func() {
+			// Clamping up to a fixed floor here would return an interval longer
+			// than the deadline it feeds, guaranteeing the kill the watchdog
+			// exists to prevent. Half is still the right answer; the operator
+			// gets a warning instead.
+			startNotifyRecorder(map[string]string{"WATCHDOG_USEC": "150000"}) // 150ms
 			n := sdnotify.New()
 			DeferCleanup(func() { Expect(n.Close()).To(Succeed()) })
 
-			Expect(heartbeatInterval(n)).To(Equal(minHeartbeat))
+			Expect(heartbeatInterval(n)).To(Equal(75 * time.Millisecond))
 		})
 
-		It("keeps the floor below the shortest watchdog it will honour", func() {
-			// The floor must never exceed the deadline it is beating: at
-			// WatchdogSec=1s a one-second floor would send exactly one
-			// keep-alive per interval and systemd would kill the CA on the
-			// first tick that drifted.
-			startNotifyRecorder(map[string]string{"WATCHDOG_USEC": "1000000"})
+		It("stops shortening the ticker for an absurd watchdog", func() {
+			startNotifyRecorder(map[string]string{"WATCHDOG_USEC": "1000"}) // 1ms
 			n := sdnotify.New()
 			DeferCleanup(func() { Expect(n.Close()).To(Succeed()) })
 
-			Expect(heartbeatInterval(n)).To(Equal(500 * time.Millisecond))
-			Expect(heartbeatInterval(n)).To(BeNumerically("<", n.WatchdogInterval()))
+			Expect(heartbeatInterval(n)).To(Equal(absoluteMinHeartbeat))
 		})
+
+		DescribeTable("always beats strictly inside the deadline",
+			func(usec string) {
+				// The invariant that matters: whatever WatchdogSec is, the
+				// keep-alive must be sent more often than the deadline, or
+				// systemd kills a perfectly healthy CA.
+				startNotifyRecorder(map[string]string{"WATCHDOG_USEC": usec})
+				n := sdnotify.New()
+				DeferCleanup(func() { Expect(n.Close()).To(Succeed()) })
+
+				Expect(heartbeatInterval(n)).To(BeNumerically("<", n.WatchdogInterval()))
+			},
+			Entry("a minute", "60000000"),
+			Entry("two seconds", "2000000"),
+			Entry("one second", "1000000"),
+			Entry("200ms", "200000"),
+			Entry("150ms", "150000"),
+			Entry("30ms", "30000"),
+		)
 	})
 
 	Describe("runNotifyHeartbeat", func() {

--- a/cmd/openvox-ca/reload.go
+++ b/cmd/openvox-ca/reload.go
@@ -24,10 +24,9 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"os/signal"
+	"sort"
 	"strings"
 	"sync/atomic"
-	"syscall"
 
 	"github.com/voxpupuli/openvox-ca/internal/api"
 	"github.com/voxpupuli/openvox-ca/internal/sdnotify"
@@ -151,14 +150,43 @@ func (r *configReloader) reload() error {
 		if err != nil {
 			errs = append(errs, err)
 		} else {
-			r.auth.SetAllowList(allowList)
-			slog.Info("Reloaded admin allow list", "admin_cns", len(allowList))
+			// SECURITY: log which CNs gained or lost admin authority, not just
+			// how many there are. A count alone cannot distinguish "the list is
+			// unchanged" from "one compile server was swapped for another", and
+			// this is the only moment the change is observable — the file can be
+			// rewritten again straight afterwards. CNs are hostnames, not secrets.
+			// NIST 800-53: AU-2 (Event Logging), AC-6 (Least Privilege)
+			added, removed := diffAllowList(r.auth.SetAllowList(allowList), allowList)
+			if len(added) > 0 || len(removed) > 0 {
+				slog.Info("Reloaded admin allow list",
+					"added", added, "removed", removed, "admin_cns", len(allowList))
+			} else {
+				slog.Info("Reloaded admin allow list, unchanged", "admin_cns", len(allowList))
+			}
 		}
 	}
 
 	err := errors.Join(errs...)
 	r.failed.Store(err != nil)
 	return err
+}
+
+// diffAllowList reports which CNs the replacement adds and which it withdraws,
+// each sorted so the log line is stable and diffable.
+func diffAllowList(old, new map[string]bool) (added, removed []string) {
+	for cn := range new {
+		if !old[cn] {
+			added = append(added, cn)
+		}
+	}
+	for cn := range old {
+		if !new[cn] {
+			removed = append(removed, cn)
+		}
+	}
+	sort.Strings(added)
+	sort.Strings(removed)
+	return added, removed
 }
 
 // buildAdminAllowList merges the comma-separated CN list from the running
@@ -182,10 +210,19 @@ func buildAdminAllowList(staticCNs, cnFile string) (map[string]bool, error) {
 	return allowList, nil
 }
 
-// runReloadWatcher applies a configuration reload on every SIGHUP until ctx is
-// cancelled. It also reports the reload to the service manager, which is what
-// makes `systemctl reload` (Type=notify-reload) wait for the new configuration
-// to be in effect rather than returning the instant the signal is delivered.
+// runReloadWatcher applies a configuration reload on every signal delivered to
+// hupCh until ctx is cancelled. It also reports the reload to the service
+// manager, which is what makes `systemctl reload` (Type=notify-reload) wait for
+// the new configuration to be in effect rather than returning the instant the
+// signal is delivered.
+//
+// hupCh is registered by the caller, before the startup work this watcher's
+// configuration depends on. That ordering matters: SIGHUP's default disposition
+// is to terminate, so a reload arriving during a slow start would otherwise kill
+// the process instead of reloading it, and a reload racing the READY=1 that
+// releases a queued reload job would fall into the gap between announcing
+// readiness and this goroutine being scheduled. A signal that arrives before
+// this loop runs waits in the channel buffer and is applied on entry.
 //
 // A reload that fails is not fatal: the previous configuration is still in
 // place and still correct, so the server keeps serving. The failure is logged,
@@ -193,16 +230,12 @@ func buildAdminAllowList(staticCNs, cnFile string) (map[string]bool, error) {
 // succeeds. READY=1 is sent either way — the protocol requires it to close out
 // RELOADING=1, and withholding it would only hang the reload job without
 // telling the operator anything the logs do not.
-func runReloadWatcher(ctx context.Context, n *sdnotify.Notifier, r *configReloader, status func() string) {
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGHUP)
-	defer signal.Stop(sigCh)
-
+func runReloadWatcher(ctx context.Context, hupCh <-chan os.Signal, n *sdnotify.Notifier, r *configReloader, status func() string) {
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-sigCh:
+		case <-hupCh:
 			slog.Info("Reloading configuration (SIGHUP)")
 			n.Reloading("Reloading TLS material and the admin allow list")
 

--- a/cmd/openvox-ca/reload.go
+++ b/cmd/openvox-ca/reload.go
@@ -1,0 +1,217 @@
+// Copyright (C) 2026 Chris Boot
+// Copyright (C) 2026 Vox Pupuli and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"strings"
+	"sync/atomic"
+	"syscall"
+
+	"github.com/voxpupuli/openvox-ca/internal/api"
+	"github.com/voxpupuli/openvox-ca/internal/sdnotify"
+)
+
+// certReloader owns the server's TLS keypair and can swap it for a freshly
+// read one without disturbing established connections.
+//
+// The CA's own server certificate is issued for a bounded lifetime like any
+// other, so it has to be replaced periodically. Handing crypto/tls a
+// GetCertificate callback instead of a fixed certificate means renewal costs a
+// reload rather than a restart: connections in flight keep the certificate
+// they negotiated with, and the next handshake picks up the new one.
+type certReloader struct {
+	certFile string
+	keyFile  string
+
+	// current is the keypair handed to new handshakes. It is read on every
+	// handshake and replaced on reload, so it is held in an atomic pointer
+	// rather than behind a lock.
+	current atomic.Pointer[tls.Certificate]
+}
+
+// newCertReloader loads the keypair for the first time, failing if it cannot
+// be read: an unusable certificate at startup is a configuration error and the
+// server must not come up pretending otherwise.
+func newCertReloader(certFile, keyFile string) (*certReloader, error) {
+	c := &certReloader{certFile: certFile, keyFile: keyFile}
+	if err := c.reload(); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// reload re-reads the keypair from disk and, only if it is complete and
+// internally consistent, installs it. A failed read leaves the previous
+// certificate in place, so reloading while the files are being rewritten
+// cannot leave the server without a certificate.
+func (c *certReloader) reload() error {
+	cert, err := tls.LoadX509KeyPair(c.certFile, c.keyFile)
+	if err != nil {
+		return fmt.Errorf("loading TLS cert/key (cert %s, key %s): %w", c.certFile, c.keyFile, err)
+	}
+	c.current.Store(&cert)
+
+	if cert.Leaf != nil {
+		slog.Info("Loaded TLS certificate",
+			"cert", c.certFile,
+			"subject", cert.Leaf.Subject.CommonName,
+			"not_after", cert.Leaf.NotAfter)
+	}
+	return nil
+}
+
+// GetCertificate satisfies tls.Config.GetCertificate.
+func (c *certReloader) GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	cert := c.current.Load()
+	if cert == nil {
+		// Unreachable: newCertReloader stores one before the listener exists.
+		return nil, errors.New("no TLS certificate loaded")
+	}
+	return cert, nil
+}
+
+// configReloader re-applies the parts of the configuration that are backed by
+// files and can be swapped safely while the server is running.
+//
+// Deliberately narrow: everything else (listen address, storage backend, key
+// custody, CA properties) is bound to state established at startup, and
+// pretending otherwise would be worse than requiring a restart. See
+// docs/systemd.md for the operator-facing description.
+type configReloader struct {
+	// certs is the TLS keypair holder, or nil when the server is running
+	// without TLS and there is nothing to rotate.
+	certs *certReloader
+
+	// auth is the live authorization config whose admin allow list is
+	// replaced, or nil when no mTLS enforcement is configured.
+	auth *api.AuthConfig
+
+	// staticCNs is the comma-separated --puppet-server value from the running
+	// configuration. It cannot change without a restart, but it is merged with
+	// the file on every reload so the resulting list stays complete.
+	staticCNs string
+
+	// cnFile is the --puppet-server-file path, re-read on every reload.
+	cnFile string
+
+	// failed records whether the most recent reload failed, so the state
+	// survives in the status text instead of being overwritten by the next
+	// heartbeat. Read from the status closure on another goroutine, hence
+	// atomic.
+	failed atomic.Bool
+}
+
+// statusSuffix annotates the service manager's status text while the running
+// configuration is older than the one on disk. A `systemctl reload` that
+// quietly failed is how an operator ends up believing a certificate was
+// rotated when it was not, so the notice stays put until a reload succeeds.
+func (r *configReloader) statusSuffix() string {
+	if r != nil && r.failed.Load() {
+		return " | last reload FAILED, see the logs"
+	}
+	return ""
+}
+
+// reload re-reads every file-backed input. Each input is attempted even when
+// an earlier one failed — a broken allow list should not stop a certificate
+// rotation from landing — and the failures are reported together.
+func (r *configReloader) reload() error {
+	var errs []error
+
+	if r.certs != nil {
+		if err := r.certs.reload(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if r.auth != nil {
+		allowList, err := buildAdminAllowList(r.staticCNs, r.cnFile)
+		if err != nil {
+			errs = append(errs, err)
+		} else {
+			r.auth.SetAllowList(allowList)
+			slog.Info("Reloaded admin allow list", "admin_cns", len(allowList))
+		}
+	}
+
+	err := errors.Join(errs...)
+	r.failed.Store(err != nil)
+	return err
+}
+
+// buildAdminAllowList merges the comma-separated CN list from the running
+// configuration with the current contents of the allow-list file. It is the
+// single construction point for the admin allow list, used both at startup and
+// on reload, so the two can never diverge.
+func buildAdminAllowList(staticCNs, cnFile string) (map[string]bool, error) {
+	allowList := map[string]bool{}
+	for _, cn := range strings.Split(staticCNs, ",") {
+		if cn = strings.TrimSpace(cn); cn != "" {
+			allowList[cn] = true
+		}
+	}
+	fileCNs, err := loadPuppetServerFile(cnFile)
+	if err != nil {
+		return nil, err
+	}
+	for _, cn := range fileCNs {
+		allowList[cn] = true
+	}
+	return allowList, nil
+}
+
+// runReloadWatcher applies a configuration reload on every SIGHUP until ctx is
+// cancelled. It also reports the reload to the service manager, which is what
+// makes `systemctl reload` (Type=notify-reload) wait for the new configuration
+// to be in effect rather than returning the instant the signal is delivered.
+//
+// A reload that fails is not fatal: the previous configuration is still in
+// place and still correct, so the server keeps serving. The failure is logged,
+// and statusSuffix keeps it visible in the status text until a later reload
+// succeeds. READY=1 is sent either way — the protocol requires it to close out
+// RELOADING=1, and withholding it would only hang the reload job without
+// telling the operator anything the logs do not.
+func runReloadWatcher(ctx context.Context, n *sdnotify.Notifier, r *configReloader, status func() string) {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGHUP)
+	defer signal.Stop(sigCh)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-sigCh:
+			slog.Info("Reloading configuration (SIGHUP)")
+			n.Reloading("Reloading TLS material and the admin allow list")
+
+			if err := r.reload(); err != nil {
+				slog.Error("Configuration reload failed; keeping the previous configuration", "error", err)
+			} else {
+				slog.Info("Configuration reloaded")
+			}
+			n.Ready(status())
+		}
+	}
+}

--- a/cmd/openvox-ca/reload_test.go
+++ b/cmd/openvox-ca/reload_test.go
@@ -39,8 +39,11 @@ import (
 )
 
 // writeTestKeypair writes a self-signed server certificate and its key into
-// dir, named after cn so successive keypairs can be told apart, and returns
-// the two paths.
+// dir as the fixed names server.crt and server.key, and returns the two paths.
+// cn sets the certificate's common name, which is how specs tell one keypair
+// from another; calling this twice with the same dir deliberately overwrites,
+// which is how the rotation specs work. Two keypairs that must coexist need
+// two directories.
 func writeTestKeypair(dir, cn string) (certPath, keyPath string) {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	Expect(err).NotTo(HaveOccurred())
@@ -249,6 +252,26 @@ var _ = Describe("Configuration reloading", func() {
 		Expect(err.Error()).To(ContainSubstring("puppet-server file"))
 	})
 
+	It("names the CNs that gained and lost admin access", func() {
+		// The audit record: a count alone cannot distinguish "unchanged" from
+		// "one compile server swapped for another".
+		added, removed := diffAllowList(
+			map[string]bool{"stays.example.com": true, "goes.example.com": true},
+			map[string]bool{"stays.example.com": true, "arrives.example.com": true},
+		)
+		Expect(added).To(Equal([]string{"arrives.example.com"}))
+		Expect(removed).To(Equal([]string{"goes.example.com"}))
+	})
+
+	It("reports no change when the allow list is rewritten identically", func() {
+		added, removed := diffAllowList(
+			map[string]bool{"a.example.com": true},
+			map[string]bool{"a.example.com": true},
+		)
+		Expect(added).To(BeEmpty())
+		Expect(removed).To(BeEmpty())
+	})
+
 	It("keeps a failure visible in the status until a reload succeeds", func() {
 		// Otherwise the next heartbeat overwrites the notice and the operator
 		// is left believing the reload took effect.
@@ -277,15 +300,17 @@ var _ = Describe("Reload watcher", func() {
 		reloader *configReloader
 		rec      *notifyRecorder
 		notifier *sdnotify.Notifier
+		hupCh    chan os.Signal
 	)
 
 	BeforeEach(func() {
-		// Claim SIGHUP before anything can send one: the default action for an
+		// Claim SIGHUP before anything can send one, exactly as the server
+		// does before its own startup work: the default action for an
 		// unhandled SIGHUP is to terminate, which would take the test binary
-		// with it if the watcher had not registered yet.
-		guard := make(chan os.Signal, 1)
-		signal.Notify(guard, syscall.SIGHUP)
-		DeferCleanup(func() { signal.Stop(guard) })
+		// with it.
+		hupCh = make(chan os.Signal, 1)
+		signal.Notify(hupCh, syscall.SIGHUP)
+		DeferCleanup(func() { signal.Stop(hupCh) })
 
 		dir = GinkgoT().TempDir()
 		cnFile = filepath.Join(dir, "servers.txt")
@@ -301,13 +326,14 @@ var _ = Describe("Reload watcher", func() {
 		DeferCleanup(func() { Expect(notifier.Close()).To(Succeed()) })
 	})
 
-	// startWatcher runs the watcher for the duration of the spec.
+	// startWatcher runs the watcher for the duration of the spec, fed by the
+	// same pre-registered channel the server wires up in main.
 	startWatcher := func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		done := make(chan struct{})
 		go func() {
 			defer close(done)
-			runReloadWatcher(ctx, notifier, reloader, func() string { return "serving" + reloader.statusSuffix() })
+			runReloadWatcher(ctx, hupCh, notifier, reloader, func() string { return "serving" + reloader.statusSuffix() })
 		}()
 		DeferCleanup(func() {
 			cancel()

--- a/cmd/openvox-ca/reload_test.go
+++ b/cmd/openvox-ca/reload_test.go
@@ -1,0 +1,352 @@
+// Copyright (C) 2026 Chris Boot
+// Copyright (C) 2026 Vox Pupuli and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/voxpupuli/openvox-ca/internal/api"
+	"github.com/voxpupuli/openvox-ca/internal/sdnotify"
+)
+
+// writeTestKeypair writes a self-signed server certificate and its key into
+// dir, named after cn so successive keypairs can be told apart, and returns
+// the two paths.
+func writeTestKeypair(dir, cn string) (certPath, keyPath string) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	Expect(err).NotTo(HaveOccurred())
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		DNSNames:     []string{cn},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	Expect(err).NotTo(HaveOccurred())
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	Expect(err).NotTo(HaveOccurred())
+
+	certPath = filepath.Join(dir, "server.crt")
+	keyPath = filepath.Join(dir, "server.key")
+	Expect(os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0600)).To(Succeed())
+	Expect(os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), 0600)).To(Succeed())
+	return certPath, keyPath
+}
+
+// servedCN returns the common name of the certificate the reloader currently
+// hands to new handshakes.
+func servedCN(c *certReloader) string {
+	cert, err := c.GetCertificate(nil)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cert.Leaf).NotTo(BeNil())
+	return cert.Leaf.Subject.CommonName
+}
+
+var _ = Describe("Admin allow list construction", func() {
+	var dir string
+
+	BeforeEach(func() {
+		dir = GinkgoT().TempDir()
+	})
+
+	It("merges the configured CNs with the allow-list file", func() {
+		path := filepath.Join(dir, "servers.txt")
+		Expect(os.WriteFile(path, []byte("compile-1.example.com\n# a comment\n\ncompile-2.example.com\n"), 0600)).To(Succeed())
+
+		allowList, err := buildAdminAllowList("puppet.example.com, primary.example.com", path)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(allowList).To(Equal(map[string]bool{
+			"puppet.example.com":    true,
+			"primary.example.com":   true,
+			"compile-1.example.com": true,
+			"compile-2.example.com": true,
+		}))
+	})
+
+	It("copes with neither source being configured", func() {
+		allowList, err := buildAdminAllowList("", "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(allowList).To(BeEmpty())
+	})
+
+	It("ignores blank entries in the configured list", func() {
+		allowList, err := buildAdminAllowList(" , puppet.example.com ,", "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(allowList).To(Equal(map[string]bool{"puppet.example.com": true}))
+	})
+
+	It("reports an unreadable allow-list file", func() {
+		_, err := buildAdminAllowList("", filepath.Join(dir, "missing.txt"))
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("TLS certificate reloading", func() {
+	var dir string
+
+	BeforeEach(func() {
+		dir = GinkgoT().TempDir()
+	})
+
+	It("refuses to start with an unreadable keypair", func() {
+		_, err := newCertReloader(filepath.Join(dir, "nope.crt"), filepath.Join(dir, "nope.key"))
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("serves the keypair it loaded", func() {
+		certPath, keyPath := writeTestKeypair(dir, "first.example.com")
+		reloader, err := newCertReloader(certPath, keyPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(servedCN(reloader)).To(Equal("first.example.com"))
+	})
+
+	It("picks up a renewed certificate", func() {
+		certPath, keyPath := writeTestKeypair(dir, "first.example.com")
+		reloader, err := newCertReloader(certPath, keyPath)
+		Expect(err).NotTo(HaveOccurred())
+
+		writeTestKeypair(dir, "renewed.example.com")
+		Expect(reloader.reload()).To(Succeed())
+		Expect(servedCN(reloader)).To(Equal("renewed.example.com"))
+	})
+
+	It("keeps serving the previous certificate when the new one is unusable", func() {
+		// This is the half-written-file case: a reload that lands while the
+		// certificate is being replaced must not leave the server with no
+		// certificate at all.
+		certPath, keyPath := writeTestKeypair(dir, "first.example.com")
+		reloader, err := newCertReloader(certPath, keyPath)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(os.WriteFile(certPath, []byte("-----BEGIN CERTIFICATE-----\ntruncated"), 0600)).To(Succeed())
+		Expect(reloader.reload()).To(HaveOccurred())
+		Expect(servedCN(reloader)).To(Equal("first.example.com"))
+	})
+
+	It("rejects a certificate that does not match the key", func() {
+		certPath, keyPath := writeTestKeypair(dir, "first.example.com")
+		reloader, err := newCertReloader(certPath, keyPath)
+		Expect(err).NotTo(HaveOccurred())
+
+		otherDir := GinkgoT().TempDir()
+		_, otherKey := writeTestKeypair(otherDir, "other.example.com")
+		keyPEM, err := os.ReadFile(otherKey)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.WriteFile(keyPath, keyPEM, 0600)).To(Succeed())
+
+		Expect(reloader.reload()).To(HaveOccurred())
+		Expect(servedCN(reloader)).To(Equal("first.example.com"))
+	})
+})
+
+var _ = Describe("Configuration reloading", func() {
+	var (
+		dir      string
+		cnFile   string
+		auth     *api.AuthConfig
+		reloader *configReloader
+	)
+
+	BeforeEach(func() {
+		dir = GinkgoT().TempDir()
+		cnFile = filepath.Join(dir, "servers.txt")
+		Expect(os.WriteFile(cnFile, []byte("compile-1.example.com\n"), 0600)).To(Succeed())
+
+		allowList, err := buildAdminAllowList("puppet.example.com", cnFile)
+		Expect(err).NotTo(HaveOccurred())
+		auth = &api.AuthConfig{AllowList: allowList}
+
+		certPath, keyPath := writeTestKeypair(dir, "first.example.com")
+		certs, err := newCertReloader(certPath, keyPath)
+		Expect(err).NotTo(HaveOccurred())
+
+		reloader = &configReloader{
+			certs:     certs,
+			auth:      auth,
+			staticCNs: "puppet.example.com",
+			cnFile:    cnFile,
+		}
+	})
+
+	It("grants admin access to a newly listed compile server", func() {
+		Expect(auth.IsAdminCN("compile-2.example.com")).To(BeFalse())
+
+		Expect(os.WriteFile(cnFile, []byte("compile-1.example.com\ncompile-2.example.com\n"), 0600)).To(Succeed())
+		Expect(reloader.reload()).To(Succeed())
+
+		Expect(auth.IsAdminCN("compile-2.example.com")).To(BeTrue())
+		Expect(auth.IsAdminCN("compile-1.example.com")).To(BeTrue())
+		Expect(auth.IsAdminCN("puppet.example.com")).To(BeTrue(), "the configured CNs survive a reload")
+	})
+
+	It("withdraws admin access from a removed compile server", func() {
+		// The security-relevant direction: a decommissioned compile server
+		// must stop being an admin without waiting for a restart.
+		Expect(auth.IsAdminCN("compile-1.example.com")).To(BeTrue())
+
+		Expect(os.WriteFile(cnFile, []byte("# decommissioned\n"), 0600)).To(Succeed())
+		Expect(reloader.reload()).To(Succeed())
+
+		Expect(auth.IsAdminCN("compile-1.example.com")).To(BeFalse())
+	})
+
+	It("rotates the TLS certificate", func() {
+		writeTestKeypair(dir, "renewed.example.com")
+		Expect(reloader.reload()).To(Succeed())
+		Expect(servedCN(reloader.certs)).To(Equal("renewed.example.com"))
+	})
+
+	It("still applies the allow list when the certificate cannot be reloaded", func() {
+		// One broken input must not block the other: the two are independent
+		// and an operator fixing one should not have to fix both.
+		Expect(os.WriteFile(filepath.Join(dir, "server.crt"), []byte("garbage"), 0600)).To(Succeed())
+		Expect(os.WriteFile(cnFile, []byte("compile-9.example.com\n"), 0600)).To(Succeed())
+
+		err := reloader.reload()
+		Expect(err).To(HaveOccurred())
+		Expect(auth.IsAdminCN("compile-9.example.com")).To(BeTrue())
+	})
+
+	It("reports every failure together", func() {
+		Expect(os.WriteFile(filepath.Join(dir, "server.crt"), []byte("garbage"), 0600)).To(Succeed())
+		Expect(os.Remove(cnFile)).To(Succeed())
+
+		err := reloader.reload()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("TLS cert/key"))
+		Expect(err.Error()).To(ContainSubstring("puppet-server file"))
+	})
+
+	It("keeps a failure visible in the status until a reload succeeds", func() {
+		// Otherwise the next heartbeat overwrites the notice and the operator
+		// is left believing the reload took effect.
+		Expect(reloader.statusSuffix()).To(BeEmpty())
+
+		Expect(os.Remove(cnFile)).To(Succeed())
+		Expect(reloader.reload()).To(HaveOccurred())
+		Expect(reloader.statusSuffix()).To(ContainSubstring("FAILED"))
+
+		Expect(os.WriteFile(cnFile, []byte("compile-1.example.com\n"), 0600)).To(Succeed())
+		Expect(reloader.reload()).To(Succeed())
+		Expect(reloader.statusSuffix()).To(BeEmpty())
+	})
+
+	It("does nothing when there is nothing reloadable", func() {
+		// Plain HTTP mode: no TLS keypair, no auth config.
+		Expect((&configReloader{}).reload()).To(Succeed())
+	})
+})
+
+var _ = Describe("Reload watcher", func() {
+	var (
+		dir      string
+		cnFile   string
+		auth     *api.AuthConfig
+		reloader *configReloader
+		rec      *notifyRecorder
+		notifier *sdnotify.Notifier
+	)
+
+	BeforeEach(func() {
+		// Claim SIGHUP before anything can send one: the default action for an
+		// unhandled SIGHUP is to terminate, which would take the test binary
+		// with it if the watcher had not registered yet.
+		guard := make(chan os.Signal, 1)
+		signal.Notify(guard, syscall.SIGHUP)
+		DeferCleanup(func() { signal.Stop(guard) })
+
+		dir = GinkgoT().TempDir()
+		cnFile = filepath.Join(dir, "servers.txt")
+		Expect(os.WriteFile(cnFile, []byte("compile-1.example.com\n"), 0600)).To(Succeed())
+
+		allowList, err := buildAdminAllowList("", cnFile)
+		Expect(err).NotTo(HaveOccurred())
+		auth = &api.AuthConfig{AllowList: allowList}
+		reloader = &configReloader{auth: auth, cnFile: cnFile}
+
+		rec = startNotifyRecorder(nil)
+		notifier = sdnotify.New()
+		DeferCleanup(func() { Expect(notifier.Close()).To(Succeed()) })
+	})
+
+	// startWatcher runs the watcher for the duration of the spec.
+	startWatcher := func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			runReloadWatcher(ctx, notifier, reloader, func() string { return "serving" + reloader.statusSuffix() })
+		}()
+		DeferCleanup(func() {
+			cancel()
+			Eventually(done).Should(BeClosed())
+		})
+	}
+
+	It("reloads on SIGHUP and reports the reload to the service manager", func() {
+		startWatcher()
+
+		Expect(os.WriteFile(cnFile, []byte("compile-2.example.com\n"), 0600)).To(Succeed())
+		Expect(syscall.Kill(os.Getpid(), syscall.SIGHUP)).To(Succeed())
+
+		Eventually(rec.msgs).Should(Receive(HavePrefix("RELOADING=1")))
+		Eventually(rec.msgs).Should(Receive(Equal("READY=1\nSTATUS=serving\n")))
+		Expect(auth.IsAdminCN("compile-2.example.com")).To(BeTrue())
+		Expect(auth.IsAdminCN("compile-1.example.com")).To(BeFalse())
+	})
+
+	It("keeps serving and says so when the reload fails", func() {
+		startWatcher()
+
+		Expect(os.Remove(cnFile)).To(Succeed())
+		Expect(syscall.Kill(os.Getpid(), syscall.SIGHUP)).To(Succeed())
+
+		// READY=1 still closes out the reload -- withholding it would only
+		// hang `systemctl reload` -- but the status says the reload failed.
+		Eventually(rec.msgs).Should(Receive(HavePrefix("RELOADING=1")))
+		Eventually(rec.msgs).Should(Receive(Equal("READY=1\nSTATUS=serving | last reload FAILED, see the logs\n")))
+		Expect(auth.IsAdminCN("compile-1.example.com")).To(BeTrue(), "the previous allow list is still in force")
+	})
+
+	It("handles repeated reloads", func() {
+		startWatcher()
+
+		for _, cn := range []string{"a.example.com", "b.example.com"} {
+			Expect(os.WriteFile(cnFile, []byte(cn+"\n"), 0600)).To(Succeed())
+			Expect(syscall.Kill(os.Getpid(), syscall.SIGHUP)).To(Succeed())
+			Eventually(func() bool { return auth.IsAdminCN(cn) }).Should(BeTrue())
+		}
+	})
+})

--- a/cmd/openvox-ca/reload_test.go
+++ b/cmd/openvox-ca/reload_test.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -25,6 +26,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"log/slog"
 	"math/big"
 	"os"
 	"os/signal"
@@ -250,6 +252,24 @@ var _ = Describe("Configuration reloading", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("TLS cert/key"))
 		Expect(err.Error()).To(ContainSubstring("puppet-server file"))
+	})
+
+	It("logs the CNs that a real reload granted and withdrew", func() {
+		// Exercised through the live call site, not just diffAllowList's own
+		// arguments: transposing the two would still leave the allow list
+		// correct (so IsAdminCN specs stay green) while attributing every
+		// grant as a withdrawal in the security audit log.
+		var buf bytes.Buffer
+		orig := slog.Default()
+		slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+		defer slog.SetDefault(orig)
+
+		Expect(os.WriteFile(cnFile, []byte("compile-2.example.com\n"), 0600)).To(Succeed())
+		Expect(reloader.reload()).To(Succeed())
+
+		logged := buf.String()
+		Expect(logged).To(ContainSubstring("added=[compile-2.example.com]"))
+		Expect(logged).To(ContainSubstring("removed=[compile-1.example.com]"))
 	})
 
 	It("names the CNs that gained and lost admin access", func() {

--- a/docs/api.md
+++ b/docs/api.md
@@ -192,4 +192,6 @@ A client certificate is considered an admin credential if **either** condition i
 
 The `pp_cli_auth` check is enabled by default. Disable it with `--no-pp-cli-auth` (or `no_pp_cli_auth: true` in the config file) if you prefer strict CN-only authorization.
 
+The CN allow list is not fixed for the life of the process: `SIGHUP` (or `systemctl reload`) rebuilds it from `--puppet-server` plus the current contents of `--puppet-server-file`, so admin access can be granted or **withdrawn** without a restart. The swap is atomic with respect to in-flight requests, and the CNs added or removed are named in the log. See [reloading configuration](configuration.md#reloading-configuration).
+
 > **OID source:** [`lib/puppet/ssl/oids.rb`](https://github.com/puppetlabs/puppet/blob/main/lib/puppet/ssl/oids.rb)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -270,4 +270,19 @@ The drain budget defaults to **25 seconds** and is configurable via `shutdown_ti
 
 In the default isolated-process deployment, the supervisor gives its child processes the drain budget **plus a 3-second headroom** (28 seconds by default) before force-killing anything that has not exited, so the drain is never truncated.
 
-This is particularly important for **Kubernetes rolling updates**: pods receive `SIGTERM` with a configurable grace period (`terminationGracePeriodSeconds`, default 30 seconds). The defaults (25s drain, 28s supervisor) nest under that 30-second grace so the server drains and exits cleanly before the platform `SIGKILL`s the pod. If you raise `shutdown_timeout_sec`, raise `terminationGracePeriodSeconds` to at least the drain budget plus 3 seconds.
+This is particularly important for **Kubernetes rolling updates**: pods receive `SIGTERM` with a configurable grace period (`terminationGracePeriodSeconds`, default 30 seconds). The defaults (25s drain, 28s supervisor) nest under that 30-second grace so the server drains and exits cleanly before the platform `SIGKILL`s the pod. If you raise `shutdown_timeout_sec`, raise `terminationGracePeriodSeconds` to at least the drain budget plus 3 seconds. Under systemd, raise `TimeoutStopSec` instead — see [running under systemd](systemd.md).
+
+## Reloading configuration
+
+`SIGHUP` re-reads the two file-backed inputs that can be swapped safely while the server is running:
+
+| Input | Effect |
+| --- | --- |
+| `--tls-cert` / `--tls-key` | The renewed keypair is served to new TLS handshakes; connections in flight keep the certificate they negotiated with |
+| `--puppet-server-file` | The admin allow list is rebuilt from `--puppet-server` plus the current file contents, and swapped atomically with respect to in-flight requests |
+
+Everything else — listen address, storage backend, CA key custody, CA properties, autosign configuration — requires a restart.
+
+A reload that fails (an unreadable keypair, a missing allow-list file) is logged and leaves the previous configuration in place; the server keeps serving. Each input is applied independently, so a broken allow list does not block a certificate rotation.
+
+In the default isolated-process deployment, send `SIGHUP` to the supervisor (the process you started); it forwards the signal to the frontend. Under systemd this is `systemctl reload openvox-ca` — see [running under systemd](systemd.md#reloading).

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -15,12 +15,15 @@ A ready-to-use unit ships in [`packaging/systemd/openvox-ca.service`](../packagi
 
 ```console
 $ sudo useradd --system --home-dir /var/lib/puppet-ca --shell /usr/sbin/nologin puppet-ca
+$ sudo install -m 0755 openvox-ca openvox-ca-ctl /usr/local/bin/
 $ sudo install -m 0644 openvox-ca.service /etc/systemd/system/
 $ sudo systemctl daemon-reload
 $ sudo systemctl enable --now openvox-ca.service
 ```
 
 The unit expects the binary at `/usr/local/bin/openvox-ca` and its configuration at `/etc/puppet-ca/config.yaml`. See [configuring the server](configuration.md).
+
+**Set `cadir` to `/var/lib/puppet-ca`** (the `StateDirectory=` the unit creates), or the CA will not be able to write: `ProtectSystem=strict` makes the rest of the filesystem read-only. To keep an existing directory instead — a CA migrated from OpenVox/Puppet Server usually lives in `/etc/puppetlabs/puppet/ssl/ca` — uncomment the `ReadWritePaths=` line in the unit and point it there.
 
 ### The two settings you must not drop
 
@@ -31,7 +34,7 @@ NotifyAccess=all
 
 `NotifyAccess=all` is required, not optional hardening slack. In the default deployment `openvox-ca` runs as three processes — a launcher supervising an isolated signer that holds the CA key, and a frontend that serves the API (see [CA key security](ca-key-security.md)) — and readiness is reported by the **frontend child**, because only it knows when the listener is accepting. systemd's default (`NotifyAccess=main`) accepts notifications only from the launcher, silently discards the frontend's, and the start job then fails on `TimeoutStartSec`.
 
-The notification socket is withheld from the signer process, so even under `NotifyAccess=all` only the launcher and the frontend can notify.
+The notification socket is withheld from the signer process, so it never notifies in normal operation. Treat that as hygiene rather than as an access control: `NotifyAccess=all` authorises every process in the unit's cgroup, and the socket path is well known, so the isolation is defence in depth — the residual cost of the multi-process design.
 
 Running with `--single-process` collapses this to one process and `NotifyAccess=main` is then sufficient — but the shipped unit keeps `all` so it works either way.
 
@@ -72,7 +75,7 @@ Everything in the line is read from memory. Certificate counts are deliberately 
 | `--tls-cert` / `--tls-key` | The CA's own server certificate expires like any other and has to be renewed |
 | `--puppet-server-file` | A compile server is added, or a decommissioned one must stop being an admin |
 
-Connections in flight keep the certificate they negotiated with; the next TLS handshake picks up the new one. The allow list is swapped atomically with respect to in-flight requests: each request sees either the whole old list or the whole new one.
+Connections in flight keep the certificate they negotiated with; the next TLS handshake picks up the new one. The allow list is swapped atomically with respect to in-flight requests: each request sees either the whole old list or the whole new one, and any CN that gained or lost admin rights is named in the log so the change is auditable.
 
 Everything else — listen address, storage backend, CA key custody, CA properties, autosign configuration — needs a restart. Those are bound to state established at startup, and re-reading them behind your back would be worse than telling you to restart.
 
@@ -101,9 +104,11 @@ WatchdogSec=60s
 Restart=on-failure
 ```
 
-The keep-alive is sent by the frontend process on a timer at half the configured interval, so it stops arriving if the process serving the API wedges — on an unresponsive storage backend, say — and systemd restarts the service. A launcher-side ping would only ever prove the supervisor was alive, which it always is.
+The keep-alive is sent by the frontend process on a timer at half the configured interval — not by the launcher, which would only ever prove the supervisor was alive.
 
-Remove `WatchdogSec=` to disable it. Note that a watchdog restart is a hard kill: it does not drain in-flight requests.
+Be clear about what this does and does not catch. It stops arriving if the frontend dies outright, if the Go runtime deadlocks, or if the heartbeat goroutine itself stalls — which includes a storage operation wedged while holding the CA's write lock, since composing the status text takes the matching read lock. It keeps arriving quite happily if the API is unresponsive for a reason that leaves that goroutine scheduling normally, such as request handlers blocked on a read-only backend call. For genuine end-to-end liveness, point a probe at `/healthz/ready` as well; the watchdog is a backstop, not a health check.
+
+Remove `WatchdogSec=` to disable it. Note that a watchdog restart is a hard kill: it does not drain in-flight requests, and a `WatchdogSec=` under two seconds is reported in the log and clamped rather than honoured.
 
 ## Shutdown
 
@@ -118,6 +123,8 @@ Status: "Shutting down: draining connections (up to 25s)"
 ## Hardening
 
 The shipped unit runs the CA as a dedicated `puppet-ca` user with `ProtectSystem=strict`, an empty capability set (the API's port 8140 and the exporter's 9140 are both unprivileged), and a `@system-service` syscall filter. `RestrictAddressFamilies` includes `AF_UNIX`, which is needed for both the notification socket and the launcher's socketpair to the isolated signer.
+
+`LimitCORE=0` is deliberate and worth keeping: the signer holds the decrypted CA private key in memory for its whole life, so a core dump would write that key to `/var/lib/systemd/coredump` — undoing [key encryption at rest](ca-key-security.md) for anything that ships crash dumps off the host.
 
 If you point `cadir` somewhere other than the `StateDirectory=puppet-ca` the unit creates, add that path to `ReadWritePaths=`. The same applies to `--logfile`, though logging to stderr and letting journald handle it is simpler.
 

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -108,7 +108,7 @@ The keep-alive is sent by the frontend process on a timer at half the configured
 
 Be clear about what this does and does not catch. It stops arriving if the frontend dies outright, if the Go runtime deadlocks, or if the heartbeat goroutine itself stalls — which includes a storage operation wedged while holding the CA's write lock, since composing the status text takes the matching read lock. It keeps arriving quite happily if the API is unresponsive for a reason that leaves that goroutine scheduling normally, such as request handlers blocked on a read-only backend call. For genuine end-to-end liveness, point a probe at `/healthz/ready` as well; the watchdog is a backstop, not a health check.
 
-Remove `WatchdogSec=` to disable it. Note that a watchdog restart is a hard kill: it does not drain in-flight requests, and a `WatchdogSec=` under 200ms is logged as too short to feed reliably. It is still fed at half the deadline down to 20ms; below that the CA stops shortening the ticker at 10ms and the deadline will be missed, which is the deliberate trade against spinning on a value nobody sets on purpose.
+Remove `WatchdogSec=` to disable it. Note that a watchdog restart is a hard kill: it does not drain in-flight requests, and a `WatchdogSec=` under 200ms is logged as too short to feed reliably. It is still fed at half the deadline down to 20ms. Below that the CA stops shortening the ticker at 10ms, which first costs the twice-per-interval margin `sd_watchdog_enabled(3)` recommends and, below about 10ms, stops beating the deadline at all — at which point the service manager kills the CA. That is the deliberate trade against spinning on a value nobody sets on purpose.
 
 ## Shutdown
 

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -108,7 +108,7 @@ The keep-alive is sent by the frontend process on a timer at half the configured
 
 Be clear about what this does and does not catch. It stops arriving if the frontend dies outright, if the Go runtime deadlocks, or if the heartbeat goroutine itself stalls — which includes a storage operation wedged while holding the CA's write lock, since composing the status text takes the matching read lock. It keeps arriving quite happily if the API is unresponsive for a reason that leaves that goroutine scheduling normally, such as request handlers blocked on a read-only backend call. For genuine end-to-end liveness, point a probe at `/healthz/ready` as well; the watchdog is a backstop, not a health check.
 
-Remove `WatchdogSec=` to disable it. Note that a watchdog restart is a hard kill: it does not drain in-flight requests, and a `WatchdogSec=` under two seconds is reported in the log and clamped rather than honoured.
+Remove `WatchdogSec=` to disable it. Note that a watchdog restart is a hard kill: it does not drain in-flight requests, and a `WatchdogSec=` short enough that half of it falls below the 100ms heartbeat floor (so, under 200ms) is reported in the log and fed at that floor instead.
 
 ## Shutdown
 
@@ -126,7 +126,7 @@ The shipped unit runs the CA as a dedicated `puppet-ca` user with `ProtectSystem
 
 `LimitCORE=0` is deliberate and worth keeping: the signer holds the decrypted CA private key in memory for its whole life, so a core dump would write that key to `/var/lib/systemd/coredump` — undoing [key encryption at rest](ca-key-security.md) for anything that ships crash dumps off the host.
 
-If you point `cadir` somewhere other than the `StateDirectory=puppet-ca` the unit creates, add that path to `ReadWritePaths=`. The same applies to `--logfile`, though logging to stderr and letting journald handle it is simpler.
+`ProtectSystem=strict` is the directive most likely to bite: see [installing the unit](#installing-the-unit) for the `cadir` / `ReadWritePaths=` choice it forces. The same applies to `--logfile`, though logging to stderr and letting journald handle it is simpler.
 
 Check your changes with:
 

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -108,7 +108,7 @@ The keep-alive is sent by the frontend process on a timer at half the configured
 
 Be clear about what this does and does not catch. It stops arriving if the frontend dies outright, if the Go runtime deadlocks, or if the heartbeat goroutine itself stalls — which includes a storage operation wedged while holding the CA's write lock, since composing the status text takes the matching read lock. It keeps arriving quite happily if the API is unresponsive for a reason that leaves that goroutine scheduling normally, such as request handlers blocked on a read-only backend call. For genuine end-to-end liveness, point a probe at `/healthz/ready` as well; the watchdog is a backstop, not a health check.
 
-Remove `WatchdogSec=` to disable it. Note that a watchdog restart is a hard kill: it does not drain in-flight requests, and a `WatchdogSec=` short enough that half of it falls below the 100ms heartbeat floor (so, under 200ms) is reported in the log and fed at that floor instead.
+Remove `WatchdogSec=` to disable it. Note that a watchdog restart is a hard kill: it does not drain in-flight requests, and a `WatchdogSec=` under 200ms is logged as too short to feed reliably. It is still fed at half the deadline down to 20ms; below that the CA stops shortening the ticker at 10ms and the deadline will be missed, which is the deliberate trade against spinning on a value nobody sets on purpose.
 
 ## Shutdown
 

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -1,0 +1,140 @@
+# Running under systemd
+
+`openvox-ca` speaks the systemd notification protocol ([`sd_notify(3)`](https://www.freedesktop.org/software/systemd/man/sd_notify.html)), so a unit can be `Type=notify` rather than `Type=simple`. That gives you four things:
+
+- **`systemctl start` blocks until the CA is actually serving** — storage reachable, CA loaded (bootstrapped on a first run), listener accepting. Units ordered `After=openvox-ca.service` no longer race a cold start.
+- **`systemctl status` says what the CA is doing**, both during startup and while it runs.
+- **`systemctl reload` re-reads the TLS keypair and the admin allow list** without dropping connections.
+- **An optional watchdog** restarts a CA that has stopped making progress.
+
+None of it needs configuration. The protocol is driven entirely by `$NOTIFY_SOCKET`, which systemd sets; without it every notification is a no-op, so the same binary behaves normally under a shell, another supervisor, or in a container.
+
+## Installing the unit
+
+A ready-to-use unit ships in [`packaging/systemd/openvox-ca.service`](../packaging/systemd/openvox-ca.service) (and in the release tarballs):
+
+```console
+$ sudo useradd --system --home-dir /var/lib/puppet-ca --shell /usr/sbin/nologin puppet-ca
+$ sudo install -m 0644 openvox-ca.service /etc/systemd/system/
+$ sudo systemctl daemon-reload
+$ sudo systemctl enable --now openvox-ca.service
+```
+
+The unit expects the binary at `/usr/local/bin/openvox-ca` and its configuration at `/etc/puppet-ca/config.yaml`. See [configuring the server](configuration.md).
+
+### The two settings you must not drop
+
+```ini
+Type=notify
+NotifyAccess=all
+```
+
+`NotifyAccess=all` is required, not optional hardening slack. In the default deployment `openvox-ca` runs as three processes — a launcher supervising an isolated signer that holds the CA key, and a frontend that serves the API (see [CA key security](ca-key-security.md)) — and readiness is reported by the **frontend child**, because only it knows when the listener is accepting. systemd's default (`NotifyAccess=main`) accepts notifications only from the launcher, silently discards the frontend's, and the start job then fails on `TimeoutStartSec`.
+
+The notification socket is withheld from the signer process, so even under `NotifyAccess=all` only the launcher and the frontend can notify.
+
+Running with `--single-process` collapses this to one process and `NotifyAccess=main` is then sufficient — but the shipped unit keeps `all` so it works either way.
+
+### `--daemon` is for something else
+
+Do not add `--daemon` to `ExecStart`. It forks and exits, which under `Type=notify` looks exactly like the service dying the moment it started. The CA logs a warning if you try. Running in the foreground is what a service manager wants; journald captures stderr.
+
+## What the status text shows
+
+During startup, each phase reports what it is waiting on — which is usually all you need to diagnose a start that hangs:
+
+```console
+$ systemctl status openvox-ca
+     Active: activating (start) since Sat 2026-08-01 21:02:38 BST; 3s ago
+     Status: "Waiting for the signer process to initialise the CA"
+```
+
+Once serving, the status summarises the listener, the CA certificate and the CRL:
+
+```text
+Status: "Serving HTTPS on 0.0.0.0:8140 | CA \"Puppet CA: puppet.example.com\" expires in 1824d | CRL #7 (3 revoked) expires in 29d"
+```
+
+It is refreshed on a timer, so the countdowns stay true. An elapsed deadline is spelled in capitals, so an expired CA certificate or a lapsed CRL is visible at a glance:
+
+```text
+Status: "Serving HTTPS on 0.0.0.0:8140 | CA \"Puppet CA: puppet.example.com\" expires in 1824d | CRL #7 (3 revoked) EXPIRED 2d ago"
+```
+
+Everything in the line is read from memory. Certificate counts are deliberately absent: that means listing the inventory in the storage backend, which is scrape-weight work and belongs in the [Prometheus exporter](metrics.md), not in a status line refreshed every minute.
+
+## Reloading
+
+`systemctl reload openvox-ca` re-reads the two file-backed inputs that can be swapped safely under live traffic:
+
+| Input | Why it changes |
+| --- | --- |
+| `--tls-cert` / `--tls-key` | The CA's own server certificate expires like any other and has to be renewed |
+| `--puppet-server-file` | A compile server is added, or a decommissioned one must stop being an admin |
+
+Connections in flight keep the certificate they negotiated with; the next TLS handshake picks up the new one. The allow list is swapped atomically with respect to in-flight requests: each request sees either the whole old list or the whole new one.
+
+Everything else — listen address, storage backend, CA key custody, CA properties, autosign configuration — needs a restart. Those are bound to state established at startup, and re-reading them behind your back would be worse than telling you to restart.
+
+A reload that fails (a half-written certificate, a deleted allow-list file) leaves the previous configuration in place and the CA serving. The failure is logged and stays in the status text until a reload succeeds:
+
+```text
+Status: "Serving HTTPS on 0.0.0.0:8140 | ... | last reload FAILED, see the logs"
+```
+
+Check for that line after rotating a certificate. `systemctl reload` itself reports success either way — the notification protocol has no way to fail a reload without hanging the job.
+
+### systemd 253 and later
+
+The shipped unit uses `ExecReload=/bin/kill -HUP $MAINPID`, which works everywhere. On systemd 253+ you can instead drop `ExecReload` and use:
+
+```ini
+Type=notify-reload
+```
+
+systemd then sends `SIGHUP` itself and — because the CA stamps its reload acknowledgement with `MONOTONIC_USEC` — waits for the new configuration to be in effect before `systemctl reload` returns.
+
+## Watchdog
+
+```ini
+WatchdogSec=60s
+Restart=on-failure
+```
+
+The keep-alive is sent by the frontend process on a timer at half the configured interval, so it stops arriving if the process serving the API wedges — on an unresponsive storage backend, say — and systemd restarts the service. A launcher-side ping would only ever prove the supervisor was alive, which it always is.
+
+Remove `WatchdogSec=` to disable it. Note that a watchdog restart is a hard kill: it does not drain in-flight requests.
+
+## Shutdown
+
+On `SIGTERM` the CA reports `STOPPING=1` before draining, so a graceful shutdown is not mistaken for a crash, and the status names the budget:
+
+```text
+Status: "Shutting down: draining connections (up to 25s)"
+```
+
+`TimeoutStopSec` must exceed the drain budget (`shutdown_timeout_sec`, 25 seconds by default) plus the supervisor's 3-second headroom, or systemd will `SIGKILL` the CA part-way through the drain it asked for. The shipped unit uses 35 seconds. If you raise `shutdown_timeout_sec`, raise `TimeoutStopSec` with it — see [graceful shutdown](configuration.md#graceful-shutdown).
+
+## Hardening
+
+The shipped unit runs the CA as a dedicated `puppet-ca` user with `ProtectSystem=strict`, an empty capability set (the API's port 8140 and the exporter's 9140 are both unprivileged), and a `@system-service` syscall filter. `RestrictAddressFamilies` includes `AF_UNIX`, which is needed for both the notification socket and the launcher's socketpair to the isolated signer.
+
+If you point `cadir` somewhere other than the `StateDirectory=puppet-ca` the unit creates, add that path to `ReadWritePaths=`. The same applies to `--logfile`, though logging to stderr and letting journald handle it is simpler.
+
+Check your changes with:
+
+```console
+$ systemd-analyze security openvox-ca.service
+```
+
+## Verifying
+
+```console
+$ systemctl show openvox-ca -p Type,NotifyAccess,StatusText,WatchdogUSec,NRestarts
+```
+
+`StatusText` empty while the service is `active (running)` means notifications are not arriving — nearly always `NotifyAccess` left at its default. systemd logs a warning in that case:
+
+```text
+Got notification message from PID 1234, but reception only permitted for main PID
+```

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	go.etcd.io/etcd/server/v3 v3.7.1
 	go.yaml.in/yaml/v3 v3.0.5
 	golang.org/x/crypto v0.54.0
+	golang.org/x/sys v0.47.0
 	k8s.io/api v0.36.3
 	k8s.io/apimachinery v0.36.3
 	k8s.io/client-go v0.36.3
@@ -148,7 +149,6 @@ require (
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -48,7 +48,7 @@ func hasPpCliAuth(cert *x509.Certificate) bool {
 // is set) if the certificate carries the pp_cli_auth extension
 // (ca.OIDPpCliAuth) with value "true".
 func isAdmin(cfg *AuthConfig, clientCert *x509.Certificate, clientCN string) bool {
-	return cfg.AllowList[clientCN] || (!cfg.NoPpCliAuth && hasPpCliAuth(clientCert))
+	return cfg.IsAdminCN(clientCN) || (!cfg.NoPpCliAuth && hasPpCliAuth(clientCert))
 }
 
 type authTier int

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -76,17 +76,23 @@ func (c *AuthConfig) IsAdminCN(cn string) bool {
 	return c.AllowList[cn]
 }
 
-// SetAllowList replaces the admin allow list. The caller must not retain or
-// mutate the map afterwards; ownership passes to the AuthConfig.
+// SetAllowList replaces the admin allow list and returns the list it replaced,
+// so the caller can log exactly which CNs gained or lost admin authority. The
+// caller must not retain or mutate the map it passes in; ownership passes to
+// the AuthConfig. The returned map is no longer consulted and is the caller's.
 //
 // The replacement is atomic with respect to in-flight requests: each request
 // takes the read lock once, so it sees either the whole old list or the whole
 // new one — never a half-applied update in which a revoked CN is still an
-// admin and a newly added one is not yet.
-func (c *AuthConfig) SetAllowList(allowList map[string]bool) {
+// admin and a newly added one is not yet. Returning the previous list from
+// under the same write lock keeps the audit record consistent with the swap;
+// reading it separately beforehand would race a concurrent reload.
+func (c *AuthConfig) SetAllowList(allowList map[string]bool) map[string]bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	previous := c.AllowList
 	c.AllowList = allowList
+	return previous
 }
 
 type Server struct {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -33,6 +33,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/voxpupuli/openvox-ca/internal/ca"
@@ -46,11 +47,46 @@ const maxJSONBody = 1 << 20 // 1 MiB
 
 // AuthConfig is the mTLS authorization configuration wired into the server.
 // Nil means no mTLS enforcement (plain HTTP / dev mode).
+//
+// AuthConfig must be used through a pointer: it carries a lock and is read
+// concurrently by every request.
 type AuthConfig struct {
 	CACert            *x509.Certificate
-	AllowList         map[string]bool // admin CNs (puppet-server hostnames)
+	AllowList         map[string]bool // admin CNs (puppet-server hostnames); read via IsAdminCN
 	NoPpCliAuth       bool            // when true, pp_cli_auth extension does not grant admin access
 	AllowPublicStatus bool            // when true, GET /certificate_status is public (no client cert required)
+
+	// mu guards AllowList, which SetAllowList replaces while requests are in
+	// flight (the operator adding or removing a compile server, without a
+	// restart). The other fields are set once before the server starts
+	// serving and never change.
+	mu sync.RWMutex
+}
+
+// IsAdminCN reports whether cn is on the admin allow list.
+//
+// SECURITY: this is the read side of the allow list and the only place the map
+// may be consulted from. Reading the field directly would race SetAllowList and
+// — because that swap is what a configuration reload uses to withdraw a
+// compile server's admin rights — could serve a stale authorization decision.
+// NIST 800-53: AC-3 (Access Enforcement)
+func (c *AuthConfig) IsAdminCN(cn string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.AllowList[cn]
+}
+
+// SetAllowList replaces the admin allow list. The caller must not retain or
+// mutate the map afterwards; ownership passes to the AuthConfig.
+//
+// The replacement is atomic with respect to in-flight requests: each request
+// takes the read lock once, so it sees either the whole old list or the whole
+// new one — never a half-applied update in which a revoked CN is still an
+// admin and a newly added one is not yet.
+func (c *AuthConfig) SetAllowList(allowList map[string]bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.AllowList = allowList
 }
 
 type Server struct {

--- a/internal/ca/crl.go
+++ b/internal/ca/crl.go
@@ -161,6 +161,43 @@ func (c *CA) RefreshCRLIfDue(ctx context.Context, refreshBefore time.Duration) (
 	return reissued, err
 }
 
+// CRLSnapshot describes the CRL the CA holds in memory. It is a value copy of
+// the fields worth reporting, so a caller can inspect the CRL's freshness
+// without holding a lock, touching storage, or being handed the live
+// *x509.RevocationList the auth path reads.
+type CRLSnapshot struct {
+	// Number is the CRL number (RFC 5280 §5.2.3), which increases by one on
+	// every re-sign.
+	Number *big.Int
+	// ThisUpdate and NextUpdate bound the CRL's validity window. A NextUpdate
+	// in the past means clients are being served a stale CRL.
+	ThisUpdate time.Time
+	NextUpdate time.Time
+	// Revoked is the number of certificates listed on the CRL.
+	Revoked int
+}
+
+// CRLSnapshot returns the in-memory CRL's metadata, and whether a CRL has been
+// loaded at all. It reads the same cache the authentication path uses, so it
+// costs a read lock and no storage round-trip — cheap enough to call on a
+// timer (e.g. to refresh the service manager's status text).
+func (c *CA) CRLSnapshot() (CRLSnapshot, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.cachedCRL == nil {
+		return CRLSnapshot{}, false
+	}
+	snap := CRLSnapshot{
+		ThisUpdate: c.cachedCRL.ThisUpdate,
+		NextUpdate: c.cachedCRL.NextUpdate,
+		Revoked:    len(c.cachedCRL.RevokedCertificateEntries),
+	}
+	if c.cachedCRL.Number != nil {
+		snap.Number = new(big.Int).Set(c.cachedCRL.Number)
+	}
+	return snap, true
+}
+
 // DefaultCRLRefreshBefore returns the default refresh window: the CRL is
 // re-signed once less than a third of its validity remains (i.e. at ~2/3 of
 // its lifetime), leaving ample margin to ride out replica outages before the

--- a/internal/ca/crl.go
+++ b/internal/ca/crl.go
@@ -169,9 +169,10 @@ type CRLSnapshot struct {
 	// Number is the CRL number (RFC 5280 §5.2.3), which increases by one on
 	// every re-sign.
 	Number *big.Int
-	// ThisUpdate and NextUpdate bound the CRL's validity window. A NextUpdate
-	// in the past means clients are being served a stale CRL.
-	ThisUpdate time.Time
+	// NextUpdate bounds the CRL's validity window; a NextUpdate in the past
+	// means clients are being served a stale CRL. ThisUpdate is deliberately
+	// not carried: no caller needs it, and the Prometheus collector reads its
+	// own copy straight from storage.
 	NextUpdate time.Time
 	// Revoked is the number of certificates listed on the CRL.
 	Revoked int
@@ -188,7 +189,6 @@ func (c *CA) CRLSnapshot() (CRLSnapshot, bool) {
 		return CRLSnapshot{}, false
 	}
 	snap := CRLSnapshot{
-		ThisUpdate: c.cachedCRL.ThisUpdate,
 		NextUpdate: c.cachedCRL.NextUpdate,
 		Revoked:    len(c.cachedCRL.RevokedCertificateEntries),
 	}

--- a/internal/ca/crl_test.go
+++ b/internal/ca/crl_test.go
@@ -183,7 +183,6 @@ var _ = Describe("CA CRL reissuance", func() {
 			snap, ok := myCA.CRLSnapshot()
 			Expect(ok).To(BeTrue())
 			Expect(snap.Number).To(Equal(stored.Number))
-			Expect(snap.ThisUpdate).To(BeTemporally("==", stored.ThisUpdate))
 			Expect(snap.NextUpdate).To(BeTemporally("==", stored.NextUpdate))
 			Expect(snap.Revoked).To(Equal(len(stored.RevokedCertificateEntries)))
 		})

--- a/internal/ca/crl_test.go
+++ b/internal/ca/crl_test.go
@@ -176,6 +176,45 @@ var _ = Describe("CA CRL reissuance", func() {
 		})
 	})
 
+	Describe("CRLSnapshot", func() {
+		It("reports the cached CRL's number, window and entry count", func() {
+			stored := parseStoredCRL(store)
+
+			snap, ok := myCA.CRLSnapshot()
+			Expect(ok).To(BeTrue())
+			Expect(snap.Number).To(Equal(stored.Number))
+			Expect(snap.ThisUpdate).To(BeTemporally("==", stored.ThisUpdate))
+			Expect(snap.NextUpdate).To(BeTemporally("==", stored.NextUpdate))
+			Expect(snap.Revoked).To(Equal(len(stored.RevokedCertificateEntries)))
+		})
+
+		It("tracks re-signs of the CRL", func() {
+			before, ok := myCA.CRLSnapshot()
+			Expect(ok).To(BeTrue())
+
+			Expect(myCA.ReissueCRL(context.Background())).To(Succeed())
+
+			after, ok := myCA.CRLSnapshot()
+			Expect(ok).To(BeTrue())
+			Expect(after.Number.Cmp(before.Number)).To(Equal(1))
+			Expect(after.NextUpdate).To(BeTemporally(">", before.NextUpdate))
+		})
+
+		It("hands back a copy, so callers cannot mutate the cached CRL", func() {
+			snap, ok := myCA.CRLSnapshot()
+			Expect(ok).To(BeTrue())
+			snap.Number.SetInt64(9999)
+
+			again, _ := myCA.CRLSnapshot()
+			Expect(again.Number.Int64()).NotTo(Equal(int64(9999)))
+		})
+
+		It("reports no CRL before the CA is initialised", func() {
+			_, ok := ca.New(store, ca.AutosignConfig{Mode: "off"}, "puppet.test").CRLSnapshot()
+			Expect(ok).To(BeFalse())
+		})
+	})
+
 	Describe("DefaultCRLRefreshBefore", func() {
 		It("defaults to a third of the CRL validity window", func() {
 			// Default validity is 30 days; a third is 10 days.

--- a/internal/sdnotify/monotonic_linux.go
+++ b/internal/sdnotify/monotonic_linux.go
@@ -1,0 +1,43 @@
+// Copyright (C) 2026 Chris Boot
+// Copyright (C) 2026 Vox Pupuli and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package sdnotify
+
+import (
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// monotonicUsec returns the current CLOCK_MONOTONIC reading in microseconds.
+//
+// This is the clock systemd timestamps its own events with, so a
+// MONOTONIC_USEC field built from it is directly comparable with the moment
+// the service manager sent SIGHUP — which is exactly what `Type=notify-reload`
+// uses to tell a genuine reload acknowledgement from a stale one. Go's time
+// package keeps its monotonic reading private, hence the syscall.
+func monotonicUsec() (uint64, bool) {
+	var ts unix.Timespec
+	if err := unix.ClockGettime(unix.CLOCK_MONOTONIC, &ts); err != nil {
+		return 0, false
+	}
+	nsec := ts.Nano()
+	if nsec < 0 {
+		return 0, false
+	}
+	return uint64(nsec) / uint64(time.Microsecond), true
+}

--- a/internal/sdnotify/monotonic_other.go
+++ b/internal/sdnotify/monotonic_other.go
@@ -1,0 +1,28 @@
+// Copyright (C) 2026 Chris Boot
+// Copyright (C) 2026 Vox Pupuli and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+//go:build !linux
+
+package sdnotify
+
+// monotonicUsec reports that no systemd-comparable monotonic clock is
+// available. Only Linux hosts run a service manager that speaks this protocol;
+// on every other platform (developer workstations running the test suite)
+// RELOADING=1 is simply sent without MONOTONIC_USEC.
+func monotonicUsec() (uint64, bool) {
+	return 0, false
+}

--- a/internal/sdnotify/sdnotify.go
+++ b/internal/sdnotify/sdnotify.go
@@ -1,0 +1,280 @@
+// Copyright (C) 2026 Chris Boot
+// Copyright (C) 2026 Vox Pupuli and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+// Package sdnotify implements the service-manager notification protocol
+// described in sd_notify(3), so openvox-ca can run as a systemd `Type=notify`
+// (or `Type=notify-reload`) service.
+//
+// The protocol is deliberately simple: the service manager passes the path of
+// a datagram socket in $NOTIFY_SOCKET, and the service sends newline-separated
+// `KEY=value` assignments to it. Nothing is read back, and a lost datagram
+// only means a lost status update — so every failure here is logged and
+// swallowed rather than propagated. A Notifier constructed without
+// $NOTIFY_SOCKET in the environment is inert: every method is a no-op, which
+// is the normal case when running in a container, under another supervisor, or
+// from a shell.
+//
+// Notifications are sent from whichever process actually knows the state being
+// reported, which in openvox-ca's isolated-process topology (launcher →
+// signer + frontend children) is not always the unit's main PID. Units must
+// therefore set `NotifyAccess=all`; see docs/systemd.md.
+package sdnotify
+
+import (
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// maxStatusLen bounds the STATUS= text. systemd shows the status in
+// `systemctl status` output and in `systemctl show -p StatusText`; anything
+// longer than a terminal line is noise, and the cap also bounds what an
+// attacker-influenced certificate subject can push into the journal.
+const maxStatusLen = 256
+
+// Notifier sends state notifications to the service manager over the socket
+// named by $NOTIFY_SOCKET. The zero value and a nil *Notifier are both valid
+// and inert, so callers never need to guard their calls.
+type Notifier struct {
+	// mu serialises writes to conn. Datagram writes are atomic per message,
+	// but the heartbeat goroutine and the shutdown path can notify
+	// concurrently, and Go's net package requires no external locking only for
+	// the write itself — the lock also keeps close/write ordering sane.
+	mu   sync.Mutex
+	conn *net.UnixConn
+
+	// watchdog is the WatchdogSec= interval the service manager expects to be
+	// fed within, or zero when the watchdog is disabled.
+	watchdog time.Duration
+}
+
+// New returns a Notifier for the current environment. When $NOTIFY_SOCKET is
+// unset — or names a socket that cannot be reached — the returned Notifier is
+// inert; the error is logged at debug level and never returned, because the
+// inability to talk to a service manager must not stop the CA from serving.
+//
+// The connection is established once and held for the process lifetime rather
+// than dialled per message, so the periodic watchdog keep-alive does not churn
+// a socket every few seconds.
+func New() *Notifier {
+	addr := os.Getenv("NOTIFY_SOCKET")
+	if addr == "" {
+		return &Notifier{}
+	}
+
+	// A leading '@' selects the abstract namespace, which is spelled with a
+	// leading NUL byte in sun_path. sd_notify(3) mandates this translation;
+	// the socket is otherwise a filesystem path (typically /run/systemd/notify).
+	if strings.HasPrefix(addr, "@") {
+		addr = "\x00" + addr[1:]
+	}
+
+	conn, err := net.DialUnix("unixgram", nil, &net.UnixAddr{Name: addr, Net: "unixgram"})
+	if err != nil {
+		slog.Debug("Service manager notifications disabled: cannot connect to NOTIFY_SOCKET",
+			"socket", os.Getenv("NOTIFY_SOCKET"), "error", err)
+		return &Notifier{}
+	}
+
+	n := &Notifier{conn: conn}
+	n.watchdog = watchdogIntervalFromEnv()
+	return n
+}
+
+// Enabled reports whether notifications are actually going anywhere, i.e.
+// whether the process was started by a service manager that asked to be
+// notified.
+func (n *Notifier) Enabled() bool {
+	return n != nil && n.conn != nil
+}
+
+// WatchdogInterval returns the WatchdogSec= interval configured for the unit,
+// or zero when the service manager has not enabled the watchdog. Callers
+// should send Watchdog() keep-alives at least twice per interval, as
+// recommended by sd_watchdog_enabled(3).
+func (n *Notifier) WatchdogInterval() time.Duration {
+	if n == nil {
+		return 0
+	}
+	return n.watchdog
+}
+
+// Ready reports that startup is complete and the service is serving. status,
+// when non-empty, is also published as the unit's status text.
+func (n *Notifier) Ready(status string) {
+	n.send(assignments("READY=1", statusLine(status)))
+}
+
+// Status updates the unit's status text without changing its state. It is safe
+// (and useful) to call repeatedly: `systemctl status` shows the most recent
+// text, which is the cheapest way for an operator to see what a long startup
+// is waiting on.
+func (n *Notifier) Status(status string) {
+	if status == "" {
+		return
+	}
+	n.send(assignments(statusLine(status)))
+}
+
+// Reloading reports that the service has begun reloading its configuration.
+// The caller must follow it with Ready once the reload has finished.
+//
+// MONOTONIC_USEC is included because `Type=notify-reload` requires it: the
+// service manager compares it against the time it sent SIGHUP to distinguish
+// this reload from a stale notification. It is omitted on platforms where the
+// monotonic clock is unavailable, which downgrades cleanly to `Type=notify`
+// behaviour.
+func (n *Notifier) Reloading(status string) {
+	fields := []string{"RELOADING=1"}
+	if usec, ok := monotonicUsec(); ok {
+		fields = append(fields, "MONOTONIC_USEC="+strconv.FormatUint(usec, 10))
+	}
+	fields = append(fields, statusLine(status))
+	n.send(assignments(fields...))
+}
+
+// Stopping reports that the service has begun shutting down, so the service
+// manager can distinguish a graceful drain from an unexpected exit.
+func (n *Notifier) Stopping(status string) {
+	n.send(assignments("STOPPING=1", statusLine(status)))
+}
+
+// Watchdog sends a keep-alive, resetting the service manager's watchdog timer.
+// It is a no-op when the watchdog is not enabled for the unit.
+func (n *Notifier) Watchdog() {
+	if n.WatchdogInterval() == 0 {
+		return
+	}
+	n.send("WATCHDOG=1")
+}
+
+// Close releases the notification socket. Further calls are no-ops.
+func (n *Notifier) Close() error {
+	if n == nil {
+		return nil
+	}
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.conn == nil {
+		return nil
+	}
+	err := n.conn.Close()
+	n.conn = nil
+	return err
+}
+
+// send writes one notification datagram. Errors are logged at debug level and
+// dropped: a service manager that has gone away, or a full socket buffer, is
+// not a reason to disturb the CA.
+func (n *Notifier) send(msg string) {
+	if !n.Enabled() || msg == "" {
+		return
+	}
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.conn == nil { // closed between the Enabled check and the lock
+		return
+	}
+	if _, err := n.conn.Write([]byte(msg)); err != nil {
+		slog.Debug("Failed to notify the service manager", "error", err)
+	}
+}
+
+// assignments joins non-empty protocol assignments into a single datagram.
+// sd_notify(3) requires them newline-separated; a trailing newline is
+// permitted and keeps the payload readable in packet captures.
+func assignments(fields ...string) string {
+	kept := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if f != "" {
+			kept = append(kept, f)
+		}
+	}
+	if len(kept) == 0 {
+		return ""
+	}
+	return strings.Join(kept, "\n") + "\n"
+}
+
+// statusLine renders a STATUS= assignment, or "" for empty status.
+//
+// SECURITY: the status text is built from runtime state that includes
+// certificate subjects, which are attacker-influenced. A newline in the value
+// would terminate the assignment and let the remainder be parsed as further
+// protocol fields — for example injecting READY=1 or MAINPID=. Every control
+// character is therefore folded to a space before the value is sent, and the
+// result is truncated to maxStatusLen.
+// NIST 800-53: SI-10 (Information Input Validation)
+func statusLine(status string) string {
+	if status == "" {
+		return ""
+	}
+	clean := strings.Map(func(r rune) rune {
+		if r == '\n' || r == '\r' || r == 0 {
+			return ' '
+		}
+		return r
+	}, status)
+	if len(clean) > maxStatusLen {
+		// Trim to a rune boundary so a multi-byte character is never split.
+		clean = strings.ToValidUTF8(clean[:maxStatusLen], "")
+	}
+	return "STATUS=" + clean
+}
+
+// watchdogIntervalFromEnv reads the WatchdogSec= interval the service manager
+// published in $WATCHDOG_USEC.
+//
+// Unlike sd_watchdog_enabled(3) this deliberately ignores $WATCHDOG_PID. That
+// variable names the unit's main PID, but in openvox-ca's isolated-process
+// topology the process that knows whether the CA is actually healthy is the
+// frontend child, not the launcher (see cmd/openvox-ca/launcher.go). Units
+// already need NotifyAccess=all for that child to notify at all, so honouring
+// the PID check here would only disable the watchdog in exactly the
+// configuration it is most useful for.
+func watchdogIntervalFromEnv() time.Duration {
+	raw := os.Getenv("WATCHDOG_USEC")
+	if raw == "" {
+		return 0
+	}
+	usec, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil || usec == 0 {
+		slog.Debug("Ignoring unusable WATCHDOG_USEC", "value", raw, "error", err)
+		return 0
+	}
+	// Guard the multiplication: a bogus value near 2^64 would otherwise wrap
+	// into a small or negative interval and cause a keep-alive storm.
+	const maxUsec = uint64(1<<63-1) / uint64(time.Microsecond)
+	if usec > maxUsec {
+		slog.Debug("Ignoring out-of-range WATCHDOG_USEC", "value", raw)
+		return 0
+	}
+	return time.Duration(usec) * time.Microsecond
+}
+
+// String makes a Notifier readable in log/debug output.
+func (n *Notifier) String() string {
+	if !n.Enabled() {
+		return "sdnotify(disabled)"
+	}
+	return fmt.Sprintf("sdnotify(socket=%s, watchdog=%s)", os.Getenv("NOTIFY_SOCKET"), n.watchdog)
+}

--- a/internal/sdnotify/sdnotify.go
+++ b/internal/sdnotify/sdnotify.go
@@ -83,8 +83,11 @@ func New() *Notifier {
 	}
 
 	// A leading '@' selects the abstract namespace, which is spelled with a
-	// leading NUL byte in sun_path. sd_notify(3) mandates this translation;
-	// the socket is otherwise a filesystem path (typically /run/systemd/notify).
+	// leading NUL byte in sun_path; the socket is otherwise a filesystem path
+	// (typically /run/systemd/notify). Go's syscall layer happens to accept
+	// either spelling, so this is belt and braces — but sd_notify(3) states the
+	// translation as the service's job, and relying on a convenience of the
+	// standard library for a protocol requirement is how it breaks quietly.
 	if strings.HasPrefix(addr, "@") {
 		addr = "\x00" + addr[1:]
 	}

--- a/internal/sdnotify/sdnotify.go
+++ b/internal/sdnotify/sdnotify.go
@@ -35,7 +35,6 @@
 package sdnotify
 
 import (
-	"fmt"
 	"log/slog"
 	"net"
 	"os"
@@ -43,6 +42,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 )
 
 // maxStatusLen bounds the STATUS= text. systemd shows the status in
@@ -55,10 +55,11 @@ const maxStatusLen = 256
 // named by $NOTIFY_SOCKET. The zero value and a nil *Notifier are both valid
 // and inert, so callers never need to guard their calls.
 type Notifier struct {
-	// mu serialises writes to conn. Datagram writes are atomic per message,
-	// but the heartbeat goroutine and the shutdown path can notify
-	// concurrently, and Go's net package requires no external locking only for
-	// the write itself — the lock also keeps close/write ordering sane.
+	// mu guards conn, and is held for every read of it (Enabled, send) as well
+	// as the write in Close. Datagram writes are atomic per message, but the
+	// heartbeat goroutine and the shutdown path notify concurrently while a
+	// deferred Close can land at any time, so both sides of that race have to
+	// take the lock.
 	mu   sync.Mutex
 	conn *net.UnixConn
 
@@ -69,8 +70,8 @@ type Notifier struct {
 
 // New returns a Notifier for the current environment. When $NOTIFY_SOCKET is
 // unset — or names a socket that cannot be reached — the returned Notifier is
-// inert; the error is logged at debug level and never returned, because the
-// inability to talk to a service manager must not stop the CA from serving.
+// inert; the error is logged and never returned, because the inability to talk
+// to a service manager must not stop the CA from serving.
 //
 // The connection is established once and held for the process lifetime rather
 // than dialled per message, so the periodic watchdog keep-alive does not churn
@@ -90,7 +91,12 @@ func New() *Notifier {
 
 	conn, err := net.DialUnix("unixgram", nil, &net.UnixAddr{Name: addr, Net: "unixgram"})
 	if err != nil {
-		slog.Debug("Service manager notifications disabled: cannot connect to NOTIFY_SOCKET",
+		// Warn, not Debug: $NOTIFY_SOCKET being set means a service manager is
+		// expecting notifications, so failing to reach it is a real problem —
+		// the unit will sit there until TimeoutStartSec with no READY=1. This
+		// runs before the configured logger is installed, so a lower level
+		// could not be turned up by the operator even with --verbosity.
+		slog.Warn("Service manager notifications disabled: cannot connect to NOTIFY_SOCKET",
 			"socket", os.Getenv("NOTIFY_SOCKET"), "error", err)
 		return &Notifier{}
 	}
@@ -103,8 +109,18 @@ func New() *Notifier {
 // Enabled reports whether notifications are actually going anywhere, i.e.
 // whether the process was started by a service manager that asked to be
 // notified.
+//
+// It takes the lock: Close can run concurrently with the heartbeat and reload
+// goroutines (neither is joined before the deferred Close in the frontend), so
+// reading conn unsynchronised would be a data race even though the value it
+// races with is only ever nil.
 func (n *Notifier) Enabled() bool {
-	return n != nil && n.conn != nil
+	if n == nil {
+		return false
+	}
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.conn != nil
 }
 
 // WatchdogInterval returns the WatchdogSec= interval configured for the unit,
@@ -164,7 +180,7 @@ func (n *Notifier) Watchdog() {
 	if n.WatchdogInterval() == 0 {
 		return
 	}
-	n.send("WATCHDOG=1")
+	n.send(assignments("WATCHDOG=1"))
 }
 
 // Close releases the notification socket. Further calls are no-ops.
@@ -186,12 +202,12 @@ func (n *Notifier) Close() error {
 // dropped: a service manager that has gone away, or a full socket buffer, is
 // not a reason to disturb the CA.
 func (n *Notifier) send(msg string) {
-	if !n.Enabled() || msg == "" {
+	if n == nil || msg == "" {
 		return
 	}
 	n.mu.Lock()
 	defer n.mu.Unlock()
-	if n.conn == nil { // closed between the Enabled check and the lock
+	if n.conn == nil { // never connected, or closed while this call was queued
 		return
 	}
 	if _, err := n.conn.Write([]byte(msg)); err != nil {
@@ -222,14 +238,17 @@ func assignments(fields ...string) string {
 // would terminate the assignment and let the remainder be parsed as further
 // protocol fields — for example injecting READY=1 or MAINPID=. Every control
 // character is therefore folded to a space before the value is sent, and the
-// result is truncated to maxStatusLen.
+// result is truncated to maxStatusLen. The fold is deliberately wider than the
+// protocol needs: only the newline can break framing, but the status text is
+// relayed to a terminal by `systemctl status`, so escape sequences are stripped
+// too rather than left for the journal to pass through.
 // NIST 800-53: SI-10 (Information Input Validation)
 func statusLine(status string) string {
 	if status == "" {
 		return ""
 	}
 	clean := strings.Map(func(r rune) rune {
-		if r == '\n' || r == '\r' || r == 0 {
+		if unicode.IsControl(r) {
 			return ' '
 		}
 		return r
@@ -269,12 +288,4 @@ func watchdogIntervalFromEnv() time.Duration {
 		return 0
 	}
 	return time.Duration(usec) * time.Microsecond
-}
-
-// String makes a Notifier readable in log/debug output.
-func (n *Notifier) String() string {
-	if !n.Enabled() {
-		return "sdnotify(disabled)"
-	}
-	return fmt.Sprintf("sdnotify(socket=%s, watchdog=%s)", os.Getenv("NOTIFY_SOCKET"), n.watchdog)
 }

--- a/internal/sdnotify/sdnotify_suite_test.go
+++ b/internal/sdnotify/sdnotify_suite_test.go
@@ -1,0 +1,30 @@
+// Copyright (C) 2026 Chris Boot
+// Copyright (C) 2026 Vox Pupuli and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package sdnotify_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSdnotify(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Sdnotify Suite")
+}

--- a/internal/sdnotify/sdnotify_test.go
+++ b/internal/sdnotify/sdnotify_test.go
@@ -22,8 +22,11 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
+	"unicode/utf8"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -217,10 +220,32 @@ var _ = Describe("Notifier", func() {
 				Expect(mgr.next()).To(Equal("STATUS=a b c\n"))
 			})
 
+			It("folds every other control character too", func() {
+				// Only the newline can break framing, but the status text is
+				// relayed to a terminal by `systemctl status`, so escape
+				// sequences should not survive either.
+				n.Status("before\x1b[31mred\tafter")
+				Expect(mgr.next()).To(Equal("STATUS=before [31mred after\n"))
+			})
+
 			It("truncates an over-long status", func() {
 				n.Status(strings.Repeat("x", 500))
 				msg := mgr.next()
 				Expect(msg).To(Equal("STATUS=" + strings.Repeat("x", 256) + "\n"))
+			})
+
+			It("does not split a multi-byte character at the truncation point", func() {
+				// The cap counts bytes, so a certificate subject containing an
+				// IDN domain or a non-English organisation name can put a rune
+				// astride the boundary. Emitting half of it would be invalid
+				// UTF-8 in the journal.
+				status := strings.Repeat("x", 255) + "\u20ac" + strings.Repeat("y", 10)
+				n.Status(status)
+
+				msg := mgr.next()
+				value := strings.TrimSuffix(strings.TrimPrefix(msg, "STATUS="), "\n")
+				Expect(utf8.ValidString(value)).To(BeTrue(), "truncated status must stay valid UTF-8")
+				Expect(value).To(Equal(strings.Repeat("x", 255)), "the straddling rune is dropped, not halved")
 			})
 		})
 	})
@@ -239,7 +264,7 @@ var _ = Describe("Notifier", func() {
 
 			Expect(n.WatchdogInterval()).To(Equal(30 * time.Second))
 			n.Watchdog()
-			Expect(mgr.next()).To(Equal("WATCHDOG=1"))
+			Expect(mgr.next()).To(Equal("WATCHDOG=1\n"))
 		})
 
 		It("keeps feeding the watchdog independently of WATCHDOG_PID", func() {
@@ -272,6 +297,96 @@ var _ = Describe("Notifier", func() {
 			// (or negative) interval, causing a keep-alive storm.
 			Entry("beyond time.Duration's range", "18446744073709551615"),
 		)
+
+		It("accepts the largest interval that still fits time.Duration", func() {
+			// Guards the boundary of the overflow check itself: one microsecond
+			// more must be rejected, this value must not be.
+			const maxUsec = uint64(1<<63-1) / uint64(time.Microsecond)
+			setEnv("WATCHDOG_USEC", strconv.FormatUint(maxUsec, 10))
+			n := sdnotify.New()
+			DeferCleanup(func() { Expect(n.Close()).To(Succeed()) })
+
+			Expect(n.WatchdogInterval()).To(Equal(time.Duration(maxUsec) * time.Microsecond))
+		})
+
+		It("rejects one microsecond beyond that", func() {
+			const maxUsec = uint64(1<<63-1) / uint64(time.Microsecond)
+			setEnv("WATCHDOG_USEC", strconv.FormatUint(maxUsec+1, 10))
+			n := sdnotify.New()
+			DeferCleanup(func() { Expect(n.Close()).To(Succeed()) })
+
+			Expect(n.WatchdogInterval()).To(BeZero())
+		})
+	})
+
+	Describe("an abstract-namespace socket", func() {
+		It("connects to a @-prefixed NOTIFY_SOCKET", func() {
+			// sd_notify(3) spells abstract sockets with a leading '@' that the
+			// service has to translate to a NUL byte in sun_path. Only Linux
+			// has the abstract namespace, and only a real round-trip proves the
+			// translation lands on the right socket.
+			if runtime.GOOS != "linux" {
+				Skip("the abstract socket namespace is Linux-only")
+			}
+
+			name := "@openvox-ca-sdnotify-test-" + strconv.Itoa(os.Getpid())
+			conn, err := net.ListenUnixgram("unixgram", &net.UnixAddr{Name: name, Net: "unixgram"})
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(func() { conn.Close() })
+
+			received := make(chan string, 1)
+			go func() {
+				buf := make([]byte, 4096)
+				n, err := conn.Read(buf)
+				if err != nil {
+					return
+				}
+				received <- string(buf[:n])
+			}()
+
+			setEnv("NOTIFY_SOCKET", name)
+			n := sdnotify.New()
+			DeferCleanup(func() { Expect(n.Close()).To(Succeed()) })
+
+			Expect(n.Enabled()).To(BeTrue())
+			n.Ready("abstract")
+			Eventually(received).Should(Receive(Equal("READY=1\nSTATUS=abstract\n")))
+		})
+	})
+
+	Describe("concurrent use", func() {
+		It("tolerates notifications racing a close", func() {
+			// This is the production shape: the heartbeat and reload goroutines
+			// are never joined before the frontend's deferred Close, so both
+			// sides of that race have to be synchronised. Run with -race.
+			newFakeManager()
+			n := sdnotify.New()
+			Expect(n.Enabled()).To(BeTrue())
+
+			var wg sync.WaitGroup
+			for i := 0; i < 4; i++ {
+				wg.Add(1)
+				go func() {
+					defer GinkgoRecover()
+					defer wg.Done()
+					for j := 0; j < 50; j++ {
+						n.Status("still here")
+						n.Watchdog()
+						n.Enabled()
+					}
+				}()
+			}
+
+			wg.Add(1)
+			go func() {
+				defer GinkgoRecover()
+				defer wg.Done()
+				Expect(n.Close()).To(Succeed())
+			}()
+
+			wg.Wait()
+			Expect(n.Enabled()).To(BeFalse())
+		})
 	})
 
 	Describe("a nil Notifier", func() {

--- a/internal/sdnotify/sdnotify_test.go
+++ b/internal/sdnotify/sdnotify_test.go
@@ -321,10 +321,11 @@ var _ = Describe("Notifier", func() {
 
 	Describe("an abstract-namespace socket", func() {
 		It("connects to a @-prefixed NOTIFY_SOCKET", func() {
-			// sd_notify(3) spells abstract sockets with a leading '@' that the
-			// service has to translate to a NUL byte in sun_path. Only Linux
-			// has the abstract namespace, and only a real round-trip proves the
-			// translation lands on the right socket.
+			// sd_notify(3) spells abstract sockets with a leading '@'. This
+			// proves an @-prefixed NOTIFY_SOCKET connects and round-trips end
+			// to end; it cannot single out New's own '@'-to-NUL translation,
+			// because Go's syscall layer accepts either spelling. Only Linux
+			// has the abstract namespace at all.
 			if runtime.GOOS != "linux" {
 				Skip("the abstract socket namespace is Linux-only")
 			}
@@ -358,7 +359,8 @@ var _ = Describe("Notifier", func() {
 		It("tolerates notifications racing a close", func() {
 			// This is the production shape: the heartbeat and reload goroutines
 			// are never joined before the frontend's deferred Close, so both
-			// sides of that race have to be synchronised. Run with -race.
+			// sides of that race have to be synchronised. This spec only fails
+			// under -race, which mage test:unit passes (see magefile.go).
 			newFakeManager()
 			n := sdnotify.New()
 			Expect(n.Enabled()).To(BeTrue())

--- a/internal/sdnotify/sdnotify_test.go
+++ b/internal/sdnotify/sdnotify_test.go
@@ -1,0 +1,290 @@
+// Copyright (C) 2026 Chris Boot
+// Copyright (C) 2026 Vox Pupuli and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package sdnotify_test
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/voxpupuli/openvox-ca/internal/sdnotify"
+)
+
+// fakeManager stands in for the service manager: it owns the datagram socket
+// named by $NOTIFY_SOCKET and records every message the Notifier sends.
+type fakeManager struct {
+	msgs chan string
+}
+
+// newFakeManager binds a datagram socket in a temporary directory, points
+// $NOTIFY_SOCKET at it, and starts draining messages. Both the socket and the
+// environment variable are restored when the spec finishes.
+func newFakeManager() *fakeManager {
+	dir, err := os.MkdirTemp("", "sdnotify")
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(func() { Expect(os.RemoveAll(dir)).To(Succeed()) })
+
+	path := filepath.Join(dir, "notify.sock")
+	conn, err := net.ListenUnixgram("unixgram", &net.UnixAddr{Name: path, Net: "unixgram"})
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(func() { conn.Close() })
+
+	m := &fakeManager{msgs: make(chan string, 32)}
+	go func() {
+		buf := make([]byte, 8192)
+		for {
+			n, err := conn.Read(buf)
+			if err != nil {
+				close(m.msgs)
+				return
+			}
+			m.msgs <- string(buf[:n])
+		}
+	}()
+
+	setEnv("NOTIFY_SOCKET", path)
+	return m
+}
+
+// next returns the next message received, failing the spec if none arrives.
+func (m *fakeManager) next() string {
+	var msg string
+	EventuallyWithOffset(1, m.msgs).Should(Receive(&msg))
+	return msg
+}
+
+// setEnv sets an environment variable for the duration of the current spec,
+// restoring the previous value (or absence) afterwards. Ginkgo nodes cannot
+// use testing.T.Setenv, and specs must not leak state into their siblings.
+func setEnv(key, value string) {
+	prev, had := os.LookupEnv(key)
+	ExpectWithOffset(1, os.Setenv(key, value)).To(Succeed())
+	DeferCleanup(func() {
+		if had {
+			Expect(os.Setenv(key, prev)).To(Succeed())
+			return
+		}
+		Expect(os.Unsetenv(key)).To(Succeed())
+	})
+}
+
+// unsetEnv removes an environment variable for the duration of the spec.
+func unsetEnv(key string) {
+	prev, had := os.LookupEnv(key)
+	ExpectWithOffset(1, os.Unsetenv(key)).To(Succeed())
+	DeferCleanup(func() {
+		if had {
+			Expect(os.Setenv(key, prev)).To(Succeed())
+		}
+	})
+}
+
+var _ = Describe("Notifier", func() {
+	BeforeEach(func() {
+		// Every spec starts from a known environment: specs that want a
+		// service manager or a watchdog opt in explicitly.
+		unsetEnv("NOTIFY_SOCKET")
+		unsetEnv("WATCHDOG_USEC")
+	})
+
+	Context("when NOTIFY_SOCKET is not set", func() {
+		It("is inert and safe to use", func() {
+			n := sdnotify.New()
+			Expect(n.Enabled()).To(BeFalse())
+			Expect(n.WatchdogInterval()).To(BeZero())
+
+			// None of these may panic or block; there is nothing to notify.
+			n.Ready("serving")
+			n.Status("working")
+			n.Reloading("reloading")
+			n.Stopping("stopping")
+			n.Watchdog()
+			Expect(n.Close()).To(Succeed())
+		})
+	})
+
+	Context("when NOTIFY_SOCKET names an unusable socket", func() {
+		It("degrades to inert rather than failing", func() {
+			setEnv("NOTIFY_SOCKET", filepath.Join(GinkgoT().TempDir(), "does-not-exist.sock"))
+			n := sdnotify.New()
+			Expect(n.Enabled()).To(BeFalse())
+			n.Ready("serving") // must not panic
+		})
+	})
+
+	Context("when a service manager is listening", func() {
+		var (
+			mgr *fakeManager
+			n   *sdnotify.Notifier
+		)
+
+		BeforeEach(func() {
+			mgr = newFakeManager()
+			n = sdnotify.New()
+			Expect(n.Enabled()).To(BeTrue())
+			DeferCleanup(func() { Expect(n.Close()).To(Succeed()) })
+		})
+
+		It("reports readiness with a status line", func() {
+			n.Ready("Serving HTTPS on 0.0.0.0:8140")
+			Expect(mgr.next()).To(Equal("READY=1\nSTATUS=Serving HTTPS on 0.0.0.0:8140\n"))
+		})
+
+		It("omits the status line when no status is given", func() {
+			n.Ready("")
+			Expect(mgr.next()).To(Equal("READY=1\n"))
+		})
+
+		It("updates the status text on its own", func() {
+			n.Status("Initialising CA")
+			Expect(mgr.next()).To(Equal("STATUS=Initialising CA\n"))
+		})
+
+		It("sends nothing for an empty status update", func() {
+			n.Status("")
+			n.Status("second") // a sentinel that must arrive first if the empty one was dropped
+			Expect(mgr.next()).To(Equal("STATUS=second\n"))
+		})
+
+		It("reports the start of a reload", func() {
+			n.Reloading("Reloading TLS material")
+			msg := mgr.next()
+			Expect(msg).To(HavePrefix("RELOADING=1\n"))
+			Expect(msg).To(HaveSuffix("STATUS=Reloading TLS material\n"))
+		})
+
+		It("includes a monotonic timestamp with the reload on Linux", func() {
+			// Type=notify-reload rejects a RELOADING=1 that carries no
+			// MONOTONIC_USEC, so this field is load-bearing on Linux.
+			if runtime.GOOS != "linux" {
+				Skip("MONOTONIC_USEC is only sent on Linux")
+			}
+			n.Reloading("")
+			Expect(mgr.next()).To(MatchRegexp(`\ARELOADING=1\nMONOTONIC_USEC=[0-9]+\n\z`))
+		})
+
+		It("reports the start of shutdown", func() {
+			n.Stopping("Draining connections")
+			Expect(mgr.next()).To(Equal("STOPPING=1\nSTATUS=Draining connections\n"))
+		})
+
+		It("ignores watchdog keep-alives when the watchdog is disabled", func() {
+			n.Watchdog()
+			n.Status("sentinel")
+			Expect(mgr.next()).To(Equal("STATUS=sentinel\n"))
+		})
+
+		It("is safe to close twice", func() {
+			Expect(n.Close()).To(Succeed())
+			Expect(n.Close()).To(Succeed())
+			n.Status("after close") // must not panic
+			Expect(n.Enabled()).To(BeFalse())
+		})
+
+		Describe("status sanitisation", func() {
+			// SECURITY: status text is built from certificate subjects, which
+			// are attacker-influenced. A raw newline would let the remainder be
+			// parsed as further protocol assignments.
+			It("folds newlines so protocol fields cannot be injected", func() {
+				n.Status("evil.example.com\nREADY=1\nMAINPID=1")
+				msg := mgr.next()
+				Expect(msg).To(Equal("STATUS=evil.example.com READY=1 MAINPID=1\n"))
+				Expect(strings.Count(msg, "\n")).To(Equal(1))
+			})
+
+			It("folds carriage returns and NUL bytes", func() {
+				n.Status("a\rb\x00c")
+				Expect(mgr.next()).To(Equal("STATUS=a b c\n"))
+			})
+
+			It("truncates an over-long status", func() {
+				n.Status(strings.Repeat("x", 500))
+				msg := mgr.next()
+				Expect(msg).To(Equal("STATUS=" + strings.Repeat("x", 256) + "\n"))
+			})
+		})
+	})
+
+	Describe("watchdog configuration", func() {
+		var mgr *fakeManager
+
+		BeforeEach(func() {
+			mgr = newFakeManager()
+		})
+
+		It("adopts the interval published in WATCHDOG_USEC", func() {
+			setEnv("WATCHDOG_USEC", "30000000")
+			n := sdnotify.New()
+			DeferCleanup(func() { Expect(n.Close()).To(Succeed()) })
+
+			Expect(n.WatchdogInterval()).To(Equal(30 * time.Second))
+			n.Watchdog()
+			Expect(mgr.next()).To(Equal("WATCHDOG=1"))
+		})
+
+		It("keeps feeding the watchdog independently of WATCHDOG_PID", func() {
+			// The frontend child, not the unit's main PID, is the process that
+			// knows the CA is healthy, so the PID check is deliberately not
+			// applied. See watchdogIntervalFromEnv.
+			setEnv("WATCHDOG_USEC", "10000000")
+			setEnv("WATCHDOG_PID", "1")
+			n := sdnotify.New()
+			DeferCleanup(func() { Expect(n.Close()).To(Succeed()) })
+
+			Expect(n.WatchdogInterval()).To(Equal(10 * time.Second))
+		})
+
+		DescribeTable("rejects an unusable interval",
+			func(value string) {
+				setEnv("WATCHDOG_USEC", value)
+				n := sdnotify.New()
+				DeferCleanup(func() { Expect(n.Close()).To(Succeed()) })
+
+				Expect(n.WatchdogInterval()).To(BeZero())
+				n.Watchdog()
+				n.Status("sentinel")
+				Expect(mgr.next()).To(Equal("STATUS=sentinel\n"))
+			},
+			Entry("not a number", "soon"),
+			Entry("zero", "0"),
+			Entry("negative", "-1"),
+			// Would overflow time.Duration's nanoseconds and wrap into a tiny
+			// (or negative) interval, causing a keep-alive storm.
+			Entry("beyond time.Duration's range", "18446744073709551615"),
+		)
+	})
+
+	Describe("a nil Notifier", func() {
+		It("behaves like a disabled one", func() {
+			var n *sdnotify.Notifier
+			Expect(n.Enabled()).To(BeFalse())
+			Expect(n.WatchdogInterval()).To(BeZero())
+			n.Ready("x")
+			n.Status("x")
+			n.Reloading("x")
+			n.Stopping("x")
+			n.Watchdog()
+			Expect(n.Close()).To(Succeed())
+		})
+	})
+})

--- a/magefile.go
+++ b/magefile.go
@@ -219,12 +219,14 @@ func (Build) Dist() error {
 
 	// Archive contents, with the mode each entry must extract as. Stating the
 	// modes here rather than reading them back off the staged files keeps the
-	// tarball identical whatever umask the release is built under.
-	archiveFiles := []archiveEntry{
-		{name: bins[0], mode: 0755},
-		{name: bins[1], mode: 0755},
-		{name: unitFile, mode: 0644},
+	// tarball identical whatever umask the release is built under; deriving the
+	// executables from bins keeps the archive in step with what actually gets
+	// built.
+	archiveFiles := make([]archiveEntry, 0, len(bins)+1)
+	for _, b := range bins {
+		archiveFiles = append(archiveFiles, archiveEntry{name: b, mode: 0755})
 	}
+	archiveFiles = append(archiveFiles, archiveEntry{name: unitFile, mode: 0644})
 
 	var checksums []string
 	for _, v := range variants {
@@ -318,7 +320,12 @@ func (Test) Unit() error {
 		return err
 	}
 
-	testArgs := append([]string{"test", "-json", "-cover", "-coverprofile=coverage.out"}, pkgs...)
+	// -race is not optional here: the notification path (internal/sdnotify) is
+	// driven concurrently by the heartbeat, the reload watcher, and a deferred
+	// Close, and its locking is only verified by specs that fail exclusively
+	// under the race detector. It costs roughly 15% on the slowest package.
+	// It needs cgo, which is the default everywhere this runs.
+	testArgs := append([]string{"test", "-race", "-json", "-cover", "-coverprofile=coverage.out"}, pkgs...)
 	testCmd := exec.Command("go", testArgs...)
 	tparseCmd := exec.Command("go", "tool", "tparse", "-all")
 
@@ -1046,15 +1053,15 @@ func createTarGz(dst, srcDir string, files []archiveEntry) (retErr error) {
 		}
 	}()
 
-	for _, f := range files {
-		src := filepath.Join(srcDir, f.name)
+	for _, entry := range files {
+		src := filepath.Join(srcDir, entry.name)
 		fi, err := os.Stat(src)
 		if err != nil {
 			return err
 		}
 		if err := tw.WriteHeader(&tar.Header{
-			Name: f.name,
-			Mode: f.mode,
+			Name: entry.name,
+			Mode: entry.mode,
 			Size: fi.Size(),
 		}); err != nil {
 			return err

--- a/magefile.go
+++ b/magefile.go
@@ -217,6 +217,15 @@ func (Build) Dist() error {
 	const unitFile = "openvox-ca.service"
 	unitSrc := filepath.Join("packaging", "systemd", unitFile)
 
+	// Archive contents, with the mode each entry must extract as. Stating the
+	// modes here rather than reading them back off the staged files keeps the
+	// tarball identical whatever umask the release is built under.
+	archiveFiles := []archiveEntry{
+		{name: bins[0], mode: 0755},
+		{name: bins[1], mode: 0755},
+		{name: unitFile, mode: 0644},
+	}
+
 	var checksums []string
 	for _, v := range variants {
 		fmt.Printf("Building %s...\n", v.name)
@@ -241,7 +250,7 @@ func (Build) Dist() error {
 				return "", fmt.Errorf("stage %s for %s: %w", unitFile, v.name, err)
 			}
 
-			if err := createTarGz(archive, tmpDir, append(append([]string{}, bins...), unitFile)); err != nil {
+			if err := createTarGz(archive, tmpDir, archiveFiles); err != nil {
 				return "", fmt.Errorf("archive %s: %w", v.name, err)
 			}
 			return sha256File(archive)
@@ -1008,7 +1017,16 @@ func runComposeWithSpinner(extraEnv map[string]string, spinMsg string, args ...s
 	return cmdErr
 }
 
-func createTarGz(dst, srcDir string, files []string) (retErr error) {
+// archiveEntry is one file in a release tarball, with the permissions it must
+// extract as. The archive mixes executables with plain data (the systemd unit),
+// and neither the build host's umask nor a single hard-coded mode gets both
+// right.
+type archiveEntry struct {
+	name string
+	mode int64
+}
+
+func createTarGz(dst, srcDir string, files []archiveEntry) (retErr error) {
 	f, err := os.Create(dst)
 	if err != nil {
 		return err
@@ -1028,18 +1046,15 @@ func createTarGz(dst, srcDir string, files []string) (retErr error) {
 		}
 	}()
 
-	for _, name := range files {
-		src := filepath.Join(srcDir, name)
+	for _, f := range files {
+		src := filepath.Join(srcDir, f.name)
 		fi, err := os.Stat(src)
 		if err != nil {
 			return err
 		}
-		// Take the mode from the staged file rather than hard-coding 0755:
-		// the archive carries both executables and plain data files (the
-		// systemd unit), and a unit file installed as executable is wrong.
 		if err := tw.WriteHeader(&tar.Header{
-			Name: name,
-			Mode: int64(fi.Mode().Perm()),
+			Name: f.name,
+			Mode: f.mode,
 			Size: fi.Size(),
 		}); err != nil {
 			return err

--- a/magefile.go
+++ b/magefile.go
@@ -212,6 +212,11 @@ func (Build) Dist() error {
 
 	bins := []string{"openvox-ca", "openvox-ca-ctl"}
 
+	// Shipped alongside the binaries so a VM install has a unit file that
+	// matches this build's notification behaviour (see docs/systemd.md).
+	const unitFile = "openvox-ca.service"
+	unitSrc := filepath.Join("packaging", "systemd", unitFile)
+
 	var checksums []string
 	for _, v := range variants {
 		fmt.Printf("Building %s...\n", v.name)
@@ -232,7 +237,11 @@ func (Build) Dist() error {
 				}
 			}
 
-			if err := createTarGz(archive, tmpDir, bins); err != nil {
+			if err := sh.Copy(filepath.Join(tmpDir, unitFile), unitSrc); err != nil {
+				return "", fmt.Errorf("stage %s for %s: %w", unitFile, v.name, err)
+			}
+
+			if err := createTarGz(archive, tmpDir, append(append([]string{}, bins...), unitFile)); err != nil {
 				return "", fmt.Errorf("archive %s: %w", v.name, err)
 			}
 			return sha256File(archive)
@@ -1025,7 +1034,14 @@ func createTarGz(dst, srcDir string, files []string) (retErr error) {
 		if err != nil {
 			return err
 		}
-		if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0755, Size: fi.Size()}); err != nil {
+		// Take the mode from the staged file rather than hard-coding 0755:
+		// the archive carries both executables and plain data files (the
+		// systemd unit), and a unit file installed as executable is wrong.
+		if err := tw.WriteHeader(&tar.Header{
+			Name: name,
+			Mode: int64(fi.Mode().Perm()),
+			Size: fi.Size(),
+		}); err != nil {
 			return err
 		}
 		rf, err := os.Open(src)

--- a/magefile.go
+++ b/magefile.go
@@ -1038,7 +1038,14 @@ func createTarGz(dst, srcDir string, files []archiveEntry) (retErr error) {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	// Closed with the same care as the writers below: a failure surfacing here
+	// (ENOSPC on a deferred allocation, say) would otherwise be dropped, and
+	// the caller would checksum and publish a truncated release artefact.
+	defer func() {
+		if err := f.Close(); err != nil && retErr == nil {
+			retErr = err
+		}
+	}()
 
 	gz := gzip.NewWriter(f)
 	defer func() {

--- a/packaging/systemd/openvox-ca.service
+++ b/packaging/systemd/openvox-ca.service
@@ -1,0 +1,79 @@
+[Unit]
+Description=OpenVox Certificate Authority
+Documentation=https://github.com/voxpupuli/openvox-ca/blob/main/docs/systemd.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+# openvox-ca reports READY=1 once its listener is accepting connections, so
+# anything ordered after this unit starts against a CA that is genuinely
+# serving rather than one that has merely been forked.
+Type=notify
+
+# Readiness is reported by the frontend child process, not the launcher: only
+# the frontend knows when the socket is up. The launcher is the main PID, so
+# the default (NotifyAccess=main) would drop those notifications and the start
+# job would time out.
+NotifyAccess=all
+
+# SIGHUP re-reads the TLS keypair and the admin allow list. On systemd 253 and
+# later you can drop this line and set Type=notify-reload instead, which makes
+# "systemctl reload" wait for the new configuration to be in effect.
+ExecReload=/bin/kill -HUP $MAINPID
+
+ExecStart=/usr/local/bin/openvox-ca --config /etc/puppet-ca/config.yaml
+
+# The frontend feeds the watchdog on a timer, so a process wedged on an
+# unresponsive storage backend is restarted rather than left half-alive.
+WatchdogSec=60s
+Restart=on-failure
+RestartSec=5s
+
+# Bootstrapping a CA generates a key pair, which can take a while on a slow or
+# entropy-starved machine; the status text says what it is waiting on.
+TimeoutStartSec=300s
+
+# Must exceed the drain budget (shutdown_timeout_sec, 25s by default) plus the
+# supervisor's 3s headroom, or systemd will truncate the drain it asked for.
+TimeoutStopSec=35s
+
+User=puppet-ca
+Group=puppet-ca
+
+# /var/lib/puppet-ca, created and owned by systemd. Point cadir at it, or add
+# the directory you use to ReadWritePaths below.
+StateDirectory=puppet-ca
+StateDirectoryMode=0750
+
+# Hardening. The CA holds a private key that signs every certificate in the
+# estate, so it should reach as little of the system as possible.
+NoNewPrivileges=yes
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectSystem=strict
+ProtectHome=yes
+ProtectProc=invisible
+ProtectClock=yes
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+RemoveIPC=yes
+# AF_UNIX covers both the notification socket and the launcher's socketpair to
+# the isolated signer process.
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+# The API listens on 8140 and the metrics exporter on 9140; neither is a
+# privileged port, so the service needs no capabilities at all.
+CapabilityBoundingSet=
+AmbientCapabilities=
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/systemd/openvox-ca.service
+++ b/packaging/systemd/openvox-ca.service
@@ -23,8 +23,10 @@ ExecReload=/bin/kill -HUP $MAINPID
 
 ExecStart=/usr/local/bin/openvox-ca --config /etc/puppet-ca/config.yaml
 
-# The frontend feeds the watchdog on a timer, so a process wedged on an
-# unresponsive storage backend is restarted rather than left half-alive.
+# The frontend feeds the watchdog on a timer, so a frontend that has died or
+# whose heartbeat has stalled is restarted rather than left half-alive. It is
+# not a backend health check -- see docs/systemd.md for what it does and does
+# not catch.
 WatchdogSec=60s
 Restart=on-failure
 RestartSec=5s
@@ -40,13 +42,22 @@ TimeoutStopSec=35s
 User=puppet-ca
 Group=puppet-ca
 
-# /var/lib/puppet-ca, created and owned by systemd. Point cadir at it, or add
-# the directory you use to ReadWritePaths below.
+# /var/lib/puppet-ca, created and owned by systemd, and the only writable path
+# under ProtectSystem=strict below. Either point cadir at it, or uncomment
+# ReadWritePaths and name the directory you use -- for a CA migrated from
+# OpenVox/Puppet Server that is typically /etc/puppetlabs/puppet/ssl/ca.
 StateDirectory=puppet-ca
 StateDirectoryMode=0750
+#ReadWritePaths=/etc/puppetlabs/puppet/ssl/ca
 
 # Hardening. The CA holds a private key that signs every certificate in the
 # estate, so it should reach as little of the system as possible.
+#
+# The signer holds the decrypted CA private key in memory for its whole life,
+# so a core dump would write that key to /var/lib/systemd/coredump -- defeating
+# encryption at rest. Go re-raises fatal signals with the default handler, so
+# this is reachable from an ordinary crash or a SIGQUIT taken for a stack dump.
+LimitCORE=0
 NoNewPrivileges=yes
 PrivateTmp=yes
 PrivateDevices=yes


### PR DESCRIPTION
`openvox-ca` has no way to tell a supervisor when it is actually serving. Under systemd that forces `Type=simple`, so `systemctl start` returns the moment the process is forked — before storage is reachable, before the CA has bootstrapped (which on a first run means generating a CA key pair), and before the listener is bound. Anything ordered `After=` the CA races its startup, and a CA that fails to initialise looks `active` until something tries to use it.

This adds `sd_notify(3)` support so a unit can be `Type=notify`, plus the reload capability that gives `RELOADING=1` something real to report, a shipped unit file, and documentation.

## What it does

**Readiness.** `READY=1` is sent by the frontend process between binding the listener and entering the accept loop, so `systemctl start` returning means the socket is genuinely accepting. That is why the unit sets `NotifyAccess=all`: in the default deployment the CA is three processes (launcher, isolated signer, frontend), and only the frontend knows when the listener is up — systemd's default of `NotifyAccess=main` would silently discard its notifications and the start job would fail on `TimeoutStartSec`.

**Status.** Each startup phase publishes what it is waiting on, so a hung start is diagnosable from `systemctl status` alone. Once serving:

```text
Status: "Serving HTTPS on 0.0.0.0:8140 | CA \"Puppet CA: puppet.example.com\" expires in 1824d | CRL #7 (3 revoked) expires in 29d"
```

Refreshed on a timer so the countdowns stay true, with elapsed deadlines in capitals. Everything in it is read from memory — counting certificates would mean listing the inventory in the storage backend on every beat, which is scrape-weight work and belongs in the exporter.

**Watchdog.** The same timer feeds `WatchdogSec=` when the unit enables one. It runs in the frontend, so a frontend stalled behind the CA's write lock stops feeding it; a launcher-side ping would only ever prove the supervisor was alive. The documentation is explicit about what it does *not* catch (handlers blocked on a read-only backend call leave the heartbeat scheduling normally) and points at `/healthz/ready` for the rest.

**Reload.** `SIGHUP` re-reads the two file-backed inputs that can be swapped safely under live traffic: the TLS keypair (the CA's own server certificate expires like any other, and until now renewing it meant a restart) and the admin allow list (adding or decommissioning a compile server). Connections in flight keep the certificate they negotiated with; the allow list is swapped atomically with respect to in-flight requests, and any CN that gained or lost admin rights is named in the log. Everything else needs a restart, and the docs say so. A failed reload keeps the previous configuration and sticks in the status text until one succeeds — a silently ineffective `systemctl reload` is how an operator ends up believing a certificate was rotated when it was not.

**Shutdown.** `STOPPING=1` marks a deliberate drain, with the drain budget in the status text.

None of it needs configuration: the protocol is driven by `$NOTIFY_SOCKET`, so the same binary behaves normally under a shell, another supervisor, or in a container.

## Relationship to #158

[#158](https://github.com/voxpupuli/openvox-ca/issues/158) wants deb/rpm packages, and the discussion there lists "a systemd unit" as the first item of the packaging payload that does not exist yet, along with two specific concerns. Both are addressed here:

- **`--daemon` must not be used under systemd.** It forks and exits, which under `Type=notify` looks exactly like the service dying at startup. The CA now warns when it sees `$NOTIFY_SOCKET` and `--daemon` together, the unit does not use it, and the docs say why.
- **Hardening has to be checked against the forked signer, not just the parent.** It has been: `RestrictAddressFamilies` keeps `AF_UNIX` for the signer socketpair as well as the notification socket, `$NOTIFY_SOCKET` is withheld from the signer entirely, and `LimitCORE=0` is there specifically because the *signer* holds the decrypted CA key for its whole life — a core dump would write it to `/var/lib/systemd/coredump` and undo encryption at rest.

The unit lands in `packaging/systemd/`, matching the `packaging/` directory that issue anticipates, and `mage build:dist` stages it into the release tarballs. This does not close #158 — no deb or rpm is built here — but it removes the first blocker.

## Notable decisions

- **No new dependency.** `internal/sdnotify` is a small implementation of the protocol rather than a wrapper around `coreos/go-systemd`, whose `SdWatchdogEnabled` enforces a `WATCHDOG_PID` check this topology has to bypass (the pinger is the frontend child, not the main PID), which does not translate `@`-prefixed abstract sockets, and which has no `MONOTONIC_USEC`. What remained after those was a dial and a write. `golang.org/x/sys` moves from indirect to direct for `CLOCK_MONOTONIC`; no new module enters the graph and there is no crypto surface, so the boringcrypto contract is untouched.
- **`Type=notify` with `ExecReload`, not `Type=notify-reload`.** Debian 12 and RHEL 9 ship systemd 252, which cannot parse the newer type. `Type=notify-reload` is documented as the upgrade for 253+, where the `MONOTONIC_USEC` stamp makes `systemctl reload` wait for the new configuration to land.
- **`TimeoutStopSec=35s` is derived, not picked.** It has to exceed the 25s drain budget plus the supervisor's 3s headroom, or systemd truncates the drain it just asked for.
- **The unit-test gate now runs `-race`.** The notification path is driven concurrently by the heartbeat, the reload watcher and a deferred `Close`, and its locking is only verified by a spec that fails exclusively under the detector. Costs roughly 15% on the slowest package. Happy to split this into its own change if you would rather it were a separate CI leg.

## Review

The last four commits are fixes from four rounds of `/review-council`. The substantive one: `SIGHUP` default-terminates a process, and the reload watcher only claimed the signal *after* `READY=1` — so a `systemctl reload` landing in that window killed the frontend, which the launcher read as a crash and used to bring down the unit. The signal is now claimed before any startup work; verified by hitting a cold start with six `SIGHUP`s. The rest were an unsynchronised read on the notifier's connection, an audit log that recorded only a count, the two unit-file items above, and several rounds of my own documentation claiming slightly more than the code delivered.

Two gaps were assessed and left, rather than dropped quietly: `runLauncher` has no test (it spawns real child processes and has no injection seam), and there is no Prometheus metric for reload outcome, which leaves Kubernetes deployments with logs only as a signal that a certificate rotation failed. The second is a reasonable follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
