### PR TITLE
Mint certificates offline, without the API or raw CA key access

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The complete flag, environment-variable, and config-file reference is in
 | --- | --- |
 | [Configuring the server](docs/configuration.md) | Every flag, environment variable, config-file key; autosigning; directory layout; graceful shutdown |
 | [HTTP API reference](docs/api.md) | All endpoints, authorization tiers, and admin credential resolution |
-| [Operator CLI (`openvox-ca-ctl`)](docs/operator-cli.md) | The `openvox-ca-ctl` command reference, and the offline `openvox-ca` subcommands (`csr`, `import-ca-cert`) that run against the server's own configuration |
+| [Operator CLI (`openvox-ca-ctl`)](docs/operator-cli.md) | The `openvox-ca-ctl` command reference, and the offline `openvox-ca` subcommands (`csr`, `import-ca-cert`, `generate`) that run against the server's own configuration |
 | [Storage backends](docs/storage-backends.md) | filesystem, SQLite, PostgreSQL, MySQL, etcd, Redis/Valkey; migrating between them |
 | [CA key security](docs/ca-key-security.md) | Key encryption at rest, key-custody options, PKCS#11 plans, destructive-op monitoring |
 | [OpenBao Transit-engine CA key](docs/openbao-transit.md) | Delegating CA key custody to OpenBao |

--- a/cmd/openvox-ca/generate.go
+++ b/cmd/openvox-ca/generate.go
@@ -1,0 +1,491 @@
+// Copyright (C) 2026 Trevor Vaughan
+// Copyright (C) 2026 Vox Pupuli and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package main
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/voxpupuli/openvox-ca/internal/ca"
+	"github.com/voxpupuli/openvox-ca/internal/storage"
+)
+
+// newGenerateCmd builds the offline `openvox-ca generate` subcommand: mint a
+// certificate directly against storage and the configured key provider, with no
+// running server and no API.
+//
+// It lives on the server binary rather than openvox-ca-ctl for the same reason
+// csr and import-ca-cert do: it must reach the storage backend and key provider
+// named in the *server's* configuration, and openvox-ca-ctl can address only a
+// local filesystem directory through a different configuration schema.
+//
+// Two things the API cannot do are the reason this exists. A pp_cli_auth
+// certificate cannot be obtained through it at all, because the CSR path strips
+// authorisation-arc OIDs; and nothing can be issued before a server is running,
+// which is the bootstrap circle tls_self_provision was added to break. Ordinary
+// node certificates should keep using POST /generate/{subject}, which needs no
+// outage -- see the scope note in docs/operator-cli.md.
+func newGenerateCmd() *cobra.Command {
+	var (
+		configFile string
+		caDir      string
+		certname   string
+		dnsNames   []string
+		ppCliAuth  bool
+		keyOut     string
+		certOut    string
+		ttl        time.Duration
+		force      bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "generate",
+		Short: "Mint a certificate offline, without a running server",
+		Long: `Mint a certificate directly against the configured storage backend and CA key
+provider. No running server, no API, and no admin client certificate.
+
+The certificate is issued through the CA's own signing path, so it takes a
+serial from the CA's generator, is written to the inventory, appears in
+"openvox-ca-ctl list --all", is swept by the expiry job, and can be revoked by
+name -- unlike one signed out of band with openssl.
+
+Autosign policy is deliberately not consulted: this is an operator action rather
+than a request, and it must work when there is no policy and no server to
+evaluate one.
+
+Use the API for ordinary node certificates. This command exists for the two
+cases the API cannot serve: a pp_cli_auth administrator credential, and minting
+before a server exists.`,
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			out := cmd.ErrOrStderr()
+
+			resolvedCfgFile := resolveConfigFile(configFile, "PUPPET_CA_CONFIG", "/etc/puppet-ca/config.yaml")
+			cfg, err := loadServerConfig(resolvedCfgFile)
+			if err != nil {
+				return err
+			}
+			if cmd.Flags().Changed("cadir") {
+				cfg.CADir = caDir
+			}
+
+			reportResolvedConfig(out, resolvedCfgFile, cfg)
+			reportIssuanceSettings(out, cfg)
+
+			// Honour the configured logfile so the authorisation-grant audit
+			// line in internal/ca reaches it. Non-fatal and non-creative, for
+			// reasons setupLogger's other callers do not share: see
+			// applySubcommandLogging.
+			closeLog := applySubcommandLogging(cfg, out)
+			defer closeLog()
+
+			// Checked before resolveRuntime so nothing is opened -- and no
+			// authenticated session to a key provider established -- for a run
+			// that cannot succeed.
+			if ppCliAuth && cfg.NoPpCliAuth {
+				return fmt.Errorf("this CA is configured with no_pp_cli_auth, so a pp_cli_auth " +
+					"certificate would grant nothing. Add the certname to the admin allow list " +
+					"with --puppet-server instead, or unset no_pp_cli_auth")
+			}
+			if ppCliAuth && keyOut == "" {
+				return fmt.Errorf("--key-out is required with --pp-cli-auth: the fallback writes to " +
+					"the cadir's private directory, which is always the local filesystem whatever " +
+					"the storage backend, so on an ephemeral cadir the key is lost at the next " +
+					"restart -- leaving a live administrator certificate in the inventory with no " +
+					"key in existence")
+			}
+			if force && keyOut == "" {
+				return fmt.Errorf("--key-out is required with --force: the fallback writes the key " +
+					"only after issuance, so a failure there would roll the new certificate back " +
+					"having already revoked the old one, and CRL entries cannot be withdrawn")
+			}
+
+			// Resolve output paths before anything is issued. Everything after
+			// the mint is irreversible: the certificate has taken a serial and
+			// is in the inventory, and under --force its predecessor is on the
+			// CRL.
+			keyPath, err := prepareOutputPath(keyOut)
+			if err != nil {
+				return err
+			}
+			certPath, err := prepareOutputPath(certOut)
+			if err != nil {
+				return err
+			}
+
+			rt, err := resolveRuntime(ctx, cfg, true)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = rt.Close() }()
+
+			reportBackendCapabilities(ctx, out, rt.Store)
+
+			myCA := ca.New(rt.Store, ca.AutosignConfig{Mode: "off"}, cfg.Hostname)
+			if err := applyCAConfig(myCA, cfg); err != nil {
+				return err
+			}
+			myCA.KeyProvider = rt.KeyProvider
+			myCA.NoBootstrap = true
+
+			if err := assertCAUsable(ctx, myCA, rt.Store, cfg); err != nil {
+				return err
+			}
+
+			if err := myCA.Init(ctx); err != nil {
+				return fmt.Errorf("loading the CA: %w", err)
+			}
+
+			if ppCliAuth {
+				warnAdminCredential(out, certname, keyPath)
+			}
+
+			opts := ca.GenerateOptions{
+				DNSAltNames:               dnsNames,
+				TTL:                       ttl,
+				RetainPrivateKeyInStorage: keyPath == "",
+				ReplaceExisting:           force,
+			}
+			if ppCliAuth {
+				opts.AuthGrants = []ca.AuthGrant{ca.PpCliAuth()}
+			}
+			if keyPath != "" {
+				// Put the key somewhere durable before the CA commits to
+				// anything. Under --force the alternative is losing it after
+				// the predecessor has been revoked, which cannot be undone.
+				opts.EmitKey = func(keyPEM []byte) error {
+					if err := writePrivateFile(keyPath, keyPEM); err != nil {
+						return fmt.Errorf("writing the private key to %s: %w", keyPath, err)
+					}
+					return nil
+				}
+			}
+
+			result, err := myCA.GenerateWithOptions(ctx, certname, opts)
+			if err != nil {
+				// The key is on disk but nothing was issued. Remove it rather
+				// than leaving a private key with no certificate at a path the
+				// operator will not think to clean up.
+				if keyPath != "" {
+					if rmErr := os.Remove(keyPath); rmErr != nil && !os.IsNotExist(rmErr) {
+						_, _ = fmt.Fprintf(out, "Warning: could not remove the unused private key at %s: %v\n",
+							keyPath, rmErr)
+					}
+				}
+				return annotateGenerateError(err, certname)
+			}
+
+			if certPath != "" {
+				if err := writePublicFile(certPath, result.CertificatePEM); err != nil {
+					return fmt.Errorf("writing the certificate to %s: %w", certPath, err)
+				}
+			} else if _, err := cmd.OutOrStdout().Write(result.CertificatePEM); err != nil {
+				return err
+			}
+
+			reportSuccess(out, rt.Store, result, certname, keyPath, certPath, ppCliAuth, force, cfg)
+			return nil
+		},
+	}
+
+	f := cmd.Flags()
+	f.StringVar(&configFile, "config", "", "Path to YAML config file (default: /etc/puppet-ca/config.yaml if it exists)")
+	f.StringVar(&caDir, "cadir", "", "CA storage directory (overrides the config file)")
+	f.StringVar(&certname, "certname", "", "Subject name for the certificate")
+	f.StringSliceVar(&dnsNames, "dns", nil, "DNS alt names (repeatable, or comma-separated)")
+	f.BoolVar(&ppCliAuth, "pp-cli-auth", false, "Grant CA administrator access via the pp_cli_auth extension")
+	f.StringVar(&keyOut, "key-out", "", "Write the private key here (default: the cadir's private directory)")
+	f.StringVar(&certOut, "cert-out", "", "Write the certificate here instead of stdout")
+	f.DurationVar(&ttl, "ttl", 0, "Certificate lifetime, e.g. 8760h for one year")
+	f.BoolVar(&force, "force", false, "Revoke an existing certificate for this name and replace it")
+	_ = cmd.MarkFlagRequired("certname")
+	_ = cmd.MarkFlagRequired("ttl")
+
+	return cmd
+}
+
+// prepareOutputPath validates an operator-supplied output path before anything
+// is issued, returning it cleaned. Refusing here rather than after the mint
+// matters because issuance cannot be undone: the certificate has consumed a
+// serial and is recorded in the inventory.
+func prepareOutputPath(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolving %s: %w", path, err)
+	}
+	if _, err := os.Stat(abs); err == nil {
+		return "", fmt.Errorf("%s already exists: refusing to overwrite it", abs)
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("checking %s: %w", abs, err)
+	}
+	dir := filepath.Dir(abs)
+	info, err := os.Stat(dir)
+	if err != nil {
+		return "", fmt.Errorf("the directory for %s does not exist: %w", abs, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("%s is not a directory", dir)
+	}
+	return abs, nil
+}
+
+// assertCAUsable refuses to run against storage that holds no usable CA, before
+// Init is called.
+//
+// Init would otherwise bootstrap one when both the certificate and key are
+// absent, so a mistyped --cadir would silently mint a fresh root and issue
+// under it -- leaving the operator with certificates nothing in the fleet
+// trusts. NoBootstrap is set as a backstop, but the check runs first because
+// Init writes before it reaches that decision: EnsureDirs, then InitHMAC, whose
+// EnsureHMACKey regenerates the inventory HMAC key if the stored one is the
+// wrong length. Running that against a live CA's storage is its own hazard.
+func assertCAUsable(ctx context.Context, myCA *ca.CA, store *storage.StorageService, cfg *serverConfig) error {
+	// The frontend role proxies signing to an isolated signer and never holds
+	// the key, so this command cannot work there. Every other role can.
+	if role := os.Getenv("PUPPET_CA_ROLE"); !roleMayReachCAKey(role) {
+		return fmt.Errorf("this process is running as the %q role, which proxies signing to the "+
+			"isolated signer and cannot reach the CA key. Run this on the signer host instead", role)
+	}
+
+	hasCert, err := store.HasCACert(ctx)
+	if err != nil {
+		return fmt.Errorf("checking for an existing CA certificate: %w", err)
+	}
+	hasKey, err := myCA.HasCAKey(ctx)
+	if err != nil {
+		return fmt.Errorf("checking for an existing CA key: %w", err)
+	}
+
+	switch {
+	case !hasCert && !hasKey:
+		return fmt.Errorf("no CA exists in %s: refusing to create one. This command issues from an "+
+			"existing CA -- start the server once to bootstrap, or complete 'openvox-ca csr' and "+
+			"'openvox-ca import-ca-cert' to run under an external root", cfg.CADir)
+	case !hasCert:
+		return fmt.Errorf("a CA key exists but its certificate is missing from %s: install the signed "+
+			"chain with 'openvox-ca import-ca-cert' before issuing", cfg.CADir)
+	case !hasKey:
+		return fmt.Errorf("a CA certificate exists in %s but its key is missing: restore the key, or "+
+			"check that the configured ca_key_provider matches the server's", cfg.CADir)
+	}
+	return nil
+}
+
+// reportIssuanceSettings prints the resolved settings that shape or record what
+// is about to be issued.
+//
+// These are root-command flags as well as config keys, and this command sees
+// only the config file and PUPPET_CA_* environment. A server configured
+// entirely by flags -- the shipped container image, the compose topology -- is
+// invisible here, so a certificate could silently be minted with no CRL
+// distribution point while the server's own issuance carries one. Printing what
+// was resolved is what makes that visible while it is still cheap to fix.
+func reportIssuanceSettings(w io.Writer, cfg *serverConfig) {
+	value := func(s string) string {
+		if s == "" {
+			return "(none)"
+		}
+		return s
+	}
+	_, _ = fmt.Fprintf(w, "Issuance settings: crl_url: %s; ocsp_url: %s; promote_cn_to_san: %t\n",
+		value(cfg.CRLUrl), value(cfg.OCSPUrl), cfg.PromoteCNToSAN)
+}
+
+// reportBackendCapabilities warns when the resolved backend cannot serialise
+// this process against a running server.
+//
+// The per-subject lock is real only on backends that provide distributed
+// locking, and the inventory append is atomic only on structured ones. Where
+// either is missing, a concurrent server can issue a second certificate for the
+// same subject, or -- worse -- interleave an inventory append so the integrity
+// HMAC covers a blob that never existed, which makes the server refuse to start
+// with no supported repair (see #188).
+func reportBackendCapabilities(ctx context.Context, w io.Writer, store *storage.StorageService) {
+	locking, lockErr := store.SupportsDistributedLocking(ctx)
+	atomicInventory := store.SupportsAtomicInventory()
+
+	switch {
+	case lockErr != nil:
+		_, _ = fmt.Fprintf(w, "Warning: could not determine whether this backend coordinates locks "+
+			"across processes: %v\n", lockErr)
+	case locking && atomicInventory:
+		_, _ = fmt.Fprintf(w, "Backend coordinates across processes: safe to run alongside a live server.\n")
+		return
+	}
+
+	_, _ = fmt.Fprintf(w, "Warning: this backend does not fully coordinate writes across processes "+
+		"(cross-process locking: %t; atomic inventory append: %t).\n"+
+		"  Stop the server before running this. A concurrent write can issue a duplicate\n"+
+		"  certificate, or corrupt the inventory integrity record so the server will not restart.\n",
+		locking, atomicInventory)
+}
+
+// warnAdminCredential states what a pp_cli_auth certificate grants, and what it
+// takes to withdraw it.
+//
+// The withdrawal half is the part an operator cannot infer. Unlike an allow-list
+// entry, which is a file edit and a restart, this grant is baked into a
+// certificate, and revoking it does not take effect on a running server until
+// that server reloads its CRL.
+func warnAdminCredential(w io.Writer, certname, keyPath string) {
+	_, _ = fmt.Fprintf(w, `
+WARNING: --pp-cli-auth mints a full CA administrator credential.
+
+  Whoever holds the private key
+    %s
+  will be able to sign any pending request, sign all of them, generate a
+  certificate for any name, revoke and clean any certificate, import
+  certificates, and replace the CRL -- on this CA, without being listed in the
+  admin allow list.
+
+  Withdrawing it is not one step:
+    1. openvox-ca-ctl revoke --certname %s
+    2. restart every replica. Waiting for the CRL to refresh on its own can take
+       roughly two-thirds of crl_validity, and even then a pre-signed OCSP
+       response can vouch for the revoked serial for up to another 4 hours.
+    3. check the inventory for other live serials for this name. If renewal
+       replaced it and revoke_on_auto_renew is off -- or a renewal's best-effort
+       revoke failed -- there may be more than one, and current tooling cannot
+       revoke a superseded serial (see issue #177).
+
+`, keyPath, certname)
+}
+
+// annotateGenerateError turns a library error into something an operator can
+// act on, without swallowing the sentinel callers discriminate against.
+func annotateGenerateError(err error, certname string) error {
+	if errors.Is(err, ca.ErrCertExists) {
+		return fmt.Errorf("%w.\nPass --force to revoke it and issue a replacement, remove it with "+
+			"'openvox-ca-ctl clean --certname %s', or choose another --certname", err, certname)
+	}
+	return err
+}
+
+// reportSuccess prints what was issued, and the consequences the operator now
+// owns.
+func reportSuccess(w io.Writer, store *storage.StorageService, result *ca.GenerateResult,
+	certname, keyPath, certPath string, ppCliAuth, force bool, cfg *serverConfig,
+) {
+	if serial, notAfter, err := describeIssued(result); err == nil {
+		_, _ = fmt.Fprintf(w, "Issued %s: serial %s, expires %s\n",
+			certname, serial, notAfter.Format(time.RFC3339))
+	} else {
+		_, _ = fmt.Fprintf(w, "Issued %s\n", certname)
+	}
+
+	if keyPath != "" {
+		_, _ = fmt.Fprintf(w, "Private key: %s\n", keyPath)
+	} else {
+		_, _ = fmt.Fprintf(w, "Private key: %s\n", store.PrivateKeyPath(certname))
+		_, _ = fmt.Fprintf(w, "  Nothing sweeps keys from that directory, so it persists there until\n"+
+			"  removed -- and it is on the local filesystem whatever the storage backend, so on an\n"+
+			"  ephemeral cadir it is lost at the next restart instead.\n")
+	}
+	if certPath != "" {
+		_, _ = fmt.Fprintf(w, "Certificate: %s\n", certPath)
+	}
+
+	if force {
+		_, _ = fmt.Fprintf(w, "The previous certificate for %s was revoked. A running server honours it "+
+			"until it reloads the CRL.\n", certname)
+		if cfg.Hostname != "" && certname == cfg.Hostname {
+			_, _ = fmt.Fprintf(w, "  That name is this CA's own hostname: if it is serving with that "+
+				"certificate, restart it with the new pair now.\n")
+		}
+	}
+	if ppCliAuth {
+		_, _ = fmt.Fprintf(w, "This certificate is a CA administrator credential. Treat the private key "+
+			"accordingly.\n")
+	}
+}
+
+// describeIssued pulls the serial and expiry out of the issued certificate for
+// the success message.
+func describeIssued(result *ca.GenerateResult) (string, time.Time, error) {
+	block, _ := pem.Decode(result.CertificatePEM)
+	if block == nil {
+		return "", time.Time{}, fmt.Errorf("issued certificate is not PEM")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	return fmt.Sprintf("%X", cert.SerialNumber), cert.NotAfter, nil
+}
+
+// applySubcommandLogging points slog at the configured logfile so the
+// authorisation-grant audit line emitted by internal/ca reaches it, and returns
+// a closer.
+//
+// Two departures from how the root command uses setupLogger, both deliberate.
+//
+// It never creates the file. setupLogger opens with O_CREATE, and the primary
+// use of this command is before the server has ever started -- so running it as
+// root would mint the logfile owned by root, and the server, which runs as an
+// unprivileged user, would then fail to open it and exit at startup. Creating
+// a file that stops the service starting is a poor trade for an audit line.
+//
+// It degrades rather than failing. The root command treats a logging failure as
+// fatal; runSignerMode falls back to stderr. An interactive mint should follow
+// the signer: refusing to issue because a log file is unwritable helps nobody.
+func applySubcommandLogging(cfg *serverConfig, w io.Writer) func() {
+	effective := *cfg
+
+	if effective.LogFile != "" {
+		if _, err := os.Stat(effective.LogFile); err != nil {
+			_, _ = fmt.Fprintf(w, "Audit log: %s is not present and will not be created by this "+
+				"command; logging to stderr instead.\n", effective.LogFile)
+			effective.LogFile = ""
+		}
+	}
+
+	f, err := setupLogger(&effective)
+	if err != nil {
+		_, _ = fmt.Fprintf(w, "Audit log: could not open %s (%v); logging to stderr instead.\n",
+			effective.LogFile, err)
+		stderrOnly := effective
+		stderrOnly.LogFile = ""
+		if _, fallbackErr := setupLogger(&stderrOnly); fallbackErr != nil {
+			_, _ = fmt.Fprintf(w, "Warning: could not configure logging: %v\n", fallbackErr)
+		}
+		return func() {}
+	}
+
+	switch {
+	case f != nil:
+		_, _ = fmt.Fprintf(w, "Audit log: %s\n", effective.LogFile)
+		return func() { _ = f.Close() }
+	case cfg.LogFile == "":
+		_, _ = fmt.Fprintf(w, "No logfile configured: the audit record for this mint is terminal-only.\n")
+	}
+	return func() {}
+}

--- a/cmd/openvox-ca/generate.go
+++ b/cmd/openvox-ca/generate.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2026 Trevor Vaughan
+// Copyright (C) 2026 Chris Boot
 // Copyright (C) 2026 Vox Pupuli and contributors
 //
 // This program is free software; you can redistribute it and/or modify

--- a/cmd/openvox-ca/generate.go
+++ b/cmd/openvox-ca/generate.go
@@ -105,6 +105,17 @@ before a server exists.`,
 			closeLog := applySubcommandLogging(cfg, out)
 			defer closeLog()
 
+			// The frontend role proxies signing to an isolated signer and never
+			// holds the key, so this command cannot work there. Checked before
+			// resolveRuntime for the reason that function's own godoc gives:
+			// building a key provider opens an authenticated session to the key
+			// backend, and the frontend is precisely the role barred from doing
+			// that. Refusing after the session was opened would defeat the point.
+			if role := os.Getenv("PUPPET_CA_ROLE"); !roleMayReachCAKey(role) {
+				return fmt.Errorf("this process is running as the %q role, which proxies signing to the "+
+					"isolated signer and cannot reach the CA key. Run this on the signer host instead", role)
+			}
+
 			// Checked before resolveRuntime so nothing is opened -- and no
 			// authenticated session to a key provider established -- for a run
 			// that cannot succeed.
@@ -269,13 +280,6 @@ func prepareOutputPath(path string) (string, error) {
 // EnsureHMACKey regenerates the inventory HMAC key if the stored one is the
 // wrong length. Running that against a live CA's storage is its own hazard.
 func assertCAUsable(ctx context.Context, myCA *ca.CA, store *storage.StorageService, cfg *serverConfig) error {
-	// The frontend role proxies signing to an isolated signer and never holds
-	// the key, so this command cannot work there. Every other role can.
-	if role := os.Getenv("PUPPET_CA_ROLE"); !roleMayReachCAKey(role) {
-		return fmt.Errorf("this process is running as the %q role, which proxies signing to the "+
-			"isolated signer and cannot reach the CA key. Run this on the signer host instead", role)
-	}
-
 	hasCert, err := store.HasCACert(ctx)
 	if err != nil {
 		return fmt.Errorf("checking for an existing CA certificate: %w", err)

--- a/cmd/openvox-ca/generate_test.go
+++ b/cmd/openvox-ca/generate_test.go
@@ -27,8 +27,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"sort"
-	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -56,21 +54,27 @@ func hashTree(dir string) map[string]string {
 		if err != nil {
 			return err
 		}
+		rel, relErr := filepath.Rel(dir, path)
+		if relErr != nil {
+			return relErr
+		}
 		if d.IsDir() {
+			// Recorded too: Init calls EnsureDirs before it reaches the
+			// bootstrap decision, so a guard that moved below it would create
+			// directories and a file-only fingerprint would not notice.
+			out[rel+"/"] = ""
 			return nil
 		}
 		data, readErr := os.ReadFile(path)
 		if readErr != nil {
 			return readErr
 		}
-		rel, relErr := filepath.Rel(dir, path)
-		if relErr != nil {
-			return relErr
-		}
 		sum := sha256.Sum256(data)
 		out[rel] = string(sum[:])
 		return nil
 	})
+	// An absent directory is a legitimate "nothing here" fingerprint; any other
+	// walk error must fail the spec rather than silently yield a partial map.
 	if err != nil && !os.IsNotExist(err) {
 		Expect(err).NotTo(HaveOccurred())
 	}
@@ -140,6 +144,23 @@ var _ = Describe("openvox-ca generate", func() {
 			_, _, err := runGenerate("--cadir", caDir, "--certname", "web01",
 				"--ttl", "1h", "--key-out", keyPath("web01"))
 			Expect(err).To(MatchError(ContainSubstring("its key is missing")))
+			Expect(hashTree(caDir)).To(Equal(before))
+		})
+
+		It("will not issue when the CA key is present but its certificate is gone", func() {
+			// The state openvox-ca csr --create-key leaves behind while an
+			// external root's signature is outstanding. The remedy is
+			// import-ca-cert, and telling the operator to "start the server once
+			// to bootstrap" instead would be the one action that must not be
+			// taken here.
+			bootstrapCAInDir(caDir, "puppet.example.com")
+			Expect(os.Remove(filepath.Join(caDir, "ca_crt.pem"))).To(Succeed())
+			before := hashTree(caDir)
+
+			_, _, err := runGenerate("--cadir", caDir, "--certname", "web01",
+				"--ttl", "1h", "--key-out", keyPath("web01"))
+			Expect(err).To(MatchError(ContainSubstring("its certificate is missing")))
+			Expect(err).To(MatchError(ContainSubstring("import-ca-cert")))
 			Expect(hashTree(caDir)).To(Equal(before))
 		})
 
@@ -381,6 +402,12 @@ var _ = Describe("openvox-ca generate", func() {
 				"the sentinel is what callers discriminate on; a substring is not")
 			Expect(err.Error()).To(ContainSubstring("--force"))
 			Expect(err.Error()).To(ContainSubstring("openvox-ca-ctl clean"))
+
+			// EmitKey writes the key before the CA commits to anything, so a
+			// failed mint leaves one on disk. It must be cleaned up: a private
+			// key with no certificate, at a path the operator will not think to
+			// revisit, is a leaked credential.
+			Expect(keyPath("web01-again")).NotTo(BeAnExistingFile())
 		})
 
 		It("replaces with --force and reports the revocation", func() {
@@ -468,24 +495,5 @@ var _ = Describe("openvox-ca generate", func() {
 			Expect(stderr).To(ContainSubstring("will not be created"))
 			Expect(logPath).NotTo(BeAnExistingFile())
 		})
-	})
-})
-
-// sortedKeys is a small helper for readable failure output when comparing
-// directory fingerprints.
-func sortedKeys(m map[string]string) []string {
-	out := make([]string, 0, len(m))
-	for k := range m {
-		out = append(out, k)
-	}
-	sort.Strings(out)
-	return out
-}
-
-var _ = Describe("generate helpers", func() {
-	It("fingerprints a directory tree", func() {
-		dir := GinkgoT().TempDir()
-		Expect(os.WriteFile(filepath.Join(dir, "a"), []byte("one"), 0o600)).To(Succeed())
-		Expect(strings.Join(sortedKeys(hashTree(dir)), ",")).To(Equal("a"))
 	})
 })

--- a/cmd/openvox-ca/generate_test.go
+++ b/cmd/openvox-ca/generate_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2026 Trevor Vaughan
+// Copyright (C) 2026 Chris Boot
 // Copyright (C) 2026 Vox Pupuli and contributors
 //
 // This program is free software; you can redistribute it and/or modify

--- a/cmd/openvox-ca/generate_test.go
+++ b/cmd/openvox-ca/generate_test.go
@@ -1,0 +1,491 @@
+// Copyright (C) 2026 Trevor Vaughan
+// Copyright (C) 2026 Vox Pupuli and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/pem"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/voxpupuli/openvox-ca/internal/ca"
+	"github.com/voxpupuli/openvox-ca/internal/storage"
+)
+
+func runGenerate(args ...string) (stdout, stderr string, err error) {
+	root := newRootCmd()
+	var out, errOut bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errOut)
+	root.SetArgs(append([]string{"generate"}, args...))
+	err = root.Execute()
+	return out.String(), errOut.String(), err
+}
+
+// hashTree fingerprints every file under dir, so a spec can assert that a
+// refusal changed nothing at all rather than only that one file survived.
+func hashTree(dir string) map[string]string {
+	GinkgoHelper()
+	out := map[string]string{}
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		rel, relErr := filepath.Rel(dir, path)
+		if relErr != nil {
+			return relErr
+		}
+		sum := sha256.Sum256(data)
+		out[rel] = string(sum[:])
+		return nil
+	})
+	if err != nil && !os.IsNotExist(err) {
+		Expect(err).NotTo(HaveOccurred())
+	}
+	return out
+}
+
+func certFromPEM(pemBytes string) *x509.Certificate {
+	GinkgoHelper()
+	block, _ := pem.Decode([]byte(pemBytes))
+	Expect(block).NotTo(BeNil())
+	cert, err := x509.ParseCertificate(block.Bytes)
+	Expect(err).NotTo(HaveOccurred())
+	return cert
+}
+
+var _ = Describe("openvox-ca generate", func() {
+	var (
+		caDir  string
+		outDir string
+	)
+
+	BeforeEach(func() {
+		caDir = GinkgoT().TempDir()
+		outDir = GinkgoT().TempDir()
+
+		// ECDSA P-256 rather than the RSA defaults: these specs mint a CA and a
+		// leaf on nearly every It, and RSA at the default sizes dominates the
+		// suite's runtime for no assertion value.
+		pinnedCfg := "ca_key_algo: ecdsa\nca_key_size: 256\nleaf_key_algo: ecdsa\nleaf_key_size: 256\n"
+		cfgPath := filepath.Join(GinkgoT().TempDir(), "pinned.yaml")
+		Expect(os.WriteFile(cfgPath, []byte(pinnedCfg), 0o644)).To(Succeed())
+		setEnv("PUPPET_CA_CONFIG", cfgPath)
+		clearServerEnv()
+
+		// The command calls setupLogger, which rebinds the process-wide default
+		// logger. Restore it so it cannot leak into sibling specs.
+		orig := slog.Default()
+		DeferCleanup(func() { slog.SetDefault(orig) })
+	})
+
+	keyPath := func(name string) string { return filepath.Join(outDir, name+".key") }
+
+	Describe("refusing to act on storage that holds no usable CA", func() {
+		It("will not bootstrap a CA when none exists", func() {
+			before := hashTree(caDir)
+
+			_, _, err := runGenerate("--cadir", caDir, "--certname", "web01",
+				"--ttl", "1h", "--key-out", keyPath("web01"))
+			Expect(err).To(MatchError(ContainSubstring("refusing to create one")))
+
+			// Init writes -- EnsureDirs, InitHMAC, CRL seeding -- before it
+			// reaches the bootstrap decision, so asserting only that ca_crt.pem
+			// is absent would pass with the guard in the wrong place.
+			Expect(hashTree(caDir)).To(Equal(before), "a refusal must leave the cadir untouched")
+		})
+
+		It("will not issue when the CA certificate is present but the key is gone", func() {
+			// Init refuses this case too, so this passes with the command's own
+			// guard removed -- it is defence in depth against a regression in
+			// either layer, not a pin on this command alone. What it does pin
+			// here is that the refusal happens before Init's side effects, so
+			// the cadir is left byte-identical rather than merely un-bootstrapped.
+			bootstrapCAInDir(caDir, "puppet.example.com")
+			Expect(os.Remove(filepath.Join(caDir, "private", "ca_key.pem"))).To(Succeed())
+			before := hashTree(caDir)
+
+			_, _, err := runGenerate("--cadir", caDir, "--certname", "web01",
+				"--ttl", "1h", "--key-out", keyPath("web01"))
+			Expect(err).To(MatchError(ContainSubstring("its key is missing")))
+			Expect(hashTree(caDir)).To(Equal(before))
+		})
+
+		It("refuses on the frontend role, which cannot reach the CA key", func() {
+			// The role is an environment variable the launcher sets into its
+			// children, not a config key. roleMayReachCAKey is role !=
+			// "frontend", so the predicate is easy to invert -- hence both
+			// directions below.
+			bootstrapCAInDir(caDir, "puppet.example.com")
+			setEnv("PUPPET_CA_ROLE", "frontend")
+
+			_, _, err := runGenerate("--cadir", caDir, "--certname", "web01",
+				"--ttl", "1h", "--key-out", keyPath("web01"))
+			Expect(err).To(MatchError(ContainSubstring("frontend")))
+		})
+
+		It("proceeds on the signer role, which does hold the key", func() {
+			bootstrapCAInDir(caDir, "puppet.example.com")
+			setEnv("PUPPET_CA_ROLE", "signer")
+
+			_, _, err := runGenerate("--cadir", caDir, "--certname", "web01",
+				"--ttl", "1h", "--key-out", keyPath("web01"))
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("minting against an existing CA", func() {
+		BeforeEach(func() { bootstrapCAInDir(caDir, "puppet.example.com") })
+
+		It("requires a ttl rather than defaulting to five years", func() {
+			_, _, err := runGenerate("--cadir", caDir, "--certname", "web01",
+				"--key-out", keyPath("web01"))
+			Expect(err).To(MatchError(ContainSubstring(`"ttl" not set`)))
+		})
+
+		It("emits a certificate signed by the CA on stdout", func() {
+			stdout, _, err := runGenerate("--cadir", caDir, "--certname", "web01.example.com",
+				"--ttl", "8760h", "--key-out", keyPath("web01"))
+			Expect(err).NotTo(HaveOccurred())
+
+			cert := certFromPEM(stdout)
+			Expect(cert.Subject.CommonName).To(Equal("web01.example.com"))
+			Expect(cert.DNSNames).To(ConsistOf("web01.example.com"), "the CN is promoted to a SAN")
+
+			caPEM, err := os.ReadFile(filepath.Join(caDir, "ca_crt.pem"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cert.CheckSignatureFrom(certFromPEM(string(caPEM)))).To(Succeed())
+		})
+
+		It("writes the private key at 0600 and leaves none in the cadir", func() {
+			stdout, _, err := runGenerate("--cadir", caDir, "--certname", "web01",
+				"--ttl", "8760h", "--key-out", keyPath("web01"))
+			Expect(err).NotTo(HaveOccurred())
+
+			info, err := os.Stat(keyPath("web01"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o600)))
+
+			// The key must match the certificate, or the operator has a
+			// credential they cannot use.
+			keyPEM, err := os.ReadFile(keyPath("web01"))
+			Expect(err).NotTo(HaveOccurred())
+			block, _ := pem.Decode(keyPEM)
+			Expect(block).NotTo(BeNil())
+			key, err := x509.ParseECPrivateKey(block.Bytes)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(key.PublicKey.Equal(certFromPEM(stdout).PublicKey)).To(BeTrue())
+
+			_, statErr := os.Stat(storage.New(caDir).PrivateKeyPath("web01"))
+			Expect(os.IsNotExist(statErr)).To(BeTrue(),
+				"nothing should be left in the cadir when --key-out was given")
+		})
+
+		It("falls back to the cadir and says what that costs", func() {
+			_, stderr, err := runGenerate("--cadir", caDir, "--certname", "web01", "--ttl", "8760h")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(storage.New(caDir).PrivateKeyPath("web01")).To(BeAnExistingFile())
+			Expect(stderr).To(ContainSubstring("persists there until"))
+			Expect(stderr).To(ContainSubstring("ephemeral cadir"))
+		})
+
+		It("applies dns alt names and an explicit ttl", func() {
+			stdout, _, err := runGenerate("--cadir", caDir, "--certname", "web01",
+				"--ttl", "1h", "--dns", "a.example.com,b.example.com",
+				"--key-out", keyPath("web01"))
+			Expect(err).NotTo(HaveOccurred())
+
+			cert := certFromPEM(stdout)
+			Expect(cert.DNSNames).To(ConsistOf("a.example.com", "b.example.com"))
+			Expect(cert.NotAfter.Sub(cert.NotBefore)).To(BeNumerically("<", 26*60*60*1e9),
+				"a 1h ttl plus the 24h backdate, not the multi-year default")
+		})
+
+		It("writes the certificate to --cert-out at 0644, leaving stdout empty", func() {
+			certOut := filepath.Join(outDir, "web01.crt")
+			stdout, _, err := runGenerate("--cadir", caDir, "--certname", "web01",
+				"--ttl", "8760h", "--key-out", keyPath("web01"), "--cert-out", certOut)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stdout).To(BeEmpty())
+
+			info, err := os.Stat(certOut)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o644)))
+		})
+
+		It("reports the configuration and backend capabilities before acting", func() {
+			_, stderr, err := runGenerate("--cadir", caDir, "--certname", "web01",
+				"--ttl", "8760h", "--key-out", keyPath("web01"))
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(stderr).To(ContainSubstring("Storage backend: filesystem"))
+			Expect(stderr).To(ContainSubstring("Issuance settings:"))
+			// The filesystem backend provides neither capability, so the
+			// stop-the-server warning is the correct output here.
+			Expect(stderr).To(ContainSubstring("Stop the server before running this"))
+		})
+
+		It("bypasses autosign policy, which is not consulted at all", func() {
+			// Deliberate: this is an operator action, not a request, and must
+			// work when there is no policy and no server to evaluate one.
+			denyAll := filepath.Join(GinkgoT().TempDir(), "autosign.conf")
+			Expect(os.WriteFile(denyAll, []byte("# matches nothing\n"), 0o644)).To(Succeed())
+			setEnv("PUPPET_CA_AUTOSIGN_CONFIG", denyAll)
+
+			_, _, err := runGenerate("--cadir", caDir, "--certname", "web01",
+				"--ttl", "8760h", "--key-out", keyPath("web01"))
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("output pre-flight", func() {
+		BeforeEach(func() { bootstrapCAInDir(caDir, "puppet.example.com") })
+
+		It("refuses to overwrite an existing key, issuing nothing", func() {
+			existing := keyPath("web01")
+			Expect(os.WriteFile(existing, []byte("original"), 0o600)).To(Succeed())
+
+			_, _, err := runGenerate("--cadir", caDir, "--certname", "web01",
+				"--ttl", "8760h", "--key-out", existing)
+			Expect(err).To(MatchError(ContainSubstring("refusing to overwrite")))
+
+			data, readErr := os.ReadFile(existing)
+			Expect(readErr).NotTo(HaveOccurred())
+			Expect(string(data)).To(Equal("original"))
+
+			// The point of checking before issuing: the certificate would
+			// otherwise have consumed a serial and be in the inventory.
+			Expect(storage.New(caDir).HasCert(context.Background(), "web01")).To(BeFalse())
+		})
+
+		It("refuses when the key's directory does not exist", func() {
+			_, _, err := runGenerate("--cadir", caDir, "--certname", "web01",
+				"--ttl", "8760h", "--key-out", filepath.Join(outDir, "nope", "web01.key"))
+			Expect(err).To(MatchError(ContainSubstring("does not exist")))
+		})
+
+		It("refuses to overwrite an existing certificate file", func() {
+			certOut := filepath.Join(outDir, "web01.crt")
+			Expect(os.WriteFile(certOut, []byte("original"), 0o644)).To(Succeed())
+
+			_, _, err := runGenerate("--cadir", caDir, "--certname", "web01",
+				"--ttl", "8760h", "--key-out", keyPath("web01"), "--cert-out", certOut)
+			Expect(err).To(MatchError(ContainSubstring("refusing to overwrite")))
+		})
+	})
+
+	Describe("administrator credentials", func() {
+		BeforeEach(func() { bootstrapCAInDir(caDir, "puppet.example.com") })
+
+		It("stamps pp_cli_auth only when asked", func() {
+			stdout, _, err := runGenerate("--cadir", caDir, "--certname", "node",
+				"--ttl", "8760h", "--key-out", keyPath("node"))
+			Expect(err).NotTo(HaveOccurred())
+			for _, ext := range certFromPEM(stdout).Extensions {
+				Expect(ca.IsAuthOID(ext.Id)).To(BeFalse())
+			}
+
+			stdout, _, err = runGenerate("--cadir", caDir, "--certname", "admin",
+				"--ttl", "8760h", "--pp-cli-auth", "--key-out", keyPath("admin"))
+			Expect(err).NotTo(HaveOccurred())
+
+			var found bool
+			for _, ext := range certFromPEM(stdout).Extensions {
+				if ext.Id.Equal(ca.OIDPpCliAuth) {
+					found = true
+					Expect(ext.Value).To(Equal([]byte{0x0c, 0x04, 't', 'r', 'u', 'e'}))
+				}
+			}
+			Expect(found).To(BeTrue())
+		})
+
+		It("requires --key-out, so the key cannot land somewhere ephemeral", func() {
+			_, _, err := runGenerate("--cadir", caDir, "--certname", "admin",
+				"--ttl", "8760h", "--pp-cli-auth")
+			Expect(err).To(MatchError(ContainSubstring("--key-out is required with --pp-cli-auth")))
+
+			Expect(storage.New(caDir).HasCert(context.Background(), "admin")).To(BeFalse())
+		})
+
+		It("states what the credential grants and how to withdraw it", func() {
+			_, stderr, err := runGenerate("--cadir", caDir, "--certname", "admin",
+				"--ttl", "8760h", "--pp-cli-auth", "--key-out", keyPath("admin"))
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(stderr).To(ContainSubstring("administrator credential"))
+			// The withdrawal procedure is the part an operator cannot infer,
+			// and all three steps matter: revoking alone does not take effect
+			// on a running server, and a superseded serial may not be
+			// revocable at all.
+			Expect(stderr).To(ContainSubstring("openvox-ca-ctl revoke --certname admin"))
+			Expect(stderr).To(ContainSubstring("restart every replica"))
+			Expect(stderr).To(ContainSubstring("other live serials"))
+		})
+
+		It("refuses when the CA is configured to ignore pp_cli_auth", func() {
+			cfgPath := filepath.Join(GinkgoT().TempDir(), "nopp.yaml")
+			Expect(os.WriteFile(cfgPath, []byte(
+				"ca_key_algo: ecdsa\nca_key_size: 256\nno_pp_cli_auth: true\n"), 0o644)).To(Succeed())
+			setEnv("PUPPET_CA_CONFIG", cfgPath)
+
+			_, _, err := runGenerate("--cadir", caDir, "--certname", "admin",
+				"--ttl", "8760h", "--pp-cli-auth", "--key-out", keyPath("admin"))
+			Expect(err).To(MatchError(ContainSubstring("no_pp_cli_auth")))
+		})
+	})
+
+	Describe("replacing an existing certificate", func() {
+		BeforeEach(func() { bootstrapCAInDir(caDir, "puppet.example.com") })
+
+		It("names both remedies when a certificate already exists", func() {
+			_, _, err := runGenerate("--cadir", caDir, "--certname", "web01",
+				"--ttl", "8760h", "--key-out", keyPath("web01"))
+			Expect(err).NotTo(HaveOccurred())
+
+			_, _, err = runGenerate("--cadir", caDir, "--certname", "web01",
+				"--ttl", "8760h", "--key-out", keyPath("web01-again"))
+			Expect(err).To(MatchError(ca.ErrCertExists),
+				"the sentinel is what callers discriminate on; a substring is not")
+			Expect(err.Error()).To(ContainSubstring("--force"))
+			Expect(err.Error()).To(ContainSubstring("openvox-ca-ctl clean"))
+		})
+
+		It("replaces with --force and reports the revocation", func() {
+			first, _, err := runGenerate("--cadir", caDir, "--certname", "web01",
+				"--ttl", "8760h", "--key-out", keyPath("web01"))
+			Expect(err).NotTo(HaveOccurred())
+			oldSerial := certFromPEM(first).SerialNumber
+
+			second, stderr, err := runGenerate("--cadir", caDir, "--certname", "web01",
+				"--ttl", "8760h", "--force", "--key-out", keyPath("web01-new"))
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(certFromPEM(second).SerialNumber.Cmp(oldSerial)).NotTo(Equal(0))
+			Expect(stderr).To(ContainSubstring("was revoked"))
+			Expect(stderr).To(ContainSubstring("until it reloads the CRL"))
+		})
+
+		It("requires --key-out, because a failed key write after the revoke is unrecoverable", func() {
+			_, _, err := runGenerate("--cadir", caDir, "--certname", "web01",
+				"--ttl", "8760h", "--force")
+			Expect(err).To(MatchError(ContainSubstring("--key-out is required with --force")))
+		})
+
+		It("issues again once an existing certificate has been revoked", func() {
+			revokeInDir(caDir, "web01")
+
+			_, _, err := runGenerate("--cadir", caDir, "--certname", "web01",
+				"--ttl", "8760h", "--key-out", keyPath("web01"))
+			Expect(err).NotTo(HaveOccurred(), "a revoked certificate must be evictable without --force")
+		})
+
+		It("warns when replacing the CA's own serving name", func() {
+			cfgPath := filepath.Join(GinkgoT().TempDir(), "host.yaml")
+			Expect(os.WriteFile(cfgPath, []byte(
+				"ca_key_algo: ecdsa\nca_key_size: 256\nhostname: puppet.example.com\n"), 0o644)).To(Succeed())
+			setEnv("PUPPET_CA_CONFIG", cfgPath)
+
+			_, _, err := runGenerate("--cadir", caDir, "--certname", "puppet.example.com",
+				"--ttl", "8760h", "--key-out", keyPath("serving"))
+			Expect(err).NotTo(HaveOccurred())
+
+			_, stderr, err := runGenerate("--cadir", caDir, "--certname", "puppet.example.com",
+				"--ttl", "8760h", "--force", "--key-out", keyPath("serving-new"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stderr).To(ContainSubstring("this CA's own hostname"))
+		})
+	})
+
+	Describe("audit logging", func() {
+		BeforeEach(func() { bootstrapCAInDir(caDir, "puppet.example.com") })
+
+		It("writes the grant to a configured logfile", func() {
+			logPath := filepath.Join(outDir, "ca.log")
+			Expect(os.WriteFile(logPath, nil, 0o600)).To(Succeed())
+
+			cfgPath := filepath.Join(GinkgoT().TempDir(), "log.yaml")
+			Expect(os.WriteFile(cfgPath, []byte(
+				"ca_key_algo: ecdsa\nca_key_size: 256\nlogfile: "+logPath+"\n"), 0o644)).To(Succeed())
+			setEnv("PUPPET_CA_CONFIG", cfgPath)
+
+			_, _, err := runGenerate("--cadir", caDir, "--certname", "admin",
+				"--ttl", "8760h", "--pp-cli-auth", "--key-out", keyPath("admin"))
+			Expect(err).NotTo(HaveOccurred())
+
+			logged, err := os.ReadFile(logPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(logged)).To(ContainSubstring("pp_cli_auth=true"))
+			Expect(string(logged)).To(ContainSubstring("admin"))
+		})
+
+		It("does not create a missing logfile, and mints anyway", func() {
+			// Creating it would be actively harmful: run as root before the
+			// server has ever started, the file would end up owned by root and
+			// the server -- running unprivileged -- would fail to open it and
+			// exit at startup.
+			logPath := filepath.Join(outDir, "absent.log")
+			cfgPath := filepath.Join(GinkgoT().TempDir(), "log.yaml")
+			Expect(os.WriteFile(cfgPath, []byte(
+				"ca_key_algo: ecdsa\nca_key_size: 256\nlogfile: "+logPath+"\n"), 0o644)).To(Succeed())
+			setEnv("PUPPET_CA_CONFIG", cfgPath)
+
+			_, stderr, err := runGenerate("--cadir", caDir, "--certname", "web01",
+				"--ttl", "8760h", "--key-out", keyPath("web01"))
+			Expect(err).NotTo(HaveOccurred(), "a logging problem must not stop an operator issuing")
+			Expect(stderr).To(ContainSubstring("will not be created"))
+			Expect(logPath).NotTo(BeAnExistingFile())
+		})
+	})
+})
+
+// sortedKeys is a small helper for readable failure output when comparing
+// directory fingerprints.
+func sortedKeys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+var _ = Describe("generate helpers", func() {
+	It("fingerprints a directory tree", func() {
+		dir := GinkgoT().TempDir()
+		Expect(os.WriteFile(filepath.Join(dir, "a"), []byte("one"), 0o600)).To(Succeed())
+		Expect(strings.Join(sortedKeys(hashTree(dir)), ",")).To(Equal("a"))
+	})
+})

--- a/cmd/openvox-ca/main.go
+++ b/cmd/openvox-ca/main.go
@@ -781,6 +781,7 @@ func newRootCmd() *cobra.Command {
 	// the server" and cobra.NoArgs above still rejects stray arguments.
 	cmd.AddCommand(newCSRCmd())
 	cmd.AddCommand(newImportCACertCmd())
+	cmd.AddCommand(newGenerateCmd())
 
 	return cmd
 }

--- a/cmd/openvox-ca/writefile.go
+++ b/cmd/openvox-ca/writefile.go
@@ -41,6 +41,28 @@ import (
 // way, and docs/storage-backends.md advertises that property; a file destined for
 // the same place should not be weaker.
 func writePublicFile(path string, data []byte) error {
+	return writeFileAtomic(path, data, storage.FilePermPublic)
+}
+
+// writePrivateFile writes private key material to an operator-supplied path.
+//
+// Mode 0600, and the difference from writePublicFile is not only the number.
+// os.CreateTemp already creates at 0600, so unlike the public path there is no
+// window in which the file exists world-readable before the Chmod — the key is
+// never observable by another user, even briefly. The Chmod is kept anyway so
+// the mode is asserted rather than inherited from a stdlib detail.
+//
+// The deferred cleanup of the temporary file also matters more here: a leftover
+// public certificate is litter, a leftover private key is a leaked credential
+// sitting beside the path the operator chose.
+func writePrivateFile(path string, data []byte) error {
+	return writeFileAtomic(path, data, storage.FilePermPrivate)
+}
+
+// writeFileAtomic is the shared implementation. Factored out so the durability
+// reasoning above lives in one place: two copies would drift, and the half that
+// drifted would be the one nobody was looking at.
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
 	dir := filepath.Dir(path)
 	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp*")
 	if err != nil {
@@ -68,7 +90,7 @@ func writePublicFile(path string, data []byte) error {
 	if err := tmp.Close(); err != nil {
 		return fmt.Errorf("writing %s: %w", path, err)
 	}
-	if err := os.Chmod(tmpName, storage.FilePermPublic); err != nil {
+	if err := os.Chmod(tmpName, perm); err != nil {
 		return fmt.Errorf("setting permissions on %s: %w", path, err)
 	}
 	if err := os.Rename(tmpName, path); err != nil {

--- a/cmd/openvox-ca/writefile_test.go
+++ b/cmd/openvox-ca/writefile_test.go
@@ -52,10 +52,12 @@ var _ = Describe("Atomic file writers", func() {
 		Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o600)))
 	})
 
-	It("sets the mode explicitly rather than inheriting the caller's umask", func() {
-		// Without the explicit Chmod, a umask of 077 would yield 0600 for the
-		// public path -- silently correct-looking on a developer's machine with
-		// the usual 022, and wrong wherever an operator's shell differs.
+	It("sets the mode explicitly rather than inheriting it", func() {
+		// os.CreateTemp creates at 0600 whatever the umask, so what the Chmod
+		// actually guards is inheritance from *that*, not from the shell: drop
+		// it and the public path stays 0600 under any umask. The hostile umask
+		// here is belt and braces -- it pins that neither source of inheritance
+		// wins over the explicit mode.
 		old := syscall.Umask(0o077)
 		defer syscall.Umask(old)
 

--- a/cmd/openvox-ca/writefile_test.go
+++ b/cmd/openvox-ca/writefile_test.go
@@ -1,0 +1,113 @@
+// Copyright (C) 2026 Trevor Vaughan
+// Copyright (C) 2026 Vox Pupuli and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Atomic file writers", func() {
+	var dir string
+
+	BeforeEach(func() { dir = GinkgoT().TempDir() })
+
+	// The two wrappers differ only in the mode they pass, so the regression
+	// worth guarding is calling the wrong one -- which would either publish a
+	// private key at 0644 or hand a third party a request they cannot read.
+	It("writes public material at 0644", func() {
+		path := filepath.Join(dir, "request.pem")
+		Expect(writePublicFile(path, []byte("public"))).To(Succeed())
+
+		info, err := os.Stat(path)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o644)))
+	})
+
+	It("writes private material at 0600", func() {
+		path := filepath.Join(dir, "node_key.pem")
+		Expect(writePrivateFile(path, []byte("private"))).To(Succeed())
+
+		info, err := os.Stat(path)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o600)))
+	})
+
+	It("sets the mode explicitly rather than inheriting the caller's umask", func() {
+		// Without the explicit Chmod, a umask of 077 would yield 0600 for the
+		// public path -- silently correct-looking on a developer's machine with
+		// the usual 022, and wrong wherever an operator's shell differs.
+		old := syscall.Umask(0o077)
+		defer syscall.Umask(old)
+
+		path := filepath.Join(dir, "umask.pem")
+		Expect(writePublicFile(path, []byte("public"))).To(Succeed())
+
+		info, err := os.Stat(path)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o644)),
+			"the mode must not depend on the invoking shell")
+	})
+
+	It("leaves no temporary file behind on success", func() {
+		Expect(writePrivateFile(filepath.Join(dir, "clean.pem"), []byte("x"))).To(Succeed())
+
+		entries, err := os.ReadDir(dir)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(entries).To(HaveLen(1), "a leftover temporary private key is a leaked credential")
+	})
+
+	It("leaves no temporary file behind when the rename cannot happen", func() {
+		// A directory at the target path makes the rename fail after the
+		// temporary file has been written -- the failure mode the deferred
+		// cleanup exists for.
+		path := filepath.Join(dir, "occupied")
+		Expect(os.Mkdir(path, 0o755)).To(Succeed())
+
+		Expect(writePrivateFile(path, []byte("x"))).NotTo(Succeed())
+
+		entries, err := os.ReadDir(dir)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(entries).To(HaveLen(1), "only the directory should remain; the temp file must be cleaned up")
+	})
+
+	It("does not disturb an existing file when the write fails", func() {
+		path := filepath.Join(dir, "existing.pem")
+		Expect(os.WriteFile(path, []byte("original"), 0o600)).To(Succeed())
+
+		// An unwritable directory fails at CreateTemp, before anything touches
+		// the target.
+		Expect(os.Chmod(dir, 0o500)).To(Succeed())
+		DeferCleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+		if os.Geteuid() == 0 {
+			Skip("root ignores directory permissions")
+		}
+
+		Expect(writePrivateFile(path, []byte("replacement"))).NotTo(Succeed())
+
+		Expect(os.Chmod(dir, 0o700)).To(Succeed())
+		data, err := os.ReadFile(path)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal("original"))
+	})
+})

--- a/cmd/openvox-ca/writefile_test.go
+++ b/cmd/openvox-ca/writefile_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2026 Trevor Vaughan
+// Copyright (C) 2026 Chris Boot
 // Copyright (C) 2026 Vox Pupuli and contributors
 //
 // This program is free software; you can redistribute it and/or modify

--- a/docs/api.md
+++ b/docs/api.md
@@ -67,11 +67,6 @@ All endpoints are served under both the bare path and `/puppet-ca/v1/<path>`, so
 Requires a valid CA-signed client certificate. The new certificate is issued immediately without entering the pending-CSR queue or autosign evaluation, and the certificate it replaces is revoked once the new one is safely stored (see `revoke_on_auto_renew` below for the auto-renewal case).
 
 - **CSR body (re-key):** the CSR Common Name must match the authenticated client CN — an agent can only renew its own certificate, not another's. Issues a certificate for the new key in the CSR. Puppet OID extensions are copied from the CSR **except** authorization-arc OIDs (`1.3.6.1.4.1.34380.1.3.*`, such as `pp_cli_auth`), which are stripped so a submitted CSR cannot request elevated privileges.
-Both renewal forms serialise on the same per-subject lock as signing, so either
-can answer `503 certificate authority busy, retry` when another replica holds
-that lock or the storage backend's lock service is unreachable. That is
-transient: retry.
-
 - **Empty body (wire-compatible auto-renewal):** matches the request real OpenVox/Puppet agents send by default (`hostcert_renewal_interval`, and the `puppet ssl renew_cert` CLI action). Identity and key possession come solely from the mTLS-presented client certificate; the same public key is reissued with a fresh serial and validity, carrying forward the original certificate's SANs and Puppet OID extensions unchanged. Unlike the CSR path, this **preserves authorization-arc OIDs** (e.g. `pp_cli_auth`): they were already vetted when the presented certificate was issued, so a cert that legitimately holds them keeps them across renewal.
 
 If the presented certificate's (or CSR's) key falls below the CA key-strength policy — for example an RSA-1024 key imported from a legacy CA — the request is rejected with `422 Unprocessable Entity` rather than renewed; the agent must re-key via the CSR path with a compliant key.
@@ -124,9 +119,8 @@ Response:
 { "private_key": "-----BEGIN RSA PRIVATE KEY-----\n...", "certificate": "-----BEGIN CERTIFICATE-----\n..." }
 ```
 
-This route serialises on the same per-subject lock as signing, so it can answer
-`503 certificate authority busy, retry` when another replica holds that lock or
-the storage backend's lock service is unreachable. That is transient: retry.
+This route serialises on the same per-subject lock as signing, so it can block
+while another replica holds that lock.
 
 It cannot issue a certificate carrying `pp_cli_auth` — see
 [authorization tiers](#authorization-tiers) — and it needs a running server.

--- a/docs/api.md
+++ b/docs/api.md
@@ -119,6 +119,15 @@ Response:
 { "private_key": "-----BEGIN RSA PRIVATE KEY-----\n...", "certificate": "-----BEGIN CERTIFICATE-----\n..." }
 ```
 
+This route serialises on the same per-subject lock as signing, so it can answer
+`503 certificate authority busy, retry` when another replica holds that lock or
+the storage backend's lock service is unreachable. That is transient: retry.
+
+It cannot issue a certificate carrying `pp_cli_auth` — see
+[authorization tiers](#authorization-tiers) — and it needs a running server.
+Neither is true of [`openvox-ca generate`](operator-cli.md#generate-minting-a-certificate-offline),
+which mints against storage directly.
+
 ## Certificate import
 
 | Method | Path | Description |
@@ -191,5 +200,7 @@ A client certificate is considered an admin credential if **either** condition i
 2. **`pp_cli_auth` extension:** the certificate carries the Puppet authorization extension OID `1.3.6.1.4.1.34380.1.3.39` with the UTF8String value `"true"`. OpenVox Server embeds this extension in its own certificate by default, so the `puppetserver ca` CLI can authenticate without being listed by CN.
 
 The `pp_cli_auth` check is enabled by default. Disable it with `--no-pp-cli-auth` (or `no_pp_cli_auth: true` in the config file) if you prefer strict CN-only authorization.
+
+A certificate carrying `pp_cli_auth` cannot be obtained through this API at all: authorization-arc OIDs are stripped from submitted CSRs so that no request can ask for elevated privileges. Mint one offline with [`openvox-ca generate --pp-cli-auth`](operator-cli.md#administrator-credentials), which also documents what the grant covers and the three steps needed to withdraw it.
 
 > **OID source:** [`lib/puppet/ssl/oids.rb`](https://github.com/puppetlabs/puppet/blob/main/lib/puppet/ssl/oids.rb)

--- a/docs/api.md
+++ b/docs/api.md
@@ -67,6 +67,11 @@ All endpoints are served under both the bare path and `/puppet-ca/v1/<path>`, so
 Requires a valid CA-signed client certificate. The new certificate is issued immediately without entering the pending-CSR queue or autosign evaluation, and the certificate it replaces is revoked once the new one is safely stored (see `revoke_on_auto_renew` below for the auto-renewal case).
 
 - **CSR body (re-key):** the CSR Common Name must match the authenticated client CN — an agent can only renew its own certificate, not another's. Issues a certificate for the new key in the CSR. Puppet OID extensions are copied from the CSR **except** authorization-arc OIDs (`1.3.6.1.4.1.34380.1.3.*`, such as `pp_cli_auth`), which are stripped so a submitted CSR cannot request elevated privileges.
+Both renewal forms serialise on the same per-subject lock as signing, so either
+can answer `503 certificate authority busy, retry` when another replica holds
+that lock or the storage backend's lock service is unreachable. That is
+transient: retry.
+
 - **Empty body (wire-compatible auto-renewal):** matches the request real OpenVox/Puppet agents send by default (`hostcert_renewal_interval`, and the `puppet ssl renew_cert` CLI action). Identity and key possession come solely from the mTLS-presented client certificate; the same public key is reissued with a fresh serial and validity, carrying forward the original certificate's SANs and Puppet OID extensions unchanged. Unlike the CSR path, this **preserves authorization-arc OIDs** (e.g. `pp_cli_auth`): they were already vetted when the presented certificate was issued, so a cert that legitimately holds them keeps them across renewal.
 
 If the presented certificate's (or CSR's) key falls below the CA key-strength policy — for example an RSA-1024 key imported from a legacy CA — the request is rejected with `422 Unprocessable Entity` rather than renewed; the agent must re-key via the CSR path with a compliant key.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,7 +4,8 @@ This is the full configuration reference for the `openvox-ca` server. For the
 operator CLI, see [operator CLI (`openvox-ca-ctl`)](operator-cli.md), which also
 covers the offline subcommands that run on the `openvox-ca` binary itself
 against this configuration — `csr` and `import-ca-cert`, for running under an
-external root CA with any `ca_key_provider`.
+external root CA with any `ca_key_provider`, and `generate`, for minting a
+certificate with no running server.
 
 ## Flags
 

--- a/docs/development/storage-internals.md
+++ b/docs/development/storage-internals.md
@@ -217,11 +217,62 @@ migration rewrites the head under the correct scheme; a store cannot be migrated
 onto itself) and then serve from that destination. This affects pre-release
 builds only; deployments created after the fix are unaffected.
 
+## Optional capabilities
+
+Two properties vary by backend and are not visible from the `Backend` interface
+alone. `StorageService` answers both, because callers that need to know cannot
+determine them for themselves — `openvox-ca generate` uses them to decide
+whether it is safe to write to storage a live server is also using.
+
+| Backend | `SupportsDistributedLocking` | `SupportsAtomicInventory` |
+| --- | --- | --- |
+| `postgres`, `mysql` | yes | yes |
+| `sqlite` | no | yes |
+| `etcd`, `redis` | yes | no |
+| `filesystem` | no | no |
+
+`SupportsAtomicInventory` wraps `asInventoryStore`, so it is true exactly for
+backends implementing `InventoryStore` — the SQL backends, including SQLite.
+It is a method rather than a caller-side type assertion because
+`asInventoryStore` unwraps `OverlayBackend`, and a caller asserting on the
+wrapper would answer "no" for a SQL backend that happens to be overlaid by
+`ca_cert_file`.
+
+`SupportsDistributedLocking` deliberately does **not** answer
+`_, ok := backend.(Locker)`. That assertion is true for two backends that
+provide no cross-process lock at all: `SQLBackend` implements `Locker` but
+returns `ErrDistributedLockingUnsupported` for SQLite, and `OverlayBackend`
+implements it but delegates to a base that may not. A caller using the
+assertion to decide whether a second process is safe would be told the opposite
+of the truth in exactly the configurations where it matters. So the method
+reproduces `WithLock`'s decision instead — same `AcquireLock` call, same
+classification of the result, lock released immediately.
+
+It returns three outcomes, not two. A non-sentinel `AcquireLock` failure means
+the lock service is unreachable, which `WithLock` treats as fatal; reporting
+that as `false` would tell an operator their backend does not do distributed
+locking when the truth is that it is temporarily unavailable.
+
+The probe cannot be folded into `WithLock` — that would add a lock round trip
+to every `Sign` — so the two necessarily duplicate the classification. A
+`DescribeTable` in
+[internal/storage/capability_test.go](../../internal/storage/capability_test.go)
+runs each backend through both and asserts they agree; that spec is what keeps
+them from drifting, not the type system. **A new backend must be added to that
+table**, or its classification is unverified.
+
+`ErrLockUnavailable` (backend.go) is the sentinel `WithLock` wraps around an
+acquisition failure. It is a cross-package contract: the HTTP layer
+discriminates on it to answer `503 Service Unavailable` rather than `500`, so a
+client knows a lock timeout is transient and worth retrying. Keep it wrapped
+(`%w`) in any new failure path that can lose a lock.
+
 ## Extending
 
 The `Backend` interface is defined in
 [internal/storage/backend.go](../../internal/storage/backend.go). To add a new
-backend, implement the interface, register it in
+backend, implement the interface, declare its optional capabilities (see above,
+including the `capability_test.go` table), register it in
 [internal/storage/spec.go](../../internal/storage/spec.go)'s
 `NewServiceFromSpec`, and add any backend-specific config fields to
 [internal/config/storage.go](../../internal/config/storage.go)'s `StorageConfig`

--- a/docs/development/storage-internals.md
+++ b/docs/development/storage-internals.md
@@ -257,9 +257,13 @@ The probe cannot be folded into `WithLock` — that would add a lock round trip
 to every `Sign` — so the two necessarily duplicate the classification. A
 `DescribeTable` in
 [internal/storage/capability_test.go](../../internal/storage/capability_test.go)
-runs each backend through both and asserts they agree; that spec is what keeps
-them from drifting, not the type system. **A new backend must be added to that
-table**, or its classification is unverified.
+runs the backends constructible without a live service — `filesystem`, `sqlite`
+and a stub `Locker` — through both and asserts they agree. That spec is what
+keeps the probe and `WithLock` from drifting, not the type system. The
+networked backends (`postgres`, `mysql`, `etcd`, `redis`) are classified by the
+code above rather than by a spec, because the table needs no running service.
+**Add a new backend to that table when it can be constructed in-process**, and
+otherwise state its classification here.
 
 `ErrLockUnavailable` (backend.go) is the sentinel `WithLock` wraps around an
 acquisition failure. It is a cross-package contract: the HTTP layer

--- a/docs/development/storage-internals.md
+++ b/docs/development/storage-internals.md
@@ -265,12 +265,6 @@ code above rather than by a spec, because the table needs no running service.
 **Add a new backend to that table when it can be constructed in-process**, and
 otherwise state its classification here.
 
-`ErrLockUnavailable` (backend.go) is the sentinel `WithLock` wraps around an
-acquisition failure. It is a cross-package contract: the HTTP layer
-discriminates on it to answer `503 Service Unavailable` rather than `500`, so a
-client knows a lock timeout is transient and worth retrying. Keep it wrapped
-(`%w`) in any new failure path that can lose a lock.
-
 ## Extending
 
 The `Backend` interface is defined in

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -63,7 +63,7 @@ mage test:puppet
 | 15 | OCSP: good/revoked status, nonce handling, cache invalidation on revoke, malformed request (400) |
 | 16 | Autosign modes: `true`, glob-pattern file, executable plugin |
 | 17 | Config drivers: env vars, config file |
-| 18 | `pp_cli_auth` mTLS: Phase 1 bootstraps certs (loopback HTTP); Phase 2 asserts pp_cli_auth cert reaches admin endpoints while plain cert is denied |
+| 18 | `pp_cli_auth` mTLS: the admin credential is minted offline with `openvox-ca generate --pp-cli-auth` before any server starts; Phase 1 bootstraps the remaining certs (loopback HTTP); Phase 2 asserts the pp_cli_auth cert reaches admin endpoints while a plain cert is denied |
 | 19 | `openvox-ca-ctl` error paths: revoke/clean/sign/generate against non-existent or duplicate subjects; arg validation; `--dns` SAN delivery; full mTLS via `--ca-cert`/`--client-cert`/`--client-key`; unreachable server |
 | 20 | Migration from an OpenVox/Puppet Server CA: import CA cert/key/CRL via `openvox-ca-ctl import`, copy pre-existing signed certs, verify fetch/sign/revoke/list all work on the migrated CA |
 | 21 | `POST /certificate_renewal` over mTLS: agent renews its own certificate; CN-mismatch renewal rejected |

--- a/docs/migrating-from-puppet-server.md
+++ b/docs/migrating-from-puppet-server.md
@@ -168,24 +168,37 @@ First, generate a TLS server certificate for openvox-ca itself:
 
 ```bash
 openvox-ca generate \
+  --cadir    "$NEW_CADIR" \
   --certname openvox-ca.example.com \
   --ttl      8760h \
   --key-out  "$NEW_CADIR/private/openvox-ca.example.com_key.pem" \
-  > "$NEW_CADIR/signed/openvox-ca.example.com.pem"
+  >/dev/null
 
 # Or, if you prefer a DNS SAN for the old puppet-master hostname:
 openvox-ca generate \
+  --cadir    "$NEW_CADIR" \
   --certname openvox-ca.example.com \
   --ttl      8760h \
   --dns      openvox-ca.example.com,puppet-master.example.com \
   --key-out  "$NEW_CADIR/private/openvox-ca.example.com_key.pem" \
-  > "$NEW_CADIR/signed/openvox-ca.example.com.pem"
+  >/dev/null
 ```
 
 This runs before the server starts, against the cadir `openvox-ca-ctl import`
 populated in the previous step. Earlier versions of this guide had to start the
 CA temporarily on loopback without TLS to mint this certificate through the API,
 then restart it with TLS; that is no longer necessary.
+
+Two details worth copying exactly. `--cadir` is required here because this guide
+configures everything by flag and never writes a config file — without it the
+command exits with `cadir is required`. And the certificate is **not** captured
+by redirecting stdout: `generate` already writes it to
+`$NEW_CADIR/signed/openvox-ca.example.com.pem` through the storage layer, which
+is the path the server is pointed at below. Redirecting into that path would
+make the shell truncate it before the command runs, and the CA would then refuse
+to issue because a (zero-length, undecodable) certificate already exists for
+that name. If you want a second copy elsewhere, use `--cert-out` with a path
+outside the cadir.
 
 ```bash
 # Production start with TLS

--- a/docs/migrating-from-puppet-server.md
+++ b/docs/migrating-from-puppet-server.md
@@ -167,33 +167,27 @@ ca_port   = 8140
 First, generate a TLS server certificate for openvox-ca itself:
 
 ```bash
-openvox-ca-ctl generate \
-  --server-url http://127.0.0.1:8140 \
-  --certname   openvox-ca.example.com
+openvox-ca generate \
+  --certname openvox-ca.example.com \
+  --ttl      8760h \
+  --key-out  "$NEW_CADIR/private/openvox-ca.example.com_key.pem" \
+  > "$NEW_CADIR/signed/openvox-ca.example.com.pem"
 
 # Or, if you prefer a DNS SAN for the old puppet-master hostname:
-openvox-ca-ctl generate \
-  --server-url http://127.0.0.1:8140 \
-  --certname   openvox-ca.example.com \
-  --dns        puppet-master.example.com
+openvox-ca generate \
+  --certname openvox-ca.example.com \
+  --ttl      8760h \
+  --dns      openvox-ca.example.com,puppet-master.example.com \
+  --key-out  "$NEW_CADIR/private/openvox-ca.example.com_key.pem" \
+  > "$NEW_CADIR/signed/openvox-ca.example.com.pem"
 ```
 
-> **Note:** `generate` requires a running openvox-ca instance. Start it
-> temporarily on loopback without TLS, generate the cert, then restart
-> with TLS:
+This runs before the server starts, against the cadir `openvox-ca-ctl import`
+populated in the previous step. Earlier versions of this guide had to start the
+CA temporarily on loopback without TLS to mint this certificate through the API,
+then restart it with TLS; that is no longer necessary.
 
 ```bash
-# Temporary start (loopback only, no TLS)
-openvox-ca --cadir "$NEW_CADIR" --host 127.0.0.1 --port 8140 &
-PCA_PID=$!
-sleep 2
-
-openvox-ca-ctl generate \
-  --server-url http://127.0.0.1:8140 \
-  --certname   openvox-ca.example.com
-
-kill $PCA_PID; wait $PCA_PID 2>/dev/null
-
 # Production start with TLS
 openvox-ca \
   --cadir    "$NEW_CADIR" \
@@ -248,7 +242,7 @@ puppet agent --test --noop
 | `puppet cert clean <name>` | `openvox-ca-ctl clean --certname <name>` | Revoke + delete |
 | `puppetserver ca setup` | `openvox-ca-ctl setup --cadir <path>` | |
 | `puppetserver ca import` | `openvox-ca-ctl import --cadir <path> ...` | |
-| `puppetserver ca generate` | `openvox-ca-ctl generate --certname <name>` | |
+| `puppetserver ca generate` | `openvox-ca-ctl generate --certname <name>` | Needs a running server. Use `openvox-ca generate --certname <name> --ttl <duration>` to mint offline, which is also the only way to obtain a `pp_cli_auth` certificate |
 
 ## Differences to be aware of
 
@@ -264,42 +258,67 @@ used to. The `serial` file from old Puppet CAs is ignored.
 openvox-ca strips Puppet authorization-arc OIDs (`1.3.6.1.4.1.34380.1.3.*`)
 from CSRs during signing as a security measure to prevent privilege
 escalation. This means you cannot create admin certificates (with
-`pp_cli_auth`) by submitting a CSR through the API.
+`pp_cli_auth`) by submitting a CSR through the API. That is deliberate and
+unchanged: a request that could ask for `pp_cli_auth` would let any agent ask
+for CA admin.
 
-To create admin certificates with `pp_cli_auth`, sign them directly using
-the CA key with openssl:
+Mint one offline instead:
 
 ```bash
-# Generate key and CSR with pp_cli_auth extension
-openssl genrsa -out admin.key 2048
-cat > admin.cnf <<EOF
-[req]
-distinguished_name = dn
-req_extensions     = v3_req
-prompt             = no
-[dn]
-CN = admin-tool
-[v3_req]
-1.3.6.1.4.1.34380.1.3.39 = DER:0c:04:74:72:75:65
-EOF
-openssl req -new -key admin.key -config admin.cnf -out admin.csr
-
-# Sign directly with the CA key
-cat > admin_ext.cnf <<EOF
-1.3.6.1.4.1.34380.1.3.39 = DER:0c:04:74:72:75:65
-EOF
-openssl x509 -req \
-  -in admin.csr \
-  -CA <cadir>/ca_crt.pem \
-  -CAkey <cadir>/private/ca_key.pem \
-  -CAcreateserial \
-  -days 365 \
-  -extfile admin_ext.cnf \
-  -out admin.crt
+openvox-ca generate --certname admin-cli --ttl 8760h --pp-cli-auth \
+  --key-out admin-cli_key.pem > admin-cli.crt
 ```
 
+Run it on the CA host, against the server's own configuration. No running
+server, no admin certificate, and no API.
+
+This is not merely a shorter recipe than signing with `openssl` by hand. It
+needs no access to the raw CA key, so it works under `ca_key_provider: openbao`
+— where the key never leaves the vault — and under `encrypt_ca_key`, neither of
+which can be fed to `openssl x509 -req` at all. And the certificate it produces
+is one the CA can see: it takes a serial from the CA's own generator, is written
+to the inventory, appears in `openvox-ca-ctl list --all`, is swept by the expiry
+job, and can be revoked by name.
+
+`pp_cli_auth` grants the entire admin tier — signing, revoking, cleaning,
+importing, replacing the CRL. Withdrawing it takes three steps rather than one,
+and `--pp-cli-auth` has other requirements and caveats worth reading before you
+use it: see [`generate`](operator-cli.md#administrator-credentials).
+
+It has no effect where `no_pp_cli_auth: true` is set; the command refuses rather
+than issuing a certificate that would grant nothing.
+
 Alternatively, use the `--puppet-server` flag to grant admin access by CN
-without needing the `pp_cli_auth` extension at all.
+without needing the `pp_cli_auth` extension at all. Prefer it where the caller
+has a stable CN: an allow-list entry is withdrawn by editing a file and
+restarting, whereas this grant is withdrawn only by revoking the certificate and
+restarting every replica.
+
+#### Certificates you already minted with openssl
+
+Earlier versions of this guide told you to sign admin certificates directly with
+the CA key. Those certificates have no inventory row, which means
+`openvox-ca-ctl revoke --certname` cannot find them and `--force` cannot replace
+them: they were never in the CA's storage. They are nonetheless valid,
+CA-signed, admin-granting credentials until they expire.
+
+To retire one, register it first so the CA can see it, then revoke it:
+
+```bash
+# 1. With the server running, authenticated by the very certificate you are
+#    retiring (it is still an admin credential until you revoke it).
+openvox-ca-ctl import-cert --certname admin-tool --cert-file admin.crt
+
+# 2. It is now in the inventory and revocable by name.
+openvox-ca-ctl revoke --certname admin-tool
+
+# 3. Restart every replica so the revocation is honoured, then re-mint.
+openvox-ca generate --certname admin-tool --ttl 8760h --pp-cli-auth \
+  --key-out admin-tool_key.pem > admin-tool.crt
+```
+
+Note that step 1 is an admin-authenticated API call and needs a running server —
+importing is a prerequisite for revoking here, not an alternative to it.
 
 ### No `puppet cert` compatibility shim
 

--- a/docs/migrating-from-puppet-server.md
+++ b/docs/migrating-from-puppet-server.md
@@ -278,12 +278,15 @@ for CA admin.
 Mint one offline instead:
 
 ```bash
-openvox-ca generate --certname admin-cli --ttl 8760h --pp-cli-auth \
-  --key-out admin-cli_key.pem > admin-cli.crt
+openvox-ca generate --cadir "$NEW_CADIR" --certname admin-cli \
+  --ttl 8760h --pp-cli-auth --key-out admin-cli_key.pem > admin-cli.crt
 ```
 
 Run it on the CA host, against the server's own configuration. No running
-server, no admin certificate, and no API.
+server, no admin certificate, and no API. `--cadir` is spelled out because this
+guide configures the server entirely by flag and never writes
+`/etc/puppet-ca/config.yaml`; where that file does exist, the command reads the
+cadir from it and the flag can be dropped.
 
 This is not merely a shorter recipe than signing with `openssl` by hand. It
 needs no access to the raw CA key, so it works under `ca_key_provider: openbao`
@@ -326,8 +329,8 @@ openvox-ca-ctl import-cert --certname admin-tool --cert-file admin.crt
 openvox-ca-ctl revoke --certname admin-tool
 
 # 3. Restart every replica so the revocation is honoured, then re-mint.
-openvox-ca generate --certname admin-tool --ttl 8760h --pp-cli-auth \
-  --key-out admin-tool_key.pem > admin-tool.crt
+openvox-ca generate --cadir "$NEW_CADIR" --certname admin-tool \
+  --ttl 8760h --pp-cli-auth --key-out admin-tool_key.pem > admin-tool.crt
 ```
 
 Note that step 1 is an admin-authenticated API call and needs a running server —

--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -111,15 +111,15 @@ See [storage backends](storage-backends.md#migrating-between-backends) for migra
 
 ## Offline subcommands on the server binary
 
-Two subcommands live on `openvox-ca` rather than `openvox-ca-ctl`, because they
+Three subcommands live on `openvox-ca` rather than `openvox-ca-ctl`, because they
 must reach the storage backend and CA key provider named in the *server's*
 configuration. `openvox-ca-ctl` reads a different configuration file and can
 only address a local filesystem directory, so it cannot serve a CA whose state
 is in PostgreSQL or whose key is in OpenBao Transit.
 
-Neither needs a running server.
+None of them needs a running server.
 
-Both read the **server's** configuration, not `openvox-ca-ctl`'s: `--config`, or
+All three read the **server's** configuration, not `openvox-ca-ctl`'s: `--config`, or
 `PUPPET_CA_CONFIG`, defaulting to `/etc/puppet-ca/config.yaml`. A working
 `ctl.yaml` has no effect on them. `--cadir` overrides the configured storage
 directory for a one-off run.
@@ -134,6 +134,14 @@ openvox-ca csr --hostname puppet.example.com --create-key --out ca-request.pem
 
 # Install the chain the parent signed, completing the round trip
 openvox-ca import-ca-cert --cert-bundle signed-chain.pem
+
+# Mint a certificate with no running server and no API
+openvox-ca generate --certname web01.example.com --ttl 8760h \
+  --key-out web01_key.pem > web01.crt
+
+# ... and make it a CA administrator credential
+openvox-ca generate --certname admin-cli --ttl 8760h --pp-cli-auth \
+  --key-out admin-cli_key.pem > admin-cli.crt
 ```
 
 `csr` reuses an existing CA certificate's subject verbatim — the encoded DN is
@@ -159,11 +167,17 @@ together, or stop the service while you do.
 > matters: with no config file, `csr --create-key` would resolve
 > `ca_key_provider: file`, mint a **local** CA key, and emit a request bound to a
 > key a Transit-backed server will never use, so the parent would sign the wrong
-> key. Both commands therefore print the config file, storage backend and key
-> provider they resolved before doing anything — check those lines match the
+> key. All three commands therefore print the config file, storage backend and
+> key provider they resolved before doing anything — check those lines match the
 > server. If your server is configured by flags, mirror the storage and
 > key-provider settings into the config file or `PUPPET_CA_*` environment for
 > these commands.
+>
+> `generate` extends this to the settings that shape or record what it issues:
+> `crl_url`, `ocsp_url`, `promote_cn_to_san` and `logfile`. A flag-configured
+> server would otherwise leave it minting certificates with no CRL distribution
+> point while the server's own issuance carries one, and with no durable record
+> that an administrator credential was created. Mirror those too.
 
 `import-ca-cert` requires a **complete chain, nearest first**: this CA's own
 certificate, each issuer after it, ending with a self-signed root. Supply only
@@ -206,3 +220,161 @@ See [running under an external root CA](openbao-transit.md#running-under-an-exte
 — written against OpenBao Transit, but the procedure is identical for every
 `ca_key_provider`, including the default file provider —
 for the end-to-end procedure.
+
+### `generate`: minting a certificate offline
+
+`generate` issues a certificate directly against the configured storage backend
+and CA key provider. No running server, no API, and no admin client certificate.
+
+**Use the API for ordinary node certificates.** `POST /generate/{subject}`, or
+an agent submitting a CSR, needs no outage and no shell on the CA host. This
+command exists for the two cases the API cannot serve:
+
+- a `pp_cli_auth` administrator credential, which the API refuses to issue by
+  construction (see [Auth-arc OID stripping](migrating-from-puppet-server.md#auth-arc-oid-stripping));
+- minting before a server exists, which is the circle `openvox-ca-ctl generate`
+  cannot break — it needs an admin certificate, which needs a running server,
+  which needs a serving certificate.
+
+`--ttl` is required. There is deliberately no default: a certificate minted this
+way is usually long-lived and privileged, and inheriting a multi-year built-in
+silently is the wrong failure. One year is `8760h`.
+
+What you get is a certificate the CA can see. It takes a serial from the CA's
+own generator, is written to the inventory, appears in `openvox-ca-ctl list
+--all`, is swept by the expiry job, and can be revoked by name — none of which
+is true of a certificate signed out of band with `openssl`.
+
+**Autosign policy is not consulted.** This is an operator action rather than a
+request, and it has to work when there is no policy configured and no server
+running to evaluate one.
+
+**It refuses rather than bootstrapping.** If the configured storage holds no CA
+certificate and no key, the command stops. A mistyped `--cadir` would otherwise
+mint a brand-new CA and issue under it, leaving you with certificates nothing in
+your fleet trusts and no obvious sign of why.
+
+#### Where the private key goes
+
+`--key-out` writes the key to a path you choose, at mode 0600, and keeps no copy.
+
+Without it the key goes to the cadir's `private/` directory, which has two
+properties worth knowing. Nothing sweeps that directory, so the key persists
+there until you remove it. And it is written to the **local filesystem whatever
+the storage backend**, so on an ephemeral cadir — a container with no persistent
+volume — it is lost at the next restart while its certificate stays live in the
+shared inventory.
+
+`--key-out` is therefore **required** with `--pp-cli-auth` (an administrator
+credential whose key evaporates is the worst version of that problem) and with
+`--force` (see below).
+
+#### Running alongside a live server
+
+The command prints whether the resolved backend can coordinate writes with other
+processes, and warns when it cannot.
+
+Certificate issuance is serialised on a per-subject lock, and the inventory
+append is atomic, only on backends that support them: PostgreSQL, MySQL, etcd
+and Redis provide cross-process locking, and the SQL backends provide atomic
+inventory appends. The default `filesystem` backend and `sqlite` provide
+neither — they are documented as single-node — so on those, **stop the server
+before running this command**.
+
+Two things can go wrong if you do not. Two writers can each decide a subject has
+no certificate and both issue one. Worse, the inventory's integrity record is
+recomputed from a snapshot on blob backends, so an interleaved append leaves an
+HMAC covering a state that never existed — after which the server refuses to
+start, and there is no supported repair
+([#188](https://github.com/voxpupuli/openvox-ca/issues/188)).
+
+On a fresh install this costs nothing, because there is no server running yet.
+It is re-minting on an established CA that forces a real outage.
+
+In containers, pass `--cadir` explicitly: the shipped image sets it in the
+image's `CMD` rather than in a config file, so the bare command cannot find it.
+Where the backend does coordinate, `podman exec` or `kubectl exec` into the
+running CA is fine. Where it does not, stop the service and run a one-shot
+container against the same volume, mounting somewhere for `--key-out` to land
+that outlives the container:
+
+```bash
+podman run --rm -v ca-data:/data -v "$PWD":/out:z openvox-ca:latest \
+  generate --cadir /data --certname admin-cli --ttl 8760h \
+  --pp-cli-auth --key-out /out/admin-cli_key.pem > admin-cli.crt
+```
+
+On Kubernetes the equivalent is scaling the Deployment to zero and running a Job
+that mounts the same PVC, with a retrieval step for the key — a `--key-out` path
+inside a Job pod that is then reaped is the same as having no key at all.
+
+One more asymmetry to expect: a running server answers OCSP `unknown` for a
+certificate minted this way until it restarts, because its serial index is built
+at startup. The CRL and the inventory are correct immediately.
+
+#### Replacing a certificate
+
+By default a live certificate for the name blocks re-issuance with `certificate
+already exists`. A name whose certificate was previously cleaned or revoked
+re-issues freely — the block is on a live certificate, not on a name that
+appears in the inventory.
+
+`--force` revokes the existing certificate and issues a replacement. The old
+serial goes on the CRL, but **a running server honours it until that server
+reloads the CRL**, which can be a substantial fraction of `crl_validity` away.
+Restart it if that matters. If the name is the CA's own hostname, the command
+says so: you may be revoking the certificate the server is currently serving.
+
+`--force` revokes the serial of the certificate in storage, which is not
+necessarily every live serial for the name — see the withdrawal note below.
+
+#### Administrator credentials
+
+`--pp-cli-auth` stamps the `pp_cli_auth` extension, which grants the holder the
+entire admin tier: signing any request, signing all of them, generating for any
+name, revoking, cleaning, importing, and replacing the CRL. See
+[authorization tiers](api.md#authorization-tiers).
+
+The command prints a warning naming all of that before it issues, and requires
+`--key-out`.
+
+**Withdrawing the grant is not one step**, and this is the part that is easy to
+get wrong:
+
+1. `openvox-ca-ctl revoke --certname <name>` — revokes the newest serial.
+2. **Restart every replica.** Each holds its own CRL cache, so a revocation made
+   elsewhere is not honoured until the process reloads it; waiting for that can
+   take roughly two-thirds of `crl_validity`, and even afterwards a pre-signed
+   OCSP response can vouch for the revoked serial for up to another four hours.
+3. **Check the inventory for other live serials for that name.** With
+   `revoke_on_auto_renew: false`, or after a renewal whose best-effort revoke
+   failed, more than one can be valid — and current tooling cannot revoke a
+   superseded serial
+   ([#177](https://github.com/voxpupuli/openvox-ca/issues/177)).
+
+Bear that cost in mind when choosing `--ttl`: until #177 lands, a short lifetime
+is the most reliable limit on a credential you may not be able to fully retire.
+
+`no_pp_cli_auth: true` makes the extension grant nothing, and the command
+refuses rather than minting an inert certificate. Treat that as a convenience
+check rather than a security boundary: it reads the configuration *this command*
+resolved, so it cannot see `--no-pp-cli-auth` passed as a server flag, and it
+can refuse when a shared config file sets it but the running server does not.
+
+Note also what is *not* recorded. The inventory line is the Puppet-compatible
+format — serial, dates, subject — with nothing about the grant, so the log
+message this command emits is the only record distinguishing an administrator
+credential from a node one. It is written by whoever ran the command, and it
+only lands somewhere durable if `logfile` is configured in a file this command
+can read.
+
+**Who can do this.** The `openssl` recipe this replaces required the raw CA key
+file. This requires the ability to run the binary with the server's
+configuration — which under `ca_key_provider: openbao` means Transit sign
+permission plus write access to the cadir, rather than the key itself. That is a
+deliberate widening, and the reason the feature is possible at all, but it is
+worth knowing when deciding who gets a shell on the CA host.
+
+Where the caller has a stable CN, `--puppet-server` remains the lower-privilege
+alternative: an allow-list entry is withdrawn by editing a file and restarting,
+with none of the above.

--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -269,24 +269,41 @@ shared inventory.
 credential whose key evaporates is the worst version of that problem) and with
 `--force` (see below).
 
+Both `--key-out` and `--cert-out` refuse a path that already exists rather than
+overwriting it, and they refuse before anything is issued — a mint cannot be
+undone, so a path collision has to be caught first. There is no `--overwrite`:
+move the previous file aside, which re-minting for a name you already hold will
+require you to do.
+
 #### Running alongside a live server
 
 The command prints whether the resolved backend can coordinate writes with other
 processes, and warns when it cannot.
 
-Certificate issuance is serialised on a per-subject lock, and the inventory
-append is atomic, only on backends that support them: PostgreSQL, MySQL, etcd
-and Redis provide cross-process locking, and the SQL backends provide atomic
-inventory appends. The default `filesystem` backend and `sqlite` provide
-neither — they are documented as single-node — so on those, **stop the server
-before running this command**.
+Two independent capabilities matter, and no backend has both except PostgreSQL
+and MySQL:
 
-Two things can go wrong if you do not. Two writers can each decide a subject has
-no certificate and both issue one. Worse, the inventory's integrity record is
-recomputed from a snapshot on blob backends, so an interleaved append leaves an
-HMAC covering a state that never existed — after which the server refuses to
-start, and there is no supported repair
-([#188](https://github.com/voxpupuli/openvox-ca/issues/188)).
+| Backend | Cross-process locking | Atomic inventory append |
+| --- | --- | --- |
+| `postgres`, `mysql` | yes | yes |
+| `sqlite` | no (single-node) | yes |
+| `etcd`, `redis` | yes | no |
+| `filesystem` (default) | no (single-node) | no |
+
+The command reports safe to run alongside a live server only when **both** are
+present, so everything except PostgreSQL and MySQL gets the stop-the-server
+warning — including etcd and Redis, which lock correctly but still append to the
+inventory non-atomically.
+
+What each missing capability costs is different. Without cross-process locking,
+two writers can each decide a subject has no certificate and both issue one.
+Without an atomic inventory append — the blob backends, `filesystem`, `etcd` and
+`redis` — the integrity record is recomputed from a snapshot, so an interleaved
+append leaves an HMAC covering a state that never existed, after which the
+server refuses to start and there is no supported repair
+([#188](https://github.com/voxpupuli/openvox-ca/issues/188)). That second
+failure is the reason to take this seriously; it does not apply to `sqlite`,
+which is single-node but does append atomically.
 
 On a fresh install this costs nothing, because there is no server running yet.
 It is re-minting on an established CA that forces a real outage.

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -28,10 +28,12 @@ import (
 	"encoding/asn1"
 	"encoding/json"
 	"encoding/pem"
+	"fmt"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -893,6 +895,39 @@ var _ = Describe("API Workflow", func() {
 			mux.ServeHTTP(rr, req)
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
 		})
+
+		It("should return 503, not 500, when the subject lock cannot be taken", func() {
+			// Generate now serialises on the per-subject lock, so it can fail
+			// on lock acquisition where it previously could not fail at all.
+			// That is transient: the client should back off and retry, which a
+			// 500 does not tell it to do.
+			//
+			// The default fixture cannot produce this -- the filesystem backend
+			// implements no Locker, so WithLock falls through to a mutex that
+			// cannot fail. Inject a backend whose AcquireLock errors.
+			lockDir, err := os.MkdirTemp("", "openvox-ca-lockfail-test")
+			Expect(err).NotTo(HaveOccurred())
+			defer os.RemoveAll(lockDir)
+
+			failing := &lockFailBackend{Backend: storage.NewFilesystemBackend(lockDir)}
+			failStore := storage.NewWithBackend(failing, filepath.Join(lockDir, "private"))
+			Expect(failStore.EnsureDirs(context.Background())).To(Succeed())
+			Expect(failStore.SaveCAKey(context.Background(), cachedKeyPEM)).To(Succeed())
+			Expect(failStore.SaveCACert(context.Background(), cachedCrtPEM)).To(Succeed())
+			Expect(failStore.UpdateCRL(context.Background(), cachedCrlPEM)).To(Succeed())
+			Expect(failStore.WriteSerial(context.Background(), "0001")).To(Succeed())
+			Expect(failStore.TouchInventory(context.Background())).To(Succeed())
+
+			failCA := ca.New(failStore, ca.AutosignConfig{Mode: "off"}, "puppet.test")
+			Expect(failCA.Init(context.Background())).To(Succeed())
+			failing.fail = true
+
+			failMux := api.New(failCA).Routes()
+			req := httptest.NewRequest("POST", "/generate/lock-fail-node", nil)
+			rr := httptest.NewRecorder()
+			failMux.ServeHTTP(rr, req)
+			Expect(rr.Code).To(Equal(http.StatusServiceUnavailable))
+		})
 	})
 
 	Context("POST /generate/{subject} over plain HTTP", func() {
@@ -1447,3 +1482,21 @@ var _ = Describe("API Workflow", func() {
 	})
 
 })
+
+// lockFailBackend advertises storage.Locker but refuses to hand out locks once
+// fail is set. It stands in for a backend whose lock service is unreachable or
+// whose lock is held by another replica past the timeout -- the only way to
+// exercise the lock-failure branch, since the filesystem backend used by the
+// rest of this suite implements no Locker at all and falls through to a mutex
+// that cannot fail.
+type lockFailBackend struct {
+	storage.Backend
+	fail bool
+}
+
+func (b *lockFailBackend) AcquireLock(_ context.Context, name string) (storage.Unlocker, error) {
+	if b.fail {
+		return nil, fmt.Errorf("lock service unreachable for %q", name)
+	}
+	return nil, storage.ErrDistributedLockingUnsupported
+}

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -28,12 +28,10 @@ import (
 	"encoding/asn1"
 	"encoding/json"
 	"encoding/pem"
-	"fmt"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path/filepath"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -895,39 +893,6 @@ var _ = Describe("API Workflow", func() {
 			mux.ServeHTTP(rr, req)
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
 		})
-
-		It("should return 503, not 500, when the subject lock cannot be taken", func() {
-			// Generate now serialises on the per-subject lock, so it can fail
-			// on lock acquisition where it previously could not fail at all.
-			// That is transient: the client should back off and retry, which a
-			// 500 does not tell it to do.
-			//
-			// The default fixture cannot produce this -- the filesystem backend
-			// implements no Locker, so WithLock falls through to a mutex that
-			// cannot fail. Inject a backend whose AcquireLock errors.
-			lockDir, err := os.MkdirTemp("", "openvox-ca-lockfail-test")
-			Expect(err).NotTo(HaveOccurred())
-			defer os.RemoveAll(lockDir)
-
-			failing := &lockFailBackend{Backend: storage.NewFilesystemBackend(lockDir)}
-			failStore := storage.NewWithBackend(failing, filepath.Join(lockDir, "private"))
-			Expect(failStore.EnsureDirs(context.Background())).To(Succeed())
-			Expect(failStore.SaveCAKey(context.Background(), cachedKeyPEM)).To(Succeed())
-			Expect(failStore.SaveCACert(context.Background(), cachedCrtPEM)).To(Succeed())
-			Expect(failStore.UpdateCRL(context.Background(), cachedCrlPEM)).To(Succeed())
-			Expect(failStore.WriteSerial(context.Background(), "0001")).To(Succeed())
-			Expect(failStore.TouchInventory(context.Background())).To(Succeed())
-
-			failCA := ca.New(failStore, ca.AutosignConfig{Mode: "off"}, "puppet.test")
-			Expect(failCA.Init(context.Background())).To(Succeed())
-			failing.fail = true
-
-			failMux := api.New(failCA).Routes()
-			req := httptest.NewRequest("POST", "/generate/lock-fail-node", nil)
-			rr := httptest.NewRecorder()
-			failMux.ServeHTTP(rr, req)
-			Expect(rr.Code).To(Equal(http.StatusServiceUnavailable))
-		})
 	})
 
 	Context("POST /generate/{subject} over plain HTTP", func() {
@@ -1297,54 +1262,6 @@ var _ = Describe("API Workflow", func() {
 			Expect(rr.Code).To(Equal(http.StatusOK))
 		})
 
-		// Both renewal arms take the same per-subject lock as signing and
-		// /generate, so both can lose it. Covered separately because they are
-		// separate code paths: an empty body reaches AutoRenew, a CSR body
-		// reaches Renew, and each has its own error mapping.
-		DescribeTable("should return 503, not 500, when the subject lock cannot be taken",
-			func(withCSR bool) {
-				lockDir, err := os.MkdirTemp("", "openvox-ca-renewlock-test")
-				Expect(err).NotTo(HaveOccurred())
-				defer os.RemoveAll(lockDir)
-
-				failing := &lockFailBackend{Backend: storage.NewFilesystemBackend(lockDir)}
-				failStore := storage.NewWithBackend(failing, filepath.Join(lockDir, "private"))
-				Expect(failStore.EnsureDirs(context.Background())).To(Succeed())
-				Expect(failStore.SaveCAKey(context.Background(), cachedKeyPEM)).To(Succeed())
-				Expect(failStore.SaveCACert(context.Background(), cachedCrtPEM)).To(Succeed())
-				Expect(failStore.UpdateCRL(context.Background(), cachedCrlPEM)).To(Succeed())
-				Expect(failStore.WriteSerial(context.Background(), "0001")).To(Succeed())
-				Expect(failStore.TouchInventory(context.Background())).To(Succeed())
-
-				failCA := ca.New(failStore, ca.AutosignConfig{Mode: "off"}, "puppet.test")
-				Expect(failCA.Init(context.Background())).To(Succeed())
-
-				// Mint a certificate to renew while the lock still works.
-				result, err := failCA.Generate(context.Background(), subject, nil)
-				Expect(err).NotTo(HaveOccurred())
-				block, _ := pem.Decode(result.CertificatePEM)
-				Expect(block).NotTo(BeNil())
-				presented, err := x509.ParseCertificate(block.Bytes)
-				Expect(err).NotTo(HaveOccurred())
-
-				failing.fail = true
-
-				var body []byte
-				if withCSR {
-					body, err = testutil.GenerateCSR(subject)
-					Expect(err).NotTo(HaveOccurred())
-				}
-				req := httptest.NewRequest("POST", "/certificate_renewal", bytes.NewReader(body))
-				req.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{presented}}
-				rr := httptest.NewRecorder()
-				api.New(failCA).Routes().ServeHTTP(rr, req)
-
-				Expect(rr.Code).To(Equal(http.StatusServiceUnavailable))
-			},
-			Entry("empty body, via AutoRenew", false),
-			Entry("CSR body, via Renew", true),
-		)
-
 		It("should return 403 when no client certificate is presented", func() {
 			renewCSR, err := testutil.GenerateCSR(subject)
 			Expect(err).NotTo(HaveOccurred())
@@ -1530,21 +1447,3 @@ var _ = Describe("API Workflow", func() {
 	})
 
 })
-
-// lockFailBackend advertises storage.Locker but refuses to hand out locks once
-// fail is set. It stands in for a backend whose lock service is unreachable or
-// whose lock is held by another replica past the timeout -- the only way to
-// exercise the lock-failure branch, since the filesystem backend used by the
-// rest of this suite implements no Locker at all and falls through to a mutex
-// that cannot fail.
-type lockFailBackend struct {
-	storage.Backend
-	fail bool
-}
-
-func (b *lockFailBackend) AcquireLock(_ context.Context, name string) (storage.Unlocker, error) {
-	if b.fail {
-		return nil, fmt.Errorf("lock service unreachable for %q", name)
-	}
-	return nil, storage.ErrDistributedLockingUnsupported
-}

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1297,6 +1297,54 @@ var _ = Describe("API Workflow", func() {
 			Expect(rr.Code).To(Equal(http.StatusOK))
 		})
 
+		// Both renewal arms take the same per-subject lock as signing and
+		// /generate, so both can lose it. Covered separately because they are
+		// separate code paths: an empty body reaches AutoRenew, a CSR body
+		// reaches Renew, and each has its own error mapping.
+		DescribeTable("should return 503, not 500, when the subject lock cannot be taken",
+			func(withCSR bool) {
+				lockDir, err := os.MkdirTemp("", "openvox-ca-renewlock-test")
+				Expect(err).NotTo(HaveOccurred())
+				defer os.RemoveAll(lockDir)
+
+				failing := &lockFailBackend{Backend: storage.NewFilesystemBackend(lockDir)}
+				failStore := storage.NewWithBackend(failing, filepath.Join(lockDir, "private"))
+				Expect(failStore.EnsureDirs(context.Background())).To(Succeed())
+				Expect(failStore.SaveCAKey(context.Background(), cachedKeyPEM)).To(Succeed())
+				Expect(failStore.SaveCACert(context.Background(), cachedCrtPEM)).To(Succeed())
+				Expect(failStore.UpdateCRL(context.Background(), cachedCrlPEM)).To(Succeed())
+				Expect(failStore.WriteSerial(context.Background(), "0001")).To(Succeed())
+				Expect(failStore.TouchInventory(context.Background())).To(Succeed())
+
+				failCA := ca.New(failStore, ca.AutosignConfig{Mode: "off"}, "puppet.test")
+				Expect(failCA.Init(context.Background())).To(Succeed())
+
+				// Mint a certificate to renew while the lock still works.
+				result, err := failCA.Generate(context.Background(), subject, nil)
+				Expect(err).NotTo(HaveOccurred())
+				block, _ := pem.Decode(result.CertificatePEM)
+				Expect(block).NotTo(BeNil())
+				presented, err := x509.ParseCertificate(block.Bytes)
+				Expect(err).NotTo(HaveOccurred())
+
+				failing.fail = true
+
+				var body []byte
+				if withCSR {
+					body, err = testutil.GenerateCSR(subject)
+					Expect(err).NotTo(HaveOccurred())
+				}
+				req := httptest.NewRequest("POST", "/certificate_renewal", bytes.NewReader(body))
+				req.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{presented}}
+				rr := httptest.NewRecorder()
+				api.New(failCA).Routes().ServeHTTP(rr, req)
+
+				Expect(rr.Code).To(Equal(http.StatusServiceUnavailable))
+			},
+			Entry("empty body, via AutoRenew", false),
+			Entry("CSR body, via Renew", true),
+		)
+
 		It("should return 403 when no client certificate is presented", func() {
 			renewCSR, err := testutil.GenerateCSR(subject)
 			Expect(err).NotTo(HaveOccurred())

--- a/internal/api/authseam_test.go
+++ b/internal/api/authseam_test.go
@@ -1,0 +1,106 @@
+// Copyright (C) 2026 Trevor Vaughan
+// Copyright (C) 2026 Vox Pupuli and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package api
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// SECURITY: the CSR signing path strips Puppet authorisation-arc OIDs from
+// submitted requests, so no agent can ask for pp_cli_auth. ca.AuthGrant is the
+// deliberate in-process exception, and ca.GenerateWithOptions is how it is
+// reached. Neither may be named from this package: an HTTP handler that
+// constructed a grant would put the escalation back exactly where the filter
+// exists to prevent it, and one that reached the options form could turn
+// POST /generate into a revoke-and-replace over the network.
+//
+// ca.Generate -- the narrow wrapper with no extension parameter -- is what this
+// package is meant to call, and is not in the forbidden set.
+//
+// This is a real gate rather than a convention, because the type system cannot
+// be one here: AuthGrant's fields are unexported and it has a single
+// constructor, which stops a value arriving from JSON or a query parameter, but
+// PpCliAuth and GenerateWithOptions are exported and this package already
+// imports internal/ca. Three lines in a handler would be enough.
+//
+// Scoped to this package's own files on purpose. Walking the transitive import
+// graph would need golang.org/x/tools (an indirect dependency today) or a Go
+// toolchain at test time, and would not catch anything this does not: the
+// escalation has to be written here to be reachable from a request.
+//
+// NIST 800-53: AC-6 (Least Privilege), CM-7 (Least Functionality)
+var _ = Describe("The authorisation-grant seam", func() {
+	forbidden := map[string]string{
+		"AuthGrant":           "constructing a grant here reintroduces the escalation the CSR filter prevents",
+		"PpCliAuth":           "only an operator at a terminal may mint an admin credential, never a request",
+		"GenerateOptions":     "the options form is the offline command's, not the API's",
+		"GenerateWithOptions": "use ca.Generate, which has no extension parameter by design",
+	}
+
+	It("is not reachable from any handler in this package", func() {
+		fset := token.NewFileSet()
+		entries, err := os.ReadDir(".")
+		Expect(err).NotTo(HaveOccurred())
+
+		var checked int
+		for _, entry := range entries {
+			name := entry.Name()
+			if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+				continue
+			}
+			checked++
+
+			file, err := parser.ParseFile(fset, filepath.Join(".", name), nil, 0)
+			Expect(err).NotTo(HaveOccurred(), name)
+
+			ast.Inspect(file, func(n ast.Node) bool {
+				sel, ok := n.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+				why, isForbidden := forbidden[sel.Sel.Name]
+				if !isForbidden {
+					return true
+				}
+
+				// Matched on the selector alone, deliberately. Checking that
+				// the receiver is the ca package would miss the method form:
+				// GenerateWithOptions is a method on *CA, so a handler writes
+				// s.CA.GenerateWithOptions(...), whose receiver is s.CA rather
+				// than the package identifier.
+				Fail(strings.Join([]string{
+					fset.Position(sel.Pos()).String() + " references " + sel.Sel.Name,
+					"Reason it is forbidden: " + why + ".",
+					"If this is deliberate, the security argument in internal/ca/authgrant.go",
+					"has to be revisited first -- not this test.",
+				}, "\n"))
+				return true
+			})
+		}
+
+		Expect(checked).To(BeNumerically(">", 0), "no source files were examined; the walk is not working")
+	})
+})

--- a/internal/api/authseam_test.go
+++ b/internal/api/authseam_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2026 Trevor Vaughan
+// Copyright (C) 2026 Chris Boot
 // Copyright (C) 2026 Vox Pupuli and contributors
 //
 // This program is free software; you can redistribute it and/or modify

--- a/internal/api/authseam_test.go
+++ b/internal/api/authseam_test.go
@@ -77,22 +77,33 @@ var _ = Describe("The authorisation-grant seam", func() {
 			Expect(err).NotTo(HaveOccurred(), name)
 
 			ast.Inspect(file, func(n ast.Node) bool {
-				sel, ok := n.(*ast.SelectorExpr)
-				if !ok {
+				// Both forms, because either would work in a handler:
+				//   ca.PpCliAuth()          -> SelectorExpr
+				//   s.CA.GenerateWithOptions -> SelectorExpr (receiver is s.CA,
+				//                               not the package, so match on Sel)
+				//   PpCliAuth()             -> bare Ident, under a dot-import
+				// The Ident case cannot arise today -- a dot-import of
+				// internal/ca into this package does not compile, because both
+				// export New -- so it is unexercised. It costs three lines and
+				// closes the hole that a future rename would open, which is
+				// cheaper than remembering to revisit this then.
+				var name string
+				var pos token.Pos
+				switch node := n.(type) {
+				case *ast.SelectorExpr:
+					name, pos = node.Sel.Name, node.Sel.Pos()
+				case *ast.Ident:
+					name, pos = node.Name, node.Pos()
+				default:
 					return true
 				}
-				why, isForbidden := forbidden[sel.Sel.Name]
+				why, isForbidden := forbidden[name]
 				if !isForbidden {
 					return true
 				}
 
-				// Matched on the selector alone, deliberately. Checking that
-				// the receiver is the ca package would miss the method form:
-				// GenerateWithOptions is a method on *CA, so a handler writes
-				// s.CA.GenerateWithOptions(...), whose receiver is s.CA rather
-				// than the package identifier.
 				Fail(strings.Join([]string{
-					fset.Position(sel.Pos()).String() + " references " + sel.Sel.Name,
+					fset.Position(pos).String() + " references " + name,
 					"Reason it is forbidden: " + why + ".",
 					"If this is deliberate, the security argument in internal/ca/authgrant.go",
 					"has to be revisited first -- not this test.",

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -944,6 +944,15 @@ func (s *Server) handlePostCertificateRenewal(w http.ResponseWriter, r *http.Req
 				http.Error(w, "certificate key does not meet policy; renew with a new CSR", http.StatusUnprocessableEntity)
 				return
 			}
+			// Both renewal paths take the same per-subject lock as signing, so
+			// they can lose it to another replica. That is transient and
+			// retryable, exactly as on /generate: answer 503 so an agent backs
+			// off rather than treating contention as a server fault.
+			if errors.Is(err, storage.ErrLockUnavailable) {
+				slog.Warn("Auto-renewal could not take the subject lock", "subject", cn, "error", err)
+				http.Error(w, "certificate authority busy, retry", http.StatusServiceUnavailable)
+				return
+			}
 			slog.Warn("Auto-renewal failed", "subject", cn, "error", err)
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 			return
@@ -972,6 +981,15 @@ func (s *Server) handlePostCertificateRenewal(w http.ResponseWriter, r *http.Req
 			if errors.Is(err, ca.ErrKeyPolicy) {
 				slog.Warn("Renewal rejected: key policy", "subject", cn, "error", err)
 				http.Error(w, "CSR key does not meet policy", http.StatusUnprocessableEntity)
+				return
+			}
+			// Both renewal paths take the same per-subject lock as signing, so
+			// they can lose it to another replica. That is transient and
+			// retryable, exactly as on /generate: answer 503 so an agent backs
+			// off rather than treating contention as a server fault.
+			if errors.Is(err, storage.ErrLockUnavailable) {
+				slog.Warn("Renewal could not take the subject lock", "subject", cn, "error", err)
+				http.Error(w, "certificate authority busy, retry", http.StatusServiceUnavailable)
 				return
 			}
 			slog.Warn("Renewal failed", "subject", cn, "error", err)

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -36,6 +36,7 @@ import (
 	"time"
 
 	"github.com/voxpupuli/openvox-ca/internal/ca"
+	"github.com/voxpupuli/openvox-ca/internal/storage"
 )
 
 // maxJSONBody caps the size of JSON request bodies accepted by the POST/PUT
@@ -510,10 +511,18 @@ func (s *Server) handlePostGenerate(w http.ResponseWriter, r *http.Request) {
 
 	result, err := s.CA.Generate(r.Context(), subject, dnsAltNames)
 	if err != nil {
-		if errors.Is(err, ca.ErrCertExists) {
+		switch {
+		case errors.Is(err, ca.ErrCertExists):
 			slog.Warn("Generate conflict", "subject", subject, "error", err)
 			http.Error(w, "certificate already exists", http.StatusConflict)
-		} else {
+		case errors.Is(err, storage.ErrLockUnavailable):
+			// Generate now serialises on the per-subject lock, so it can time
+			// out waiting for another replica. That is transient and retryable,
+			// not a fault: answer 503 so the client backs off rather than
+			// reporting it as a bug.
+			slog.Warn("Generate could not take the subject lock", "subject", subject, "error", err)
+			http.Error(w, "certificate authority busy, retry", http.StatusServiceUnavailable)
+		default:
 			slog.Error("Generate failed", "subject", subject, "error", err)
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 		}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -36,7 +36,6 @@ import (
 	"time"
 
 	"github.com/voxpupuli/openvox-ca/internal/ca"
-	"github.com/voxpupuli/openvox-ca/internal/storage"
 )
 
 // maxJSONBody caps the size of JSON request bodies accepted by the POST/PUT
@@ -511,18 +510,10 @@ func (s *Server) handlePostGenerate(w http.ResponseWriter, r *http.Request) {
 
 	result, err := s.CA.Generate(r.Context(), subject, dnsAltNames)
 	if err != nil {
-		switch {
-		case errors.Is(err, ca.ErrCertExists):
+		if errors.Is(err, ca.ErrCertExists) {
 			slog.Warn("Generate conflict", "subject", subject, "error", err)
 			http.Error(w, "certificate already exists", http.StatusConflict)
-		case errors.Is(err, storage.ErrLockUnavailable):
-			// Generate now serialises on the per-subject lock, so it can time
-			// out waiting for another replica. That is transient and retryable,
-			// not a fault: answer 503 so the client backs off rather than
-			// reporting it as a bug.
-			slog.Warn("Generate could not take the subject lock", "subject", subject, "error", err)
-			http.Error(w, "certificate authority busy, retry", http.StatusServiceUnavailable)
-		default:
+		} else {
 			slog.Error("Generate failed", "subject", subject, "error", err)
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 		}
@@ -944,15 +935,6 @@ func (s *Server) handlePostCertificateRenewal(w http.ResponseWriter, r *http.Req
 				http.Error(w, "certificate key does not meet policy; renew with a new CSR", http.StatusUnprocessableEntity)
 				return
 			}
-			// Both renewal paths take the same per-subject lock as signing, so
-			// they can lose it to another replica. That is transient and
-			// retryable, exactly as on /generate: answer 503 so an agent backs
-			// off rather than treating contention as a server fault.
-			if errors.Is(err, storage.ErrLockUnavailable) {
-				slog.Warn("Auto-renewal could not take the subject lock", "subject", cn, "error", err)
-				http.Error(w, "certificate authority busy, retry", http.StatusServiceUnavailable)
-				return
-			}
 			slog.Warn("Auto-renewal failed", "subject", cn, "error", err)
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 			return
@@ -981,15 +963,6 @@ func (s *Server) handlePostCertificateRenewal(w http.ResponseWriter, r *http.Req
 			if errors.Is(err, ca.ErrKeyPolicy) {
 				slog.Warn("Renewal rejected: key policy", "subject", cn, "error", err)
 				http.Error(w, "CSR key does not meet policy", http.StatusUnprocessableEntity)
-				return
-			}
-			// Both renewal paths take the same per-subject lock as signing, so
-			// they can lose it to another replica. That is transient and
-			// retryable, exactly as on /generate: answer 503 so an agent backs
-			// off rather than treating contention as a server fault.
-			if errors.Is(err, storage.ErrLockUnavailable) {
-				slog.Warn("Renewal could not take the subject lock", "subject", cn, "error", err)
-				http.Error(w, "certificate authority busy, retry", http.StatusServiceUnavailable)
 				return
 			}
 			slog.Warn("Renewal failed", "subject", cn, "error", err)

--- a/internal/ca/authgrant.go
+++ b/internal/ca/authgrant.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2026 Trevor Vaughan
+// Copyright (C) 2026 Chris Boot
 // Copyright (C) 2026 Vox Pupuli and contributors
 //
 // This program is free software; you can redistribute it and/or modify

--- a/internal/ca/authgrant.go
+++ b/internal/ca/authgrant.go
@@ -1,0 +1,119 @@
+// Copyright (C) 2026 Trevor Vaughan
+// Copyright (C) 2026 Vox Pupuli and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package ca
+
+import (
+	"encoding/asn1"
+	"errors"
+	"fmt"
+
+	"crypto/x509/pkix"
+)
+
+// ErrInvalidAuthGrant is returned when a GenerateOptions carries an AuthGrant
+// that no constructor produced, or the same OID twice.
+var ErrInvalidAuthGrant = errors.New("invalid authorisation grant")
+
+// AuthGrant is a Puppet authorisation-arc extension (1.3.6.1.4.1.34380.1.3.*)
+// that an in-process caller may ask GenerateWithOptions to stamp onto a
+// certificate.
+//
+// SECURITY: the CSR signing path strips this arc from submitted requests
+// (signWithDuration), because a CSR that could request pp_cli_auth would let
+// any agent ask for CA admin. This type is the deliberate exception to that,
+// and its shape is what keeps the exception narrow:
+//
+//   - the fields are unexported and there is exactly one constructor, so no
+//     value can arrive from a request body, a query parameter, a config file or
+//     encoding/json — reaching this seam takes a source-level call;
+//   - the value is a closed set, not an OID plus arbitrary bytes, so there is
+//     no "stamp whatever you like" path even for in-process callers.
+//
+// Both of those guard against accident, not against a determined refactor:
+// PpCliAuth and GenerateWithOptions are exported, and internal/api already
+// imports this package. What makes it a gate rather than a convention is the
+// spec in internal/api asserting that package never names either of them.
+//
+// NIST 800-53: AC-6 (Least Privilege), CM-7 (Least Functionality)
+type AuthGrant struct {
+	oid   asn1.ObjectIdentifier
+	value string
+}
+
+// PpCliAuth grants CA administrator access: pp_cli_auth with the UTF8String
+// value "true". A certificate carrying it is admin on this CA unless
+// no_pp_cli_auth is set, which is a great deal of authority for one boolean —
+// see the caller-side warnings in cmd/openvox-ca/generate.go.
+func PpCliAuth() AuthGrant {
+	return AuthGrant{oid: OIDPpCliAuth, value: "true"}
+}
+
+// String renders the grant for logs and operator-facing messages, using the
+// Puppet short name where one exists.
+func (g AuthGrant) String() string {
+	if len(g.oid) == 0 {
+		return "<invalid>"
+	}
+	return fmt.Sprintf("%s=%s", OIDKey(g.oid), g.value)
+}
+
+// extension encodes the grant as an X.509 extension.
+//
+// The value must be a UTF8String (DER tag 0x0c), not the PrintableString that
+// plain asn1.Marshal would emit for a Go string. internal/api's hasPpCliAuth
+// unmarshals into a string and would accept either, but Puppet emits UTF8String
+// and so does the openssl recipe this feature replaces; a certificate that
+// differs here looks identical in `openssl x509 -text` while potentially being
+// read differently by anything stricter.
+//
+// Not critical: a verifier that does not understand the OID must not reject the
+// certificate over it, which is how every other Puppet-arc extension behaves.
+func (g AuthGrant) extension() (pkix.Extension, error) {
+	if len(g.oid) == 0 {
+		return pkix.Extension{}, fmt.Errorf("%w: zero value, use a constructor such as PpCliAuth()", ErrInvalidAuthGrant)
+	}
+	value, err := asn1.MarshalWithParams(g.value, "utf8")
+	if err != nil {
+		return pkix.Extension{}, fmt.Errorf("encoding %s: %w", g, err)
+	}
+	return pkix.Extension{Id: g.oid, Critical: false, Value: value}, nil
+}
+
+// authGrantExtensions converts grants to extensions, rejecting zero values and
+// duplicate OIDs. Called before any key generation or storage access so a
+// malformed request costs nothing.
+func authGrantExtensions(grants []AuthGrant) ([]pkix.Extension, error) {
+	if len(grants) == 0 {
+		return nil, nil
+	}
+	exts := make([]pkix.Extension, 0, len(grants))
+	seen := make(map[string]struct{}, len(grants))
+	for _, g := range grants {
+		ext, err := g.extension()
+		if err != nil {
+			return nil, err
+		}
+		key := ext.Id.String()
+		if _, dup := seen[key]; dup {
+			return nil, fmt.Errorf("%w: %s requested more than once", ErrInvalidAuthGrant, OIDKey(ext.Id))
+		}
+		seen[key] = struct{}{}
+		exts = append(exts, ext)
+	}
+	return exts, nil
+}

--- a/internal/ca/ca.go
+++ b/internal/ca/ca.go
@@ -139,6 +139,19 @@ type CA struct {
 	// handle the SAN extension.
 	PromoteCNToSAN bool
 
+	// NoBootstrap makes Init refuse to create a new CA when none is found,
+	// rather than bootstrapping one. For tools that operate on an existing CA
+	// and have nothing sensible to do without it: minting a fresh root because
+	// a path was mistyped is far worse than an error, since the operator ends
+	// up with certificates nobody trusts and no obvious sign of why.
+	//
+	// This is a backstop, not a read-only mode. Init writes before it reaches
+	// the bootstrap decision — EnsureDirs, InitHMAC (which regenerates the
+	// inventory HMAC key if the stored one is the wrong length), and the CRL
+	// seeding on the load path — so a caller that must not touch storage at all
+	// has to check before calling Init, not rely on this.
+	NoBootstrap bool
+
 	// RevokeOnAutoRenew, when true (the default), revokes the certificate
 	// being replaced by AutoRenew (the empty-body /certificate_renewal path)
 	// once its successor is safely signed and stored, so only the newest

--- a/internal/ca/generate.go
+++ b/internal/ca/generate.go
@@ -302,7 +302,15 @@ func (c *CA) GenerateWithOptions(ctx context.Context, subject string, opts Gener
 					slog.Warn("Failed to clean up cert after private key save failure",
 						"subject", subject, "error", delErr)
 				}
-				return fmt.Errorf("failed to save private key for %s: %w", subject, err)
+				saveErr := fmt.Errorf("failed to save private key for %s: %w", subject, err)
+				if replacing {
+					// The rollback above leaves the subject with no certificate
+					// at all, while its predecessor is already on the CRL. That
+					// is the state the caller most needs told about, and the
+					// raw save error does not mention it.
+					return c.replacementFailed(subject, saveErr)
+				}
+				return saveErr
 			}
 
 			// SECURITY: Log that a private key has been persisted to server storage.

--- a/internal/ca/generate.go
+++ b/internal/ca/generate.go
@@ -19,7 +19,9 @@ package ca
 
 import (
 	"context"
+	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
 	"log/slog"
 	"regexp"
@@ -73,6 +75,12 @@ type GenerateOptions struct {
 	// TTL overrides the certificate lifetime. Zero means the configured
 	// LeafValidityDays, or the built-in default when that is unset.
 	TTL time.Duration
+
+	// ReplaceExisting revokes the certificate currently stored for the subject
+	// and issues a replacement, rather than failing with ErrCertExists. It is
+	// not an error when there is nothing to replace: the job is to end with a
+	// certificate, not to remove one.
+	ReplaceExisting bool
 
 	// RetainPrivateKeyInStorage saves the generated key to
 	// private/{subject}_key.pem. The zero value does not: a key the CA has no
@@ -202,20 +210,77 @@ func (c *CA) GenerateWithOptions(ctx context.Context, subject string, opts Gener
 
 	var result *GenerateResult
 	lockErr := c.Storage.WithLock(ctx, subjectLockName(subject), func() error {
+		// Read phase. Its own closure because c.mu must not be held across the
+		// nested CRL lock below: c.mu is a non-reentrant RWMutex, and every
+		// lockNameCRL acquisition in this package takes the distributed lock
+		// first and c.mu second. Holding c.mu across WithLock would invert that
+		// ordering against RefreshCRLIfDue and Revoke.
+		serial, replacing, err := func() (string, bool, error) {
+			c.mu.Lock()
+			defer c.mu.Unlock()
+
+			// Re-read the CRL under the lock. evictRevokedLocked decides whether an
+			// existing certificate may be replaced by consulting c.cachedCRL, which
+			// is otherwise only ever populated at Init and by this process's own
+			// revocations. Without this, a subject revoked by another replica after
+			// our Init is invisible here and we answer ErrCertExists where we should
+			// evict and re-issue.
+			if err := c.loadCRLCache(ctx); err != nil {
+				return "", false, fmt.Errorf("refreshing CRL cache for %s: %w", subject, err)
+			}
+			if !opts.ReplaceExisting || !c.Storage.HasCert(ctx, subject) {
+				return "", false, nil
+			}
+			s, err := c.storedCertSerialLocked(ctx, subject)
+			if err != nil {
+				return "", false, err
+			}
+			return s, true, nil
+		}()
+		if err != nil {
+			return err
+		}
+
+		// Revoke phase. CRL lock outside c.mu, matching AutoRenew.
+		//
+		// The serial comes from the stored certificate, not from
+		// LatestSerialForSubject: revokeLocked resolves the latter, and
+		// revoke.go warns against exactly that for replacement paths, because
+		// the inventory's newest row for a subject and the certificate actually
+		// in storage can differ. Revoking the wrong serial is irreversible.
+		if replacing {
+			if err := c.Storage.WithLock(ctx, lockNameCRL, func() error {
+				c.mu.Lock()
+				defer c.mu.Unlock()
+				return c.revokeSerialLocked(ctx, serial)
+			}); err != nil {
+				// Fail closed. Clean logs and continues here because it is
+				// removing the certificate either way; a replacement path that
+				// did the same would leave two live certificates for one
+				// subject, which is what the subject lock exists to prevent.
+				return fmt.Errorf("could not revoke the existing certificate for %s, "+
+					"so no replacement was issued: %w", subject, err)
+			}
+		}
+
+		// Issue phase.
 		c.mu.Lock()
 		defer c.mu.Unlock()
 
-		// Re-read the CRL under the lock. evictRevokedLocked decides whether an
-		// existing certificate may be replaced by consulting c.cachedCRL, which
-		// is otherwise only ever populated at Init and by this process's own
-		// revocations. Without this, a subject revoked by another replica after
-		// our Init is invisible here and we answer ErrCertExists where we should
-		// evict and re-issue.
-		if err := c.loadCRLCache(ctx); err != nil {
-			return fmt.Errorf("refreshing CRL cache for %s: %w", subject, err)
+		if replacing {
+			// signCRLLocked refreshes the cache when it appends, but
+			// revokeSerialLocked returns early without calling it when the
+			// serial was already on the CRL. Re-read so evictRevokedLocked sees
+			// the revocation either way.
+			if err := c.loadCRLCache(ctx); err != nil {
+				return c.replacementFailed(subject, fmt.Errorf("refreshing CRL cache: %w", err))
+			}
 		}
 
 		if err := c.evictRevokedLocked(ctx, subject); err != nil {
+			if replacing {
+				return c.replacementFailed(subject, err)
+			}
 			return err
 		}
 
@@ -223,6 +288,9 @@ func (c *CA) GenerateWithOptions(ctx context.Context, subject string, opts Gener
 			pkix.Name{CommonName: subject}, key.Public(),
 			subjectAltNames{DNSNames: dnsNames}, extraExtensions, opts.TTL)
 		if err != nil {
+			if replacing {
+				return c.replacementFailed(subject, err)
+			}
 			return err
 		}
 
@@ -278,4 +346,44 @@ func (c *CA) GenerateWithOptions(ctx context.Context, subject string, opts Gener
 		return nil, lockErr
 	}
 	return result, nil
+}
+
+// storedCertSerialLocked returns the serial of the certificate currently stored
+// for subject, for a replacement to revoke. c.mu must be held.
+//
+// The stored certificate is the authority here, not the inventory: that is what
+// evictRevokedLocked consults, and revoking anything else would put a serial on
+// the CRL that does not correspond to the credential being retired.
+func (c *CA) storedCertSerialLocked(ctx context.Context, subject string) (string, error) {
+	certPEM, err := c.Storage.GetCert(ctx, subject)
+	if err != nil {
+		return "", fmt.Errorf("reading the stored certificate for %s: %w", subject, err)
+	}
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		// Do not fall through to issuance. evictRevokedLocked also fails an
+		// unparseable certificate, but it does so with ErrCertExists, whose
+		// remedy is "pass --force" -- which is what the operator just did. Say
+		// something they can act on instead.
+		return "", fmt.Errorf("the stored certificate for %s cannot be decoded; remove it with "+
+			"'openvox-ca-ctl clean --certname %s' and retry", subject, subject)
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return "", fmt.Errorf("the stored certificate for %s cannot be parsed (%v); remove it with "+
+			"'openvox-ca-ctl clean --certname %s' and retry", subject, err, subject)
+	}
+	return serialHexStr(cert.SerialNumber), nil
+}
+
+// replacementFailed wraps a failure that happens after the old certificate has
+// already been revoked.
+//
+// This state is not recoverable by retrying blindly: CRL entries are only ever
+// appended, so the predecessor stays revoked whatever happens next. Surfacing
+// the bare error would be worse than unhelpful for ErrCertExists, whose message
+// tells the operator to pass --force -- which is how they got here.
+func (c *CA) replacementFailed(subject string, err error) error {
+	return fmt.Errorf("the existing certificate for %s was revoked, but no replacement was issued: %w."+
+		"\nThat revocation cannot be undone. Re-run to issue a replacement", subject, err)
 }

--- a/internal/ca/generate.go
+++ b/internal/ca/generate.go
@@ -19,13 +19,11 @@ package ca
 
 import (
 	"context"
-	"crypto/rand"
-	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/pem"
 	"fmt"
 	"log/slog"
 	"regexp"
+	"time"
 )
 
 // maxDNSAltNames is the maximum number of DNS alt names allowed per certificate.
@@ -61,9 +59,51 @@ type GenerateResult struct {
 	CertificatePEM []byte
 }
 
+// GenerateOptions controls a server-side certificate generation.
+type GenerateOptions struct {
+	// DNSAltNames are added as subjectAltName DNS entries. When empty and
+	// PromoteCNToSAN is set, the subject is promoted to a SAN instead.
+	DNSAltNames []string
+
+	// AuthGrants are Puppet authorisation-arc extensions to stamp onto the
+	// certificate. These bypass the filter the CSR path applies to submitted
+	// requests; see AuthGrant for why that is safe here and what keeps it so.
+	AuthGrants []AuthGrant
+
+	// TTL overrides the certificate lifetime. Zero means the configured
+	// LeafValidityDays, or the built-in default when that is unset.
+	TTL time.Duration
+
+	// RetainPrivateKeyInStorage saves the generated key to
+	// private/{subject}_key.pem. The zero value does not: a key the CA has no
+	// use for is a liability, and this path is always the local filesystem
+	// regardless of the configured backend, so on an ephemeral cadir the copy
+	// is lost at the next restart anyway. Generate opts in for wire
+	// compatibility with the API, which has always left a copy.
+	RetainPrivateKeyInStorage bool
+
+	// EmitKey, when set, receives the freshly generated private key in PEM form
+	// after it is generated and BEFORE anything destructive or persistent
+	// happens -- before the subject lock is taken, before any revocation, and
+	// before issuance. A non-nil error from it aborts the call having changed
+	// nothing.
+	//
+	// This lets a caller put the key somewhere durable first. It matters for
+	// replacement: once the certificate being replaced is revoked, a failure to
+	// write the key would leave the subject with no usable credential and its
+	// previous one on the CRL, and CRL entries cannot be withdrawn. Passing the
+	// bytes out rather than accepting a path keeps this package out of the
+	// business of knowing where an operator wants their key.
+	EmitKey func(keyPEM []byte) error
+}
+
 // Generate creates a fresh key pair for subject, signs a certificate for it
 // without requiring a client-submitted CSR, saves the private key to
 // private/{subject}_key.pem, and returns both PEMs.
+//
+// This is the network-reachable form, called by the /generate handler. Its
+// signature deliberately has no extension parameter: an HTTP caller must not be
+// able to reach the AuthGrants seam, and cannot without a source change here.
 //
 // The key algorithm and size are controlled by CA.LeafKeyConfig; defaults
 // to RSA 2048 when not set.
@@ -71,12 +111,47 @@ type GenerateResult struct {
 // Returns ErrCertExists (wrapped) if a valid (non-revoked) certificate already
 // exists for subject.
 func (c *CA) Generate(ctx context.Context, subject string, dnsAltNames []string) (*GenerateResult, error) {
+	return c.GenerateWithOptions(ctx, subject, GenerateOptions{
+		DNSAltNames:               dnsAltNames,
+		RetainPrivateKeyInStorage: true,
+	})
+}
+
+// GenerateWithOptions is Generate with the knobs the offline CLI needs.
+//
+// Unlike the old implementation it does not build an internal CSR and feed it
+// back through the signing path. That round trip existed only so sign() could
+// be reused, and it had two costs: the auth-OID filter meant for submitted
+// requests also applied to certificates this CA generated for itself, and the
+// CSR was briefly visible in storage where a concurrent "sign all" could pick
+// it up and issue a second certificate for the subject. Calling issueLeafLocked
+// directly removes both, and keeps the filter exactly where it belongs -- on
+// the path that parses network input.
+func (c *CA) GenerateWithOptions(ctx context.Context, subject string, opts GenerateOptions) (*GenerateResult, error) {
 	if err := ValidateSubject(subject); err != nil {
 		return nil, err
 	}
 
 	// Validate DNS alt names: must be valid hostnames, bounded count and length.
-	if err := validateDNSAltNames(dnsAltNames); err != nil {
+	if err := validateDNSAltNames(opts.DNSAltNames); err != nil {
+		return nil, err
+	}
+
+	// Fail fast on an uninitialised CA. issueLeafLocked carries the
+	// authoritative guard, but it is now reached after the CRL cache refresh,
+	// which on an uninitialised CA fails first with a "reading CRL" error --
+	// losing the sentinel callers use to tell "not ready yet" from "broken".
+	c.mu.RLock()
+	initialised := c.CACert != nil && c.CAKey != nil
+	c.mu.RUnlock()
+	if !initialised {
+		return nil, ErrNotInitialized
+	}
+
+	// Encode the grants before generating a key, so a malformed request costs
+	// nothing.
+	extraExtensions, err := authGrantExtensions(opts.AuthGrants)
+	if err != nil {
 		return nil, err
 	}
 
@@ -86,29 +161,39 @@ func (c *CA) Generate(ctx context.Context, subject string, dnsAltNames []string)
 		leafCfg = DefaultLeafKeyConfig
 	}
 
-	// Key generation and CSR creation are CPU-bound and do not touch shared
-	// state, so they run outside the lock.
+	// Key generation is CPU-bound and touches no shared state, so it runs
+	// outside the lock. generateKey validates the config, so an off-policy
+	// algorithm or size fails here, before anything is written.
 	key, err := generateKey(leafCfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate key for %s: %w", subject, err)
 	}
 
-	// Build an internal CSR so sign() can process it normally.
-	csrTemplate := &x509.CertificateRequest{
-		Subject:  pkix.Name{CommonName: subject},
-		DNSNames: dnsAltNames,
-	}
-	csrDER, err := x509.CreateCertificateRequest(rand.Reader, csrTemplate, key)
+	keyPEM, err := marshalPrivateKeyPEM(key)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create internal CSR for %s: %w", subject, err)
+		return nil, fmt.Errorf("failed to marshal private key for %s: %w", subject, err)
 	}
-	csrPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER})
+
+	// Hand the key to the caller before anything irreversible happens.
+	if opts.EmitKey != nil {
+		if err := opts.EmitKey(keyPEM); err != nil {
+			return nil, err
+		}
+	}
+
+	// RFC 2818 3.1: TLS clients match the name against SANs, not the CN. The
+	// CSR path promotes the CN when a request carries no SANs; do the same here
+	// so a generated certificate behaves identically to a signed one.
+	dnsNames := opts.DNSAltNames
+	if c.PromoteCNToSAN && len(dnsNames) == 0 {
+		dnsNames = []string{subject}
+	}
 
 	// Serialise on the cluster-wide per-subject lock, as every other issuance
 	// path does (Sign, SignWithTTL, SaveRequest, Renew, Clean,
-	// ImportCertificate). Generate was the only one holding just c.mu, which
-	// coordinates nothing between processes — so two replicas, or a replica and
-	// an operator running an offline subcommand, could each pass
+	// ImportCertificate). Generate used to hold just c.mu, which coordinates
+	// nothing between processes -- so two replicas, or a replica and an
+	// operator running an offline subcommand, could each pass
 	// evictRevokedLocked and both issue for the same subject.
 	//
 	// Lock ordering: subject-lock (distributed) -> c.mu, matching Sign.
@@ -134,37 +219,54 @@ func (c *CA) Generate(ctx context.Context, subject string, dnsAltNames []string)
 			return err
 		}
 
-		if err := c.Storage.SaveCSR(ctx, subject, csrPEM); err != nil {
-			return fmt.Errorf("failed to save internal CSR for %s: %w", subject, err)
+		certPEM, err := c.issueLeafLocked(ctx, subject,
+			pkix.Name{CommonName: subject}, key.Public(),
+			subjectAltNames{DNSNames: dnsNames}, extraExtensions, opts.TTL)
+		if err != nil {
+			return err
 		}
 
-		certPEM, err := c.sign(ctx, subject)
-		if err != nil {
-			_ = c.Storage.DeleteCSR(ctx, subject)
-			return fmt.Errorf("failed to sign generated cert for %s: %w", subject, err)
-		}
-
-		// Encode and save the private key.
-		keyPEM, err := marshalPrivateKeyPEM(key)
-		if err != nil {
-			return fmt.Errorf("failed to marshal private key for %s: %w", subject, err)
-		}
-		if err := c.Storage.SavePrivateKey(ctx, subject, keyPEM); err != nil {
-			// Clean up the just-issued certificate to avoid inconsistent state
-			// where a cert exists on disk but the corresponding private key doesn't.
-			if delErr := c.Storage.DeleteCert(ctx, subject); delErr != nil {
-				slog.Warn("Failed to clean up cert after private key save failure",
-					"subject", subject, "error", delErr)
+		if opts.RetainPrivateKeyInStorage {
+			if err := c.Storage.SavePrivateKey(ctx, subject, keyPEM); err != nil {
+				// Clean up the just-issued certificate to avoid inconsistent state
+				// where a cert exists on disk but the corresponding private key doesn't.
+				if delErr := c.Storage.DeleteCert(ctx, subject); delErr != nil {
+					slog.Warn("Failed to clean up cert after private key save failure",
+						"subject", subject, "error", delErr)
+				}
+				return fmt.Errorf("failed to save private key for %s: %w", subject, err)
 			}
-			return fmt.Errorf("failed to save private key for %s: %w", subject, err)
+
+			// SECURITY: Log that a private key has been persisted to server storage.
+			// Generated keys remain on disk indefinitely; operators should implement
+			// external lifecycle controls (rotation, cleanup) for these keys.
+			// NIST 800-53: SC-12 (Cryptographic Key Establishment and Management)
+			slog.Debug("Generated private key persisted to server filesystem",
+				"subject", subject, "path", c.Storage.PrivateKeyPath(subject))
 		}
 
-		// SECURITY: Log that a private key has been persisted to server storage.
-		// Generated keys remain on disk indefinitely; operators should implement
-		// external lifecycle controls (rotation, cleanup) for these keys.
-		// NIST 800-53: SC-12 (Cryptographic Key Establishment and Management)
-		slog.Debug("Generated private key persisted to server filesystem",
-			"subject", subject, "path", c.Storage.PrivateKeyPath(subject))
+		// A pending CSR for this subject would otherwise survive and stay
+		// signable, yielding a second certificate for a name that already has
+		// one. The old implementation destroyed it as a side effect of
+		// overwriting the CSR slot with its own; do it deliberately instead.
+		if c.Storage.HasCSR(ctx, subject) {
+			if err := c.Storage.DeleteCSR(ctx, subject); err != nil {
+				slog.Warn("Could not remove pending CSR superseded by generation",
+					"subject", subject, "error", err)
+			} else {
+				slog.Debug("Removed pending CSR superseded by generation", "subject", subject)
+			}
+		}
+
+		for _, g := range opts.AuthGrants {
+			// SECURITY: an authorisation grant is the most privileged thing this
+			// CA issues. Logged here rather than at the call site so it is
+			// recorded whoever reaches this seam.
+			// NIST 800-53: AC-6 (Least Privilege), AU-2 (Event Logging)
+			slog.Warn("Issued certificate carrying a Puppet authorisation extension",
+				"subject", subject, "grant", g.String())
+		}
+
 		slog.Debug("Certificate generated", "subject", subject, "algo", string(leafCfg.Algo))
 		result = &GenerateResult{
 			PrivateKeyPEM:  keyPEM,

--- a/internal/ca/generate.go
+++ b/internal/ca/generate.go
@@ -104,49 +104,76 @@ func (c *CA) Generate(ctx context.Context, subject string, dnsAltNames []string)
 	}
 	csrPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER})
 
-	// Acquire lock for the entire evict + save + sign sequence to prevent
-	// TOCTOU races.
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	// Serialise on the cluster-wide per-subject lock, as every other issuance
+	// path does (Sign, SignWithTTL, SaveRequest, Renew, Clean,
+	// ImportCertificate). Generate was the only one holding just c.mu, which
+	// coordinates nothing between processes — so two replicas, or a replica and
+	// an operator running an offline subcommand, could each pass
+	// evictRevokedLocked and both issue for the same subject.
+	//
+	// Lock ordering: subject-lock (distributed) -> c.mu, matching Sign.
+	ctx, cancel := context.WithTimeout(ctx, lockTimeout)
+	defer cancel()
 
-	if err := c.evictRevokedLocked(ctx, subject); err != nil {
-		return nil, err
-	}
+	var result *GenerateResult
+	lockErr := c.Storage.WithLock(ctx, subjectLockName(subject), func() error {
+		c.mu.Lock()
+		defer c.mu.Unlock()
 
-	if err := c.Storage.SaveCSR(ctx, subject, csrPEM); err != nil {
-		return nil, fmt.Errorf("failed to save internal CSR for %s: %w", subject, err)
-	}
-
-	certPEM, err := c.sign(ctx, subject)
-	if err != nil {
-		_ = c.Storage.DeleteCSR(ctx, subject)
-		return nil, fmt.Errorf("failed to sign generated cert for %s: %w", subject, err)
-	}
-
-	// Encode and save the private key.
-	keyPEM, err := marshalPrivateKeyPEM(key)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal private key for %s: %w", subject, err)
-	}
-	if err := c.Storage.SavePrivateKey(ctx, subject, keyPEM); err != nil {
-		// Clean up the just-issued certificate to avoid inconsistent state
-		// where a cert exists on disk but the corresponding private key doesn't.
-		if delErr := c.Storage.DeleteCert(ctx, subject); delErr != nil {
-			slog.Warn("Failed to clean up cert after private key save failure",
-				"subject", subject, "error", delErr)
+		// Re-read the CRL under the lock. evictRevokedLocked decides whether an
+		// existing certificate may be replaced by consulting c.cachedCRL, which
+		// is otherwise only ever populated at Init and by this process's own
+		// revocations. Without this, a subject revoked by another replica after
+		// our Init is invisible here and we answer ErrCertExists where we should
+		// evict and re-issue.
+		if err := c.loadCRLCache(ctx); err != nil {
+			return fmt.Errorf("refreshing CRL cache for %s: %w", subject, err)
 		}
-		return nil, fmt.Errorf("failed to save private key for %s: %w", subject, err)
-	}
 
-	// SECURITY: Log that a private key has been persisted to server storage.
-	// Generated keys remain on disk indefinitely; operators should implement
-	// external lifecycle controls (rotation, cleanup) for these keys.
-	// NIST 800-53: SC-12 (Cryptographic Key Establishment and Management)
-	slog.Debug("Generated private key persisted to server filesystem",
-		"subject", subject, "path", c.Storage.PrivateKeyPath(subject))
-	slog.Debug("Certificate generated", "subject", subject, "algo", string(leafCfg.Algo))
-	return &GenerateResult{
-		PrivateKeyPEM:  keyPEM,
-		CertificatePEM: certPEM,
-	}, nil
+		if err := c.evictRevokedLocked(ctx, subject); err != nil {
+			return err
+		}
+
+		if err := c.Storage.SaveCSR(ctx, subject, csrPEM); err != nil {
+			return fmt.Errorf("failed to save internal CSR for %s: %w", subject, err)
+		}
+
+		certPEM, err := c.sign(ctx, subject)
+		if err != nil {
+			_ = c.Storage.DeleteCSR(ctx, subject)
+			return fmt.Errorf("failed to sign generated cert for %s: %w", subject, err)
+		}
+
+		// Encode and save the private key.
+		keyPEM, err := marshalPrivateKeyPEM(key)
+		if err != nil {
+			return fmt.Errorf("failed to marshal private key for %s: %w", subject, err)
+		}
+		if err := c.Storage.SavePrivateKey(ctx, subject, keyPEM); err != nil {
+			// Clean up the just-issued certificate to avoid inconsistent state
+			// where a cert exists on disk but the corresponding private key doesn't.
+			if delErr := c.Storage.DeleteCert(ctx, subject); delErr != nil {
+				slog.Warn("Failed to clean up cert after private key save failure",
+					"subject", subject, "error", delErr)
+			}
+			return fmt.Errorf("failed to save private key for %s: %w", subject, err)
+		}
+
+		// SECURITY: Log that a private key has been persisted to server storage.
+		// Generated keys remain on disk indefinitely; operators should implement
+		// external lifecycle controls (rotation, cleanup) for these keys.
+		// NIST 800-53: SC-12 (Cryptographic Key Establishment and Management)
+		slog.Debug("Generated private key persisted to server filesystem",
+			"subject", subject, "path", c.Storage.PrivateKeyPath(subject))
+		slog.Debug("Certificate generated", "subject", subject, "algo", string(leafCfg.Algo))
+		result = &GenerateResult{
+			PrivateKeyPEM:  keyPEM,
+			CertificatePEM: certPEM,
+		}
+		return nil
+	})
+	if lockErr != nil {
+		return nil, lockErr
+	}
+	return result, nil
 }

--- a/internal/ca/generate_test.go
+++ b/internal/ca/generate_test.go
@@ -21,16 +21,21 @@ import (
 	"context"
 	"crypto/rsa"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/pem"
 	"errors"
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"golang.org/x/crypto/ocsp"
+
 	"github.com/voxpupuli/openvox-ca/internal/ca"
 	"github.com/voxpupuli/openvox-ca/internal/storage"
+	"github.com/voxpupuli/openvox-ca/internal/testutil"
 )
 
 // recordingLockBackend wraps a Backend and implements storage.Locker, recording
@@ -254,6 +259,222 @@ var _ = Describe("CA Generate", func() {
 			_, err = myCA.Generate(ctx, "stale-crl-node", nil)
 			Expect(err).NotTo(HaveOccurred(),
 				"a subject revoked elsewhere must be evictable, not reported as still valid")
+		})
+	})
+})
+
+var _ = Describe("CA GenerateWithOptions", func() {
+	var (
+		ctx    context.Context
+		tmpDir string
+		myCA   *ca.CA
+		store  *storage.StorageService
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		var err error
+		tmpDir, err = os.MkdirTemp("", "openvox-ca-genopts-test")
+		Expect(err).NotTo(HaveOccurred())
+
+		store = storage.New(tmpDir)
+		myCA = ca.New(store, ca.AutosignConfig{Mode: "off"}, "puppet.test")
+
+		Expect(store.EnsureDirs(ctx)).To(Succeed())
+		Expect(store.SaveCAKey(ctx, cachedKeyPEM)).To(Succeed())
+		Expect(store.SaveCACert(ctx, cachedCrtPEM)).To(Succeed())
+		Expect(store.UpdateCRL(ctx, cachedCrlPEM)).To(Succeed())
+		Expect(store.WriteSerial(ctx, "0001")).To(Succeed())
+		Expect(store.TouchInventory(ctx)).To(Succeed())
+		Expect(myCA.Init(ctx)).To(Succeed())
+	})
+
+	AfterEach(func() { os.RemoveAll(tmpDir) })
+
+	certFrom := func(r *ca.GenerateResult) *x509.Certificate {
+		block, _ := pem.Decode(r.CertificatePEM)
+		Expect(block).NotTo(BeNil())
+		cert, err := x509.ParseCertificate(block.Bytes)
+		Expect(err).NotTo(HaveOccurred())
+		return cert
+	}
+
+	Describe("authorisation grants", func() {
+		It("stamps no authorisation OID when none is requested", func() {
+			result, err := myCA.GenerateWithOptions(ctx, "plain-node", ca.GenerateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			for _, ext := range certFrom(result).Extensions {
+				Expect(ca.IsAuthOID(ext.Id)).To(BeFalse(),
+					"the default path must never produce an authorisation extension")
+			}
+		})
+
+		It("stamps pp_cli_auth as a non-critical UTF8String \"true\"", func() {
+			result, err := myCA.GenerateWithOptions(ctx, "admin-node", ca.GenerateOptions{
+				AuthGrants: []ca.AuthGrant{ca.PpCliAuth()},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			var found *pkix.Extension
+			for i, ext := range certFrom(result).Extensions {
+				if ext.Id.Equal(ca.OIDPpCliAuth) {
+					found = &certFrom(result).Extensions[i]
+					break
+				}
+			}
+			Expect(found).NotTo(BeNil(), "pp_cli_auth must be present when granted")
+
+			// Pin the DER, not the decoded string. encoding/asn1 will happily
+			// unmarshal a PrintableString into a Go string, so a regression to
+			// plain asn1.Marshal would still read back as "true" here while
+			// producing a certificate that differs on the wire from Puppet's
+			// and from the openssl recipe this replaces.
+			Expect(found.Value).To(Equal([]byte{0x0c, 0x04, 't', 'r', 'u', 'e'}))
+			Expect(found.Critical).To(BeFalse())
+		})
+
+		It("rejects a zero-value AuthGrant", func() {
+			// ca.AuthGrant is exported, so a zero value is constructible from
+			// another package even though its fields are not. It must be inert.
+			_, err := myCA.GenerateWithOptions(ctx, "zero-grant-node", ca.GenerateOptions{
+				AuthGrants: []ca.AuthGrant{{}},
+			})
+			Expect(err).To(MatchError(ca.ErrInvalidAuthGrant))
+			Expect(store.HasCert(ctx, "zero-grant-node")).To(BeFalse())
+		})
+
+		It("rejects the same grant twice", func() {
+			_, err := myCA.GenerateWithOptions(ctx, "dup-grant-node", ca.GenerateOptions{
+				AuthGrants: []ca.AuthGrant{ca.PpCliAuth(), ca.PpCliAuth()},
+			})
+			Expect(err).To(MatchError(ca.ErrInvalidAuthGrant))
+			Expect(store.HasCert(ctx, "dup-grant-node")).To(BeFalse())
+		})
+	})
+
+	Describe("private key handling", func() {
+		It("does not retain the key in storage by default", func() {
+			_, err := myCA.GenerateWithOptions(ctx, "no-retain-node", ca.GenerateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			_, statErr := os.Stat(store.PrivateKeyPath("no-retain-node"))
+			Expect(os.IsNotExist(statErr)).To(BeTrue(),
+				"the CA has no use for this key; leaving it is a liability")
+		})
+
+		It("retains the key when asked, which is what the API path does", func() {
+			_, err := myCA.GenerateWithOptions(ctx, "retain-node", ca.GenerateOptions{
+				RetainPrivateKeyInStorage: true,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(store.PrivateKeyPath("retain-node")).To(BeAnExistingFile())
+		})
+
+		It("emits the key before issuing anything", func() {
+			var emitted []byte
+			_, err := myCA.GenerateWithOptions(ctx, "emit-node", ca.GenerateOptions{
+				EmitKey: func(keyPEM []byte) error {
+					// Nothing may exist yet: the whole point is that a caller
+					// can put the key somewhere durable before this CA commits.
+					Expect(store.HasCert(ctx, "emit-node")).To(BeFalse())
+					emitted = keyPEM
+					return nil
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(emitted).To(ContainSubstring("PRIVATE KEY"))
+		})
+
+		It("issues nothing when EmitKey fails", func() {
+			_, err := myCA.GenerateWithOptions(ctx, "emit-fail-node", ca.GenerateOptions{
+				EmitKey: func([]byte) error { return errors.New("disk full") },
+			})
+			Expect(err).To(MatchError(ContainSubstring("disk full")))
+			Expect(store.HasCert(ctx, "emit-fail-node")).To(BeFalse(),
+				"a key the caller could not keep must not leave a certificate behind")
+		})
+	})
+
+	Describe("consequences of not round-tripping through a CSR", func() {
+		It("leaves no pending CSR behind", func() {
+			_, err := myCA.GenerateWithOptions(ctx, "no-csr-node", ca.GenerateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(store.HasCSR(ctx, "no-csr-node")).To(BeFalse())
+			csrs, err := store.ListCSRs(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(csrs).To(BeEmpty(), "a CSR left in storage is signable into a second certificate")
+		})
+
+		It("removes an agent's pending CSR for the same subject", func() {
+			// The old implementation destroyed it as a side effect of
+			// overwriting the CSR slot. Without deliberate deletion it would
+			// now survive, and a later sign --all would mint a second
+			// certificate for a name that already has one.
+			Expect(store.SaveCSR(ctx, "pending-node", []byte("-----BEGIN CERTIFICATE REQUEST-----\nstale\n-----END CERTIFICATE REQUEST-----\n"))).To(Succeed())
+			Expect(store.HasCSR(ctx, "pending-node")).To(BeTrue())
+
+			_, err := myCA.GenerateWithOptions(ctx, "pending-node", ca.GenerateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(store.HasCSR(ctx, "pending-node")).To(BeFalse())
+		})
+
+		It("promotes the subject to a DNS SAN when no alt names are given", func() {
+			result, err := myCA.GenerateWithOptions(ctx, "promoted-node", ca.GenerateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(certFrom(result).DNSNames).To(ConsistOf("promoted-node"))
+		})
+
+		It("does not promote the subject when alt names are given", func() {
+			result, err := myCA.GenerateWithOptions(ctx, "san-node", ca.GenerateOptions{
+				DNSAltNames: []string{"alt.example.com"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(certFrom(result).DNSNames).To(ConsistOf("alt.example.com"))
+		})
+
+		It("records the certificate in the inventory and the serial index", func() {
+			// The issue this feature exists for is that the openssl workaround
+			// produced a certificate the CA could not see or revoke. Prove this
+			// one is tracked on both counts.
+			result, err := myCA.GenerateWithOptions(ctx, "tracked-node", ca.GenerateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			cert := certFrom(result)
+
+			inv, err := store.ReadInventory(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(inv)).To(ContainSubstring("/tracked-node"))
+
+			// serialIndex is not directly observable; OCSP is where it shows.
+			req, err := testutil.BuildOCSPRequest(cert, myCA.CACert)
+			Expect(err).NotTo(HaveOccurred())
+			respDER, err := myCA.OCSPResponse(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			resp, err := ocsp.ParseResponse(respDER, myCA.CACert)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.Status).To(Equal(ocsp.Good),
+				"a serial missing from the index answers Unknown, not Good")
+
+			Expect(myCA.Revoke(ctx, "tracked-node")).To(Succeed())
+		})
+
+		It("honours an explicit TTL", func() {
+			// Kept well under the test CA's own hour of remaining life:
+			// issueLeafLocked caps a leaf at the issuer's expiry, so a longer
+			// TTL here would be measuring the cap rather than the option.
+			result, err := myCA.GenerateWithOptions(ctx, "ttl-node", ca.GenerateOptions{
+				TTL: 10 * time.Minute,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(certFrom(result).NotAfter).To(BeTemporally("~", time.Now().Add(10*time.Minute), time.Minute))
+		})
+
+		It("returns ErrNotInitialized when Init was not called", func() {
+			bare := ca.New(storage.New(GinkgoT().TempDir()), ca.AutosignConfig{Mode: "off"}, "puppet.test")
+			_, err := bare.GenerateWithOptions(ctx, "uninit-node", ca.GenerateOptions{})
+			Expect(err).To(MatchError(ca.ErrNotInitialized))
 		})
 	})
 })

--- a/internal/ca/generate_test.go
+++ b/internal/ca/generate_test.go
@@ -240,6 +240,46 @@ var _ = Describe("CA Generate", func() {
 			Expect(rec.names()).To(ContainElement("subject:locked-node"),
 				"Generate must serialise on the same per-subject lock Sign and Clean use")
 		})
+
+		It("takes the subject lock before the CRL lock when replacing", func() {
+			// The documented ordering is subject-lock -> CRL-lock -> c.mu, and
+			// every lockNameCRL acquisition in this package follows it. Taking
+			// them the other way round would deadlock against RefreshCRLIfDue.
+			// The concurrent smoke test alongside this cannot pin the ordering
+			// -- it has no barrier forcing the hazardous interleaving -- so pin
+			// the sequence directly.
+			ctx := context.Background()
+
+			rec := &recordingLockBackend{Backend: storage.NewFilesystemBackend(tmpDir)}
+			recStore := storage.NewWithBackend(rec, filepath.Join(tmpDir, "private"))
+			recCA := ca.New(recStore, ca.AutosignConfig{Mode: "off"}, "puppet.test")
+			Expect(recCA.Init(ctx)).To(Succeed())
+
+			_, err := recCA.GenerateWithOptions(ctx, "order-node", ca.GenerateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			rec.reset()
+			_, err = recCA.GenerateWithOptions(ctx, "order-node", ca.GenerateOptions{
+				ReplaceExisting: true,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			names := rec.names()
+			subjectAt := -1
+			crlAt := -1
+			for i, n := range names {
+				if n == "subject:order-node" && subjectAt < 0 {
+					subjectAt = i
+				}
+				if n == "crl" && crlAt < 0 {
+					crlAt = i
+				}
+			}
+			Expect(subjectAt).To(BeNumerically(">=", 0), "the subject lock must be taken: %v", names)
+			Expect(crlAt).To(BeNumerically(">=", 0), "the CRL lock must be taken to revoke: %v", names)
+			Expect(subjectAt).To(BeNumerically("<", crlAt),
+				"subject lock must precede the CRL lock, not follow it: %v", names)
+		})
 	})
 
 	Context("CRL cache freshness", func() {
@@ -608,6 +648,35 @@ var _ = Describe("CA GenerateWithOptions replacement", func() {
 		Expect(err).NotTo(MatchError(ca.ErrCertExists))
 		Expect(err.Error()).To(ContainSubstring("openvox-ca-ctl clean"))
 		Expect(revokedSerials()).To(HaveLen(before), "nothing may be revoked when the read fails")
+	})
+
+	It("reports the revoked-but-not-replaced state when issuance fails after the revoke", func() {
+		// The one irreversible outcome this design cannot rule out: the old
+		// certificate is on the CRL, which cannot be undone, and no replacement
+		// exists. Surfacing the bare error would be actively misleading here --
+		// evictRevokedLocked answers ErrCertExists, whose remedy text tells the
+		// operator to pass --force, which is what they just did.
+		_, err := myCA.GenerateWithOptions(ctx, "post-revoke-fail", ca.GenerateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Fail the issue phase after the revoke phase has committed: the
+		// private directory is unwritable, so SavePrivateKey fails.
+		privDir := filepath.Join(tmpDir, "private")
+		Expect(os.Chmod(privDir, 0o555)).To(Succeed())
+		DeferCleanup(func() { _ = os.Chmod(privDir, 0o755) })
+		if os.Geteuid() == 0 {
+			Skip("root ignores directory permissions")
+		}
+
+		_, err = myCA.GenerateWithOptions(ctx, "post-revoke-fail", ca.GenerateOptions{
+			ReplaceExisting:           true,
+			RetainPrivateKeyInStorage: true,
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("was revoked, but no replacement was issued"))
+		Expect(err.Error()).To(ContainSubstring("cannot be undone"))
+		Expect(err).NotTo(MatchError(ca.ErrCertExists),
+			"a bare ErrCertExists here sends the operator round the --force loop again")
 	})
 
 	It("does not deadlock against a concurrent CRL refresh", func() {

--- a/internal/ca/generate_test.go
+++ b/internal/ca/generate_test.go
@@ -650,6 +650,29 @@ var _ = Describe("CA GenerateWithOptions replacement", func() {
 		Expect(revokedSerials()).To(HaveLen(before), "nothing may be revoked when the read fails")
 	})
 
+	It("emits the key before the revoke, not after it", func() {
+		// This ordering is the whole reason --force requires --key-out. Move
+		// the EmitKey call inside the lock -- anywhere after the revoke phase
+		// -- and every other spec still passes, while the outcome the design
+		// exists to prevent becomes reachable: the old certificate on the CRL,
+		// no replacement, and no key. Only a replacement with a failing EmitKey
+		// can tell the two orderings apart.
+		first, err := myCA.GenerateWithOptions(ctx, "emit-order-node", ca.GenerateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		oldSerial := serialOf(first)
+
+		_, err = myCA.GenerateWithOptions(ctx, "emit-order-node", ca.GenerateOptions{
+			ReplaceExisting: true,
+			EmitKey:         func([]byte) error { return errors.New("no room on device") },
+		})
+		Expect(err).To(MatchError(ContainSubstring("no room on device")))
+
+		Expect(revokedSerials()).NotTo(ContainElement(oldSerial),
+			"a key the caller could not keep must not cost them the certificate they still have")
+		Expect(store.HasCert(ctx, "emit-order-node")).To(BeTrue(),
+			"the existing certificate must survive a failure that happened before the revoke")
+	})
+
 	It("reports the revoked-but-not-replaced state when issuance fails after the revoke", func() {
 		// The one irreversible outcome this design cannot rule out: the old
 		// certificate is on the CRL, which cannot be undone, and no replacement

--- a/internal/ca/generate_test.go
+++ b/internal/ca/generate_test.go
@@ -25,12 +25,57 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sync"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/voxpupuli/openvox-ca/internal/ca"
 	"github.com/voxpupuli/openvox-ca/internal/storage"
 )
+
+// recordingLockBackend wraps a Backend and implements storage.Locker, recording
+// every lock name acquired. The locks themselves are real (a process-local
+// mutex per name) so behaviour is unchanged; only the observation is added.
+type recordingLockBackend struct {
+	storage.Backend
+
+	mu       sync.Mutex
+	locks    map[string]*sync.Mutex
+	acquired []string
+}
+
+func (b *recordingLockBackend) AcquireLock(_ context.Context, name string) (storage.Unlocker, error) {
+	b.mu.Lock()
+	if b.locks == nil {
+		b.locks = map[string]*sync.Mutex{}
+	}
+	m, ok := b.locks[name]
+	if !ok {
+		m = &sync.Mutex{}
+		b.locks[name] = m
+	}
+	b.acquired = append(b.acquired, name)
+	b.mu.Unlock()
+
+	m.Lock()
+	return unlockFunc(m.Unlock), nil
+}
+
+func (b *recordingLockBackend) reset() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.acquired = nil
+}
+
+func (b *recordingLockBackend) names() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return append([]string(nil), b.acquired...)
+}
+
+type unlockFunc func()
+
+func (f unlockFunc) Unlock() error { f(); return nil }
 
 var _ = Describe("CA Generate", func() {
 	var (
@@ -161,5 +206,54 @@ var _ = Describe("CA Generate", func() {
 		data, err := os.ReadFile(keyPath)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(data).To(ContainSubstring("RSA PRIVATE KEY"))
+	})
+
+	Context("serialisation on the per-subject lock", func() {
+		// Asserting on the lock being taken, rather than on the outcome of a
+		// live race. Racing two Generate calls is not a usable regression test
+		// here: on the filesystem backend WithLock degrades to a process-local
+		// mutex, and even without any lock at all the two goroutines serialise
+		// by luck often enough that the spec passes with the fix reverted --
+		// verified, not assumed. A spec that passes either way pins nothing, so
+		// pin the mechanism instead: Generate must route through the named
+		// cluster lock for its subject, which is what makes it correct on the
+		// backends where that lock is real.
+		It("acquires the subject lock before issuing", func() {
+			ctx := context.Background()
+
+			rec := &recordingLockBackend{Backend: storage.NewFilesystemBackend(tmpDir)}
+			recStore := storage.NewWithBackend(rec, filepath.Join(tmpDir, "private"))
+			recCA := ca.New(recStore, ca.AutosignConfig{Mode: "off"}, "puppet.test")
+			Expect(recCA.Init(ctx)).To(Succeed())
+
+			rec.reset()
+			_, err := recCA.Generate(ctx, "locked-node", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(rec.names()).To(ContainElement("subject:locked-node"),
+				"Generate must serialise on the same per-subject lock Sign and Clean use")
+		})
+	})
+
+	Context("CRL cache freshness", func() {
+		It("re-issues when the subject was revoked after this process started", func() {
+			ctx := context.Background()
+
+			// Issue, then revoke through a second CA value sharing the store --
+			// standing in for another replica. This process's cachedCRL was
+			// snapshotted at Init and knows nothing about it.
+			_, err := myCA.Generate(ctx, "stale-crl-node", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			other := ca.New(store, ca.AutosignConfig{Mode: "off"}, "puppet.test")
+			Expect(other.Init(ctx)).To(Succeed())
+			Expect(other.Revoke(ctx, "stale-crl-node")).To(Succeed())
+
+			// Without the re-read under the lock, evictRevokedLocked consults a
+			// CRL that predates the revocation and refuses with ErrCertExists.
+			_, err = myCA.Generate(ctx, "stale-crl-node", nil)
+			Expect(err).NotTo(HaveOccurred(),
+				"a subject revoked elsewhere must be evictable, not reported as still valid")
+		})
 	})
 })

--- a/internal/ca/generate_test.go
+++ b/internal/ca/generate_test.go
@@ -24,6 +24,8 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"errors"
+	"fmt"
+	"math/big"
 	"os"
 	"path/filepath"
 	"sync"
@@ -476,5 +478,168 @@ var _ = Describe("CA GenerateWithOptions", func() {
 			_, err := bare.GenerateWithOptions(ctx, "uninit-node", ca.GenerateOptions{})
 			Expect(err).To(MatchError(ca.ErrNotInitialized))
 		})
+	})
+})
+
+var _ = Describe("CA GenerateWithOptions replacement", func() {
+	var (
+		ctx    context.Context
+		tmpDir string
+		myCA   *ca.CA
+		store  *storage.StorageService
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		var err error
+		tmpDir, err = os.MkdirTemp("", "openvox-ca-replace-test")
+		Expect(err).NotTo(HaveOccurred())
+
+		store = storage.New(tmpDir)
+		myCA = ca.New(store, ca.AutosignConfig{Mode: "off"}, "puppet.test")
+
+		Expect(store.EnsureDirs(ctx)).To(Succeed())
+		Expect(store.SaveCAKey(ctx, cachedKeyPEM)).To(Succeed())
+		Expect(store.SaveCACert(ctx, cachedCrtPEM)).To(Succeed())
+		Expect(store.UpdateCRL(ctx, cachedCrlPEM)).To(Succeed())
+		Expect(store.WriteSerial(ctx, "0001")).To(Succeed())
+		Expect(store.TouchInventory(ctx)).To(Succeed())
+		Expect(myCA.Init(ctx)).To(Succeed())
+	})
+
+	AfterEach(func() { os.RemoveAll(tmpDir) })
+
+	// Compared as hex strings: big.Int has unexported fields, so gomega's
+	// structural matchers cannot compare them.
+	serialOf := func(r *ca.GenerateResult) string {
+		block, _ := pem.Decode(r.CertificatePEM)
+		Expect(block).NotTo(BeNil())
+		cert, err := x509.ParseCertificate(block.Bytes)
+		Expect(err).NotTo(HaveOccurred())
+		return fmt.Sprintf("%X", cert.SerialNumber)
+	}
+
+	revokedSerials := func() []string {
+		crlPEM, err := store.GetCRL(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		block, _ := pem.Decode(crlPEM)
+		Expect(block).NotTo(BeNil())
+		crl, err := x509.ParseRevocationList(block.Bytes)
+		Expect(err).NotTo(HaveOccurred())
+		out := make([]string, 0, len(crl.RevokedCertificateEntries))
+		for _, e := range crl.RevokedCertificateEntries {
+			out = append(out, fmt.Sprintf("%X", e.SerialNumber))
+		}
+		return out
+	}
+
+	It("revokes the old certificate and issues a new one", func() {
+		first, err := myCA.GenerateWithOptions(ctx, "replace-node", ca.GenerateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		oldSerial := serialOf(first)
+
+		second, err := myCA.GenerateWithOptions(ctx, "replace-node", ca.GenerateOptions{
+			ReplaceExisting: true,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		newSerial := serialOf(second)
+
+		Expect(newSerial).NotTo(Equal(oldSerial))
+		Expect(revokedSerials()).To(ContainElement(oldSerial))
+		Expect(revokedSerials()).NotTo(ContainElement(newSerial))
+		Expect(store.HasCert(ctx, "replace-node")).To(BeTrue())
+	})
+
+	It("is not an error when there is nothing to replace", func() {
+		// Unlike Clean, which reports ErrNotFound. This command's job is to end
+		// with a certificate, so being asked to replace one that does not exist
+		// is a no-op, not a failure -- which keeps --force usable in scripts.
+		_, err := myCA.GenerateWithOptions(ctx, "fresh-node", ca.GenerateOptions{
+			ReplaceExisting: true,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(store.HasCert(ctx, "fresh-node")).To(BeTrue())
+	})
+
+	It("revokes the stored certificate's serial, not the inventory's latest", func() {
+		// The inventory's newest row for a subject and the certificate actually
+		// in storage can diverge. revokeLocked resolves the former, which is
+		// why this path uses the stored certificate instead: putting the wrong
+		// serial on the CRL cannot be undone.
+		first, err := myCA.GenerateWithOptions(ctx, "diverged-node", ca.GenerateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		storedSerial := serialOf(first)
+
+		// Append a newer inventory row for the same subject without touching
+		// the stored certificate.
+		decoyInt := new(big.Int)
+		_, ok := decoyInt.SetString(storedSerial, 16)
+		Expect(ok).To(BeTrue())
+		decoy := fmt.Sprintf("%X", decoyInt.Add(decoyInt, big.NewInt(1)))
+		line := storage.FormatInventoryLine(decoy,
+			time.Now().Add(-time.Hour), time.Now().Add(time.Hour), "diverged-node")
+		Expect(store.AppendInventory(ctx, line)).To(Succeed())
+
+		_, err = myCA.GenerateWithOptions(ctx, "diverged-node", ca.GenerateOptions{
+			ReplaceExisting: true,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(revokedSerials()).To(ContainElement(storedSerial),
+			"the certificate actually in storage is what was retired")
+		Expect(revokedSerials()).NotTo(ContainElement(decoy),
+			"the inventory's newest row is not the credential being replaced")
+	})
+
+	It("aborts without revoking when the stored certificate cannot be parsed", func() {
+		_, err := myCA.GenerateWithOptions(ctx, "corrupt-node", ca.GenerateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		before := len(revokedSerials())
+
+		Expect(store.SaveCert(ctx, "corrupt-node", []byte("not a certificate"))).To(Succeed())
+
+		_, err = myCA.GenerateWithOptions(ctx, "corrupt-node", ca.GenerateOptions{
+			ReplaceExisting: true,
+		})
+		Expect(err).To(HaveOccurred())
+		// Not ErrCertExists: that error tells the operator to pass --force,
+		// which is exactly what they did. A dead-end loop is worse than a
+		// blunt message.
+		Expect(err).NotTo(MatchError(ca.ErrCertExists))
+		Expect(err.Error()).To(ContainSubstring("openvox-ca-ctl clean"))
+		Expect(revokedSerials()).To(HaveLen(before), "nothing may be revoked when the read fails")
+	})
+
+	It("does not deadlock against a concurrent CRL refresh", func() {
+		// The replacement path nests the CRL lock inside the subject lock.
+		// c.mu is non-reentrant and every other lockNameCRL acquisition takes
+		// the distributed lock first, so holding c.mu across the nested
+		// WithLock would invert the ordering against RefreshCRLIfDue and wedge
+		// the process.
+		_, err := myCA.GenerateWithOptions(ctx, "deadlock-node", ca.GenerateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		done := make(chan error, 2)
+		go func() {
+			defer GinkgoRecover()
+			_, err := myCA.RefreshCRLIfDue(ctx, 100*365*24*time.Hour) // always due
+			done <- err
+		}()
+		go func() {
+			defer GinkgoRecover()
+			_, err := myCA.GenerateWithOptions(ctx, "deadlock-node", ca.GenerateOptions{
+				ReplaceExisting: true,
+			})
+			done <- err
+		}()
+
+		for range 2 {
+			select {
+			case err := <-done:
+				Expect(err).NotTo(HaveOccurred())
+			case <-time.After(30 * time.Second):
+				Fail("deadlock: the replacement path and a CRL refresh blocked each other")
+			}
+		}
 	})
 })

--- a/internal/ca/init.go
+++ b/internal/ca/init.go
@@ -153,6 +153,10 @@ func (c *CA) Init(ctx context.Context) error {
 				"and requires every agent to be re-enrolled: %w", where, loadErr)
 		}
 		if !hasCert || !hasKey {
+			if c.NoBootstrap {
+				return fmt.Errorf("no CA exists in the configured storage, and this caller "+
+					"will not create one: %w", loadErr)
+			}
 			slog.Info("No existing CA found, bootstrapping new CA")
 			return c.bootstrapCA(ctx)
 		}

--- a/internal/ca/keystrength_test.go
+++ b/internal/ca/keystrength_test.go
@@ -138,4 +138,38 @@ var _ = Describe("Client CSR key-strength policy", func() {
 			Expect(err).To(HaveOccurred(), "Sign must reject a stored weak-key CSR")
 		})
 	})
+
+	Context("at the chokepoint itself", func() {
+		// The policy check lives in issueLeafLocked, ahead of serial allocation
+		// and every write. These pin that placement: a rejection must be free,
+		// consuming no serial and leaving no trace in the inventory. If the
+		// check drifts below the serial or the SaveCert, a refused weak key
+		// starts burning inventory rows and the CA's own records stop matching
+		// what it issued.
+		It("classifies the rejection as ErrKeyPolicy", func() {
+			key, err := rsa.GenerateKey(rand.Reader, 1024)
+			Expect(err).NotTo(HaveOccurred())
+
+			myCA := newCA("true")
+			_, err = myCA.SaveRequest(ctx, "policy-node", csrPEMFor("policy-node", key))
+			Expect(err).To(MatchError(ca.ErrKeyPolicy),
+				"the sentinel is what the HTTP layer discriminates on to answer 4xx, not 5xx")
+		})
+
+		It("consumes no inventory row for a rejected key", func() {
+			myCA := newCA("true")
+
+			before, err := store.ReadInventory(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			key, err := rsa.GenerateKey(rand.Reader, 1024)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = myCA.SaveRequest(ctx, "no-row-node", csrPEMFor("no-row-node", key))
+			Expect(err).To(HaveOccurred())
+
+			after, err := store.ReadInventory(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(after).To(Equal(before), "a refused key must not append an inventory row")
+		})
+	})
 })

--- a/internal/ca/nobootstrap_test.go
+++ b/internal/ca/nobootstrap_test.go
@@ -1,0 +1,68 @@
+// Copyright (C) 2026 Trevor Vaughan
+// Copyright (C) 2026 Vox Pupuli and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package ca_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/voxpupuli/openvox-ca/internal/ca"
+	"github.com/voxpupuli/openvox-ca/internal/storage"
+)
+
+var _ = Describe("CA Init with NoBootstrap", func() {
+	var ctx context.Context
+
+	BeforeEach(func() { ctx = context.Background() })
+
+	It("refuses to create a CA when none exists", func() {
+		dir := GinkgoT().TempDir()
+		store := storage.New(dir)
+		myCA := ca.New(store, ca.AutosignConfig{Mode: "off"}, "puppet.test")
+		myCA.NoBootstrap = true
+
+		err := myCA.Init(ctx)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("will not create one"))
+
+		// The point of the flag: a mistyped cadir must not leave a brand-new CA
+		// behind, under which certificates would be issued that nothing in the
+		// fleet trusts, with no obvious sign of why.
+		hasCert, err := store.HasCACert(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(hasCert).To(BeFalse())
+	})
+
+	It("still loads a CA that already exists", func() {
+		dir := GinkgoT().TempDir()
+		store := storage.New(dir)
+		Expect(store.EnsureDirs(ctx)).To(Succeed())
+		Expect(store.SaveCAKey(ctx, cachedKeyPEM)).To(Succeed())
+		Expect(store.SaveCACert(ctx, cachedCrtPEM)).To(Succeed())
+		Expect(store.UpdateCRL(ctx, cachedCrlPEM)).To(Succeed())
+		Expect(store.WriteSerial(ctx, "0001")).To(Succeed())
+		Expect(store.TouchInventory(ctx)).To(Succeed())
+
+		myCA := ca.New(store, ca.AutosignConfig{Mode: "off"}, "puppet.test")
+		myCA.NoBootstrap = true
+		Expect(myCA.Init(ctx)).To(Succeed())
+		Expect(myCA.CACert).NotTo(BeNil())
+	})
+})

--- a/internal/ca/nobootstrap_test.go
+++ b/internal/ca/nobootstrap_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2026 Trevor Vaughan
+// Copyright (C) 2026 Chris Boot
 // Copyright (C) 2026 Vox Pupuli and contributors
 //
 // This program is free software; you can redistribute it and/or modify

--- a/internal/ca/signing.go
+++ b/internal/ca/signing.go
@@ -246,14 +246,9 @@ func (c *CA) signWithDuration(ctx context.Context, subject string, ttl time.Dura
 		return nil, fmt.Errorf("invalid CSR signature for %s: %w", subject, err)
 	}
 
-	// SECURITY: Enforce the CA's key-strength policy on the client-submitted
-	// key (RSA >= 2048, ECDSA on an approved NIST curve), mirroring the policy
-	// ValidateKeyConfig applies to server-side key generation. Placed at the
-	// issuance chokepoint so no signing path can ever produce a certificate
-	// over a weak key. NIST 800-53: SC-12, SC-13 (Cryptographic Protection)
-	if err := validatePublicKey(csr.PublicKey); err != nil {
-		return nil, fmt.Errorf("rejecting CSR for %s: %w", subject, err)
-	}
+	// The key-strength policy is enforced by issueLeafLocked, the tail every
+	// issuance path shares, so a submitted CSR carrying a weak key is rejected
+	// there rather than here.
 
 	// SECURITY: Reject CSRs that request CA capabilities (BasicConstraints:
 	// CA:TRUE, OID 2.5.29.19). Without this check a submitted CSR could produce
@@ -329,6 +324,19 @@ func (c *CA) issueLeafLocked(ctx context.Context, subject string, subjectName pk
 	// would panic the entire frontend.
 	if c.CACert == nil || c.CAKey == nil {
 		return nil, ErrNotInitialized
+	}
+
+	// SECURITY: Enforce the CA's key-strength policy (RSA >= 2048, ECDSA on an
+	// approved NIST curve), mirroring the policy ValidateKeyConfig applies to
+	// server-side key generation. This is the issuance chokepoint every path
+	// shares — a submitted CSR (signWithDuration), an already-issued
+	// certificate's key (AutoRenew), and a freshly generated one
+	// (GenerateWithOptions) — so no signing path can produce a certificate over
+	// a weak key without deleting this check. It runs before the serial is
+	// allocated and before anything is written, so a rejected key consumes
+	// nothing. NIST 800-53: SC-12, SC-13 (Cryptographic Protection)
+	if err := validatePublicKey(pubKey); err != nil {
+		return nil, fmt.Errorf("rejecting certificate for %s: %w", subject, err)
 	}
 
 	// SECURITY: Generate a random 128-bit serial number (CA/Browser Forum guidance).
@@ -800,15 +808,14 @@ func (c *CA) AutoRenew(ctx context.Context, presentedCert *x509.Certificate) ([]
 		return nil, err
 	}
 
-	// SECURITY: Re-check the key-strength policy before perpetuating a key
-	// via auto-renewal. A cert imported from a legacy CA (see the migrate
-	// command) may predate this CA's key policy; auto-renewal must not be a
-	// backdoor to indefinitely extend a substandard key — the operator/agent
-	// should re-key via the CSR-based Renew path instead.
-	// NIST 800-53: SC-12, SC-13 (Cryptographic Protection)
-	if err := validatePublicKey(presentedCert.PublicKey); err != nil {
-		return nil, fmt.Errorf("rejecting auto-renewal for %s: %w", subject, err)
-	}
+	// The key-strength policy is enforced by issueLeafLocked. That matters most
+	// on this path: a cert imported from a legacy CA (see the migrate command)
+	// may predate this CA's key policy, and auto-renewal must not be a backdoor
+	// to indefinitely extend a substandard key — the operator/agent should
+	// re-key via the CSR-based Renew path instead. The rejection now happens
+	// after the subject lock is taken rather than before it, which is
+	// acceptable: this route is mTLS-authenticated and the lock is scoped to
+	// the caller's own subject.
 
 	ctx, cancel := context.WithTimeout(ctx, lockTimeout)
 	defer cancel()

--- a/internal/storage/backend.go
+++ b/internal/storage/backend.go
@@ -34,6 +34,18 @@ import (
 // back to a process-local mutex.
 var ErrDistributedLockingUnsupported = errors.New("distributed locking unsupported by this backend")
 
+// ErrLockUnavailable is wrapped by StorageService.WithLock when a distributed
+// lock could not be acquired — the backend is unreachable, or the context
+// expired waiting for a lock another node holds. It is deliberately distinct
+// from ErrDistributedLockingUnsupported, which means "this backend does not do
+// distributed locking at all" and is handled by falling back to a process-local
+// mutex rather than failing.
+//
+// Exposed as a sentinel so callers can tell a transient contention failure from
+// a fault: the HTTP layer answers 503 for this and 500 for everything else, so
+// a client knows to retry rather than treating it as a bug.
+var ErrLockUnavailable = errors.New("could not acquire lock")
+
 // BlobKind signals the desired visibility of a stored blob. The filesystem
 // backend maps these to file permissions (0600 vs 0644); remote backends
 // may ignore it or use the hint to pick a storage namespace.

--- a/internal/storage/backend.go
+++ b/internal/storage/backend.go
@@ -34,18 +34,6 @@ import (
 // back to a process-local mutex.
 var ErrDistributedLockingUnsupported = errors.New("distributed locking unsupported by this backend")
 
-// ErrLockUnavailable is wrapped by StorageService.WithLock when a distributed
-// lock could not be acquired — the backend is unreachable, or the context
-// expired waiting for a lock another node holds. It is deliberately distinct
-// from ErrDistributedLockingUnsupported, which means "this backend does not do
-// distributed locking at all" and is handled by falling back to a process-local
-// mutex rather than failing.
-//
-// Exposed as a sentinel so callers can tell a transient contention failure from
-// a fault: the HTTP layer answers 503 for this and 500 for everything else, so
-// a client knows to retry rather than treating it as a bug.
-var ErrLockUnavailable = errors.New("could not acquire lock")
-
 // BlobKind signals the desired visibility of a stored blob. The filesystem
 // backend maps these to file permissions (0600 vs 0644); remote backends
 // may ignore it or use the hint to pick a storage namespace.

--- a/internal/storage/capability_test.go
+++ b/internal/storage/capability_test.go
@@ -109,32 +109,36 @@ var _ = Describe("Backend capability reporting", func() {
 			Expect(ok).To(BeFalse())
 		})
 
-		It("agrees with WithLock about which backends coordinate across processes", func() {
-			// The probe duplicates WithLock's classification by construction --
-			// it cannot be folded into WithLock without adding a lock round
-			// trip to every Sign. This is what stops the two drifting apart.
-			for _, tc := range []struct {
-				name    string
-				backend Backend
-			}{
-				{"filesystem", NewFilesystemBackend(GinkgoT().TempDir())},
-				{"sqlite", newSQLiteBackend()},
-				{"stub locker", &stubLocker{Backend: NewFilesystemBackend(GinkgoT().TempDir())}},
-			} {
-				s := svc(tc.backend)
+		// One Entry per backend rather than a loop: a loop aborts at the first
+		// failed Expect, so a filesystem regression would hide whatever sqlite
+		// and the stub locker were about to say. This spec exists precisely to
+		// stop the probe and WithLock drifting apart, so it must report every
+		// backend that drifted, not just the first.
+		//
+		// The backend is passed as a constructor because Entry arguments are
+		// evaluated at tree-construction time, and GinkgoT().TempDir() must run
+		// inside the spec.
+		DescribeTable("agrees with WithLock about which backends coordinate across processes",
+			func(build func() Backend) {
+				s := svc(build())
 
 				reported, err := s.SupportsDistributedLocking(ctx)
-				Expect(err).NotTo(HaveOccurred(), tc.name)
+				Expect(err).NotTo(HaveOccurred())
 
 				// Observe what WithLock did: a distributed lock leaves no entry
 				// in the process-local map, a fallback creates one.
-				Expect(s.WithLock(ctx, "agreement-probe", func() error { return nil })).To(Succeed(), tc.name)
+				Expect(s.WithLock(ctx, "agreement-probe", func() error { return nil })).To(Succeed())
 				_, usedLocalMutex := s.localLocks.Load("agreement-probe")
 
 				Expect(reported).To(Equal(!usedLocalMutex),
-					"%s: SupportsDistributedLocking must match what WithLock actually does", tc.name)
-			}
-		})
+					"SupportsDistributedLocking must match what WithLock actually does")
+			},
+			Entry("filesystem", func() Backend { return NewFilesystemBackend(GinkgoT().TempDir()) }),
+			Entry("sqlite", func() Backend { return newSQLiteBackend() }),
+			Entry("stub locker", func() Backend {
+				return &stubLocker{Backend: NewFilesystemBackend(GinkgoT().TempDir())}
+			}),
+		)
 	})
 
 	Describe("SupportsAtomicInventory", func() {

--- a/internal/storage/capability_test.go
+++ b/internal/storage/capability_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2026 Trevor Vaughan
+// Copyright (C) 2026 Chris Boot
 // Copyright (C) 2026 Vox Pupuli and contributors
 //
 // This program is free software; you can redistribute it and/or modify

--- a/internal/storage/capability_test.go
+++ b/internal/storage/capability_test.go
@@ -1,0 +1,165 @@
+// Copyright (C) 2026 Trevor Vaughan
+// Copyright (C) 2026 Vox Pupuli and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package storage
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Backend capability reporting", func() {
+	var ctx context.Context
+
+	BeforeEach(func() { ctx = context.Background() })
+
+	svc := func(b Backend) *StorageService {
+		return NewWithBackend(b, filepath.Join(GinkgoT().TempDir(), "private"))
+	}
+
+	Describe("SupportsDistributedLocking", func() {
+		// The whole point of this method is that it answers a different
+		// question from `_, ok := backend.(Locker)`. These first three cases
+		// are the ones where the type assertion says "yes" and the truth is
+		// "no" -- if this method is ever simplified to an assertion, they fail.
+		It("is false for the filesystem backend, which implements no Locker", func() {
+			ok, err := svc(NewFilesystemBackend(GinkgoT().TempDir())).SupportsDistributedLocking(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeFalse())
+		})
+
+		It("is false for SQLite, which implements Locker but reports it unsupported", func() {
+			b := newSQLiteBackend()
+			Expect(b).To(BeAssignableToTypeOf(&SQLBackend{}))
+
+			var asLocker any = b
+			_, assertsAsLocker := asLocker.(Locker)
+			Expect(assertsAsLocker).To(BeTrue(),
+				"precondition: SQLBackend implements Locker, so a type assertion would say yes")
+
+			ok, err := svc(b).SupportsDistributedLocking(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeFalse(), "SQLite is single-node; WithLock falls back to a process mutex")
+		})
+
+		It("is false for an overlay over a filesystem base", func() {
+			ov, _, _, _ := overlayTestSetup()
+
+			var asLocker any = ov
+			_, assertsAsLocker := asLocker.(Locker)
+			Expect(assertsAsLocker).To(BeTrue(),
+				"precondition: OverlayBackend implements Locker, so a type assertion would say yes")
+
+			ok, err := svc(ov).SupportsDistributedLocking(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeFalse(), "the overlay delegates, and a filesystem base cannot lock")
+		})
+
+		It("is true when the backend hands out a lock", func() {
+			ok, err := svc(&stubLocker{Backend: NewFilesystemBackend(GinkgoT().TempDir())}).
+				SupportsDistributedLocking(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+		})
+
+		It("releases the probe lock it acquires", func() {
+			// A probe that leaked would hold a Postgres advisory lock on a
+			// pooled connection, or a Redis lease with its heartbeat goroutine,
+			// for the rest of the process's life.
+			released := make(chan struct{})
+			ok, err := svc(&stubLocker{
+				Backend:    NewFilesystemBackend(GinkgoT().TempDir()),
+				unlockedCh: released,
+			}).SupportsDistributedLocking(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+			// stubUnlocker signals by closing.
+			Expect(released).To(BeClosed(), "the probe must not hold the lock it took")
+		})
+
+		It("reports an error, not false, when the lock service is unreachable", func() {
+			// "Cannot reach the backend" and "this backend does not do
+			// distributed locking" are different answers. Collapsing the first
+			// into false would tell an operator to stop their server on the
+			// grounds of a capability their backend actually has.
+			ok, err := svc(&stubLocker{
+				Backend: NewFilesystemBackend(GinkgoT().TempDir()),
+				err:     errors.New("connection refused"),
+			}).SupportsDistributedLocking(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("probing distributed locking"))
+			Expect(ok).To(BeFalse())
+		})
+
+		It("agrees with WithLock about which backends coordinate across processes", func() {
+			// The probe duplicates WithLock's classification by construction --
+			// it cannot be folded into WithLock without adding a lock round
+			// trip to every Sign. This is what stops the two drifting apart.
+			for _, tc := range []struct {
+				name    string
+				backend Backend
+			}{
+				{"filesystem", NewFilesystemBackend(GinkgoT().TempDir())},
+				{"sqlite", newSQLiteBackend()},
+				{"stub locker", &stubLocker{Backend: NewFilesystemBackend(GinkgoT().TempDir())}},
+			} {
+				s := svc(tc.backend)
+
+				reported, err := s.SupportsDistributedLocking(ctx)
+				Expect(err).NotTo(HaveOccurred(), tc.name)
+
+				// Observe what WithLock did: a distributed lock leaves no entry
+				// in the process-local map, a fallback creates one.
+				Expect(s.WithLock(ctx, "agreement-probe", func() error { return nil })).To(Succeed(), tc.name)
+				_, usedLocalMutex := s.localLocks.Load("agreement-probe")
+
+				Expect(reported).To(Equal(!usedLocalMutex),
+					"%s: SupportsDistributedLocking must match what WithLock actually does", tc.name)
+			}
+		})
+	})
+
+	Describe("SupportsAtomicInventory", func() {
+		It("is false for the filesystem backend", func() {
+			Expect(svc(NewFilesystemBackend(GinkgoT().TempDir())).SupportsAtomicInventory()).To(BeFalse())
+		})
+
+		It("is true for a SQL backend", func() {
+			// Note this is true for SQLite while SupportsDistributedLocking is
+			// false: the two capabilities are independent, which is exactly why
+			// callers must check both before deciding it is safe to write from
+			// a second process.
+			Expect(svc(newSQLiteBackend()).SupportsAtomicInventory()).To(BeTrue())
+		})
+
+		It("sees through an overlay to a SQL base", func() {
+			base := newSQLiteBackend()
+			overlayDir := GinkgoT().TempDir()
+			ov, err := NewOverlayBackend(base, map[string]string{
+				KeyCACert: filepath.Join(overlayDir, "ca_crt.pem"),
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(svc(ov).SupportsAtomicInventory()).To(BeTrue(),
+				"a caller-side type assertion would answer no here")
+		})
+	})
+})

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -79,7 +79,7 @@ func (s *StorageService) WithLock(ctx context.Context, name string, fn func() er
 			return fn()
 		}
 		if !errors.Is(err, ErrDistributedLockingUnsupported) {
-			return fmt.Errorf("acquiring distributed lock %q: %w", name, err)
+			return fmt.Errorf("%w %q: %w", ErrLockUnavailable, name, err)
 		}
 		// Backend advertises Locker but cannot actually provide one (e.g.
 		// OverlayBackend wrapping a filesystem base); fall through to the

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -91,6 +91,73 @@ func (s *StorageService) WithLock(ctx context.Context, name string, fn func() er
 	return fn()
 }
 
+// lockProbeName is the throwaway lock SupportsDistributedLocking acquires and
+// immediately releases. It is deliberately outside the namespaces real callers
+// use ("bootstrap", "crl", "subject:<name>") so a probe can never contend with
+// an operation in flight.
+const lockProbeName = "capability-probe"
+
+// SupportsDistributedLocking reports whether WithLock actually coordinates
+// across processes for the configured backend.
+//
+// This deliberately does NOT answer `_, ok := backend.(Locker)`, which is a
+// different and misleading question. SQLBackend implements Locker but reports
+// ErrDistributedLockingUnsupported for SQLite, and OverlayBackend implements it
+// but delegates to a base that may not — so a type assertion says "yes" for
+// SQLite and for any backend an overlay wraps over a filesystem base, both of
+// which fall through to a process-local mutex. Callers that use this to decide
+// whether it is safe to run a second process against the same storage would be
+// told exactly the wrong thing.
+//
+// Instead it reproduces WithLock's decision by making the same AcquireLock call
+// and classifying the outcome the same way, releasing the lock immediately. The
+// probe cannot live inside WithLock: that would add a lock round trip to every
+// Sign. Keeping the two in step is a test's job (see the storage suite), not
+// the type system's.
+//
+// The three outcomes are distinct, and the error case matters: WithLock treats
+// a non-sentinel AcquireLock failure as fatal, so reporting it as "false" would
+// tell an operator their backend does not do distributed locking when the truth
+// is that it is unreachable.
+func (s *StorageService) SupportsDistributedLocking(ctx context.Context) (bool, error) {
+	lk, ok := s.backend.(Locker)
+	if !ok {
+		return false, nil
+	}
+	ul, err := lk.AcquireLock(ctx, lockProbeName)
+	switch {
+	case err == nil:
+		// Release at once. A probe that leaked would hold a Postgres advisory
+		// lock on a pooled connection, or a Redis lease with a heartbeat
+		// goroutine, for the lifetime of the process.
+		if unlockErr := ul.Unlock(); unlockErr != nil {
+			slog.Warn("Failed to release capability probe lock", "error", unlockErr)
+		}
+		return true, nil
+	case errors.Is(err, ErrDistributedLockingUnsupported):
+		return false, nil
+	default:
+		return false, fmt.Errorf("probing distributed locking: %w", err)
+	}
+}
+
+// SupportsAtomicInventory reports whether AppendInventory is atomic with
+// respect to writers in other processes.
+//
+// Only structured (InventoryStore) backends are: they append a row and advance
+// the integrity chain in one transaction. Blob backends read the whole
+// inventory, append, and rewrite an HMAC computed over their own
+// reconstruction, so two concurrent appenders leave an HMAC covering a blob
+// that never existed — which fails the integrity check at the next startup.
+//
+// Needed as a method because asInventoryStore unwraps OverlayBackend, so a
+// caller-side type assertion would answer "no" for a SQL backend that happens
+// to be wrapped by ca_cert_file/ca_key_file.
+func (s *StorageService) SupportsAtomicInventory() bool {
+	_, ok := asInventoryStore(s.backend)
+	return ok
+}
+
 // localNamedLock returns the process-local mutex for name, creating it
 // on first use. Mutexes are never removed from the map; the namespace
 // is small and bounded.

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -79,7 +79,7 @@ func (s *StorageService) WithLock(ctx context.Context, name string, fn func() er
 			return fn()
 		}
 		if !errors.Is(err, ErrDistributedLockingUnsupported) {
-			return fmt.Errorf("%w %q: %w", ErrLockUnavailable, name, err)
+			return fmt.Errorf("acquiring distributed lock %q: %w", name, err)
 		}
 		// Backend advertises Locker but cannot actually provide one (e.g.
 		// OverlayBackend wrapping a filesystem base); fall through to the

--- a/test/integration-compose.sh
+++ b/test/integration-compose.sh
@@ -1312,6 +1312,39 @@ _wait_auth_ca() {
 openvox-ca-ctl setup --cadir "$_AUTH_DIR" --hostname auth-test-ca \
     2>/dev/null
 
+# Admin client cert with pp_cli_auth, minted offline BEFORE any server starts.
+#
+# This is the supported way to provision an administrator credential, and the
+# only one: the CA strips auth-arc OIDs (1.3.6.1.4.1.34380.1.3.*) from submitted
+# CSRs to prevent privilege escalation, so no API route can issue this. Minting
+# it here rather than during Phase 1 also exercises the claim that the command
+# needs no running server.
+if openvox-ca generate --cadir "$_AUTH_DIR" --certname openvox-admin \
+        --ttl 8760h --pp-cli-auth --key-out "$WORK_DIR/admin.key" \
+        > "$WORK_DIR/admin.crt" 2>/dev/null \
+    && [ -s "$WORK_DIR/admin.crt" ] && [ -s "$WORK_DIR/admin.key" ]; then
+    pass "pp_cli_auth: admin cert minted offline, with no server running"
+else
+    fail "pp_cli_auth: admin cert minted offline, with no server running" \
+        "openvox-ca generate --pp-cli-auth did not produce a cert and key"
+fi
+
+# The extension must survive as UTF8String "true"; a cert without it would sail
+# through the Phase 2 checks below for the wrong reason.
+_pp_oid_count=$(openssl x509 -text -noout -in "$WORK_DIR/admin.crt" 2>/dev/null \
+    | grep -c "1.3.6.1.4.1.34380.1.3.39") || true
+[ "${_pp_oid_count:-0}" -gt 0 ] \
+    && pass "pp_cli_auth: OID present in the offline-minted cert" \
+    || fail "pp_cli_auth: OID present in the offline-minted cert" \
+           "OID 1.3.6.1.4.1.34380.1.3.39 not found in openssl -text output"
+
+# It must also be tracked -- an inventory row is what makes it revocable by
+# name, and is the difference from the openssl recipe this replaced.
+grep -q "openvox-admin" "$_AUTH_DIR/inventory.txt" 2>/dev/null \
+    && pass "pp_cli_auth: offline-minted cert is recorded in the inventory" \
+    || fail "pp_cli_auth: offline-minted cert is recorded in the inventory" \
+           "no inventory row for openvox-admin"
+
 openvox-ca --cadir "$_AUTH_DIR" \
     --host 127.0.0.1 --port "$_AUTH_PORT" \
     --no-tls-required \
@@ -1331,53 +1364,6 @@ if _wait_auth_ca "$_AUTH_CA_URL"; then
     openvox-ca-ctl --server-url "$_AUTH_CA_URL" \
         generate --certname regular-client --out-dir "$WORK_DIR" \
         > "$WORK_DIR/regular-client.crt" 2>/dev/null
-
-    # Admin client cert with pp_cli_auth extension.
-    # DER:0c:04:74:72:75:65 is the DER encoding of UTF8String "true"
-    # (tag=0x0c, length=4, bytes="true").
-    #
-    # IMPORTANT: We sign this cert directly with openssl rather than submitting
-    # it through the CA API, because the CA correctly strips auth-arc OIDs
-    # (1.3.6.1.4.1.34380.1.3.*) from CSRs to prevent privilege escalation
-    # (see internal/ca/signing.go lines 239-243). Direct signing with the CA
-    # key is how a real deployment would provision admin certificates.
-    openssl genrsa -out "$WORK_DIR/admin.key" 2048 2>/dev/null
-    cat > "$WORK_DIR/pp_cli_auth.cnf" << 'OPENSSLEOF'
-[req]
-distinguished_name = dn
-req_extensions     = v3_req
-prompt             = no
-[dn]
-CN = openvox-admin
-[v3_req]
-1.3.6.1.4.1.34380.1.3.39 = DER:0c:04:74:72:75:65
-OPENSSLEOF
-
-    openssl req -new \
-        -key    "$WORK_DIR/admin.key" \
-        -config "$WORK_DIR/pp_cli_auth.cnf" \
-        -out    "$WORK_DIR/admin.csr" 2>/dev/null
-
-    # Sign the CSR directly with the CA key (preserves the pp_cli_auth OID).
-    cat > "$WORK_DIR/pp_cli_auth_ext.cnf" << 'OPENSSLEOF'
-1.3.6.1.4.1.34380.1.3.39 = DER:0c:04:74:72:75:65
-OPENSSLEOF
-    openssl x509 -req \
-        -in      "$WORK_DIR/admin.csr" \
-        -CA      "$_AUTH_DIR/ca_crt.pem" \
-        -CAkey   "$_AUTH_DIR/private/ca_key.pem" \
-        -CAcreateserial \
-        -days    365 \
-        -extfile "$WORK_DIR/pp_cli_auth_ext.cnf" \
-        -out     "$WORK_DIR/admin.crt" 2>/dev/null
-
-    # Verify the cert carries the pp_cli_auth OID.
-    _pp_oid_count=$(openssl x509 -text -noout -in "$WORK_DIR/admin.crt" 2>/dev/null \
-        | grep -c "1.3.6.1.4.1.34380.1.3.39") || true
-    [ "${_pp_oid_count:-0}" -gt 0 ] \
-        && pass "pp_cli_auth: OID preserved in signed cert" \
-        || fail "pp_cli_auth: OID preserved in signed cert" \
-               "OID 1.3.6.1.4.1.34380.1.3.39 not found in openssl -text output"
 else
     fail "pp_cli_auth: Phase 1 CA started (loopback HTTP, autosign=true)" \
         "timed out waiting for health"
@@ -1404,9 +1390,12 @@ if _wait_auth_ca "https://127.0.0.1:${_AUTH_PORT}"; then
         --cert "$WORK_DIR/admin.crt" \
         --key  "$WORK_DIR/admin.key" \
         -X POST "https://127.0.0.1:${_AUTH_PORT}/sign/all") || true
-    [ "$_st" != "403" ] \
-        && pass "pp_cli_auth: cert with extension reaches admin endpoint (not 403)" \
-        || fail "pp_cli_auth: cert with extension reaches admin endpoint (not 403)" \
+    # Explicitly 200, not merely "not 403": a curl failure yields 000, which
+    # would satisfy != 403 and pass this step with no certificate at all.
+    # handlePostSignAll returns 200 even with no pending CSRs.
+    [ "$_st" = "200" ] \
+        && pass "pp_cli_auth: cert with extension reaches admin endpoint (200)" \
+        || fail "pp_cli_auth: cert with extension reaches admin endpoint (200)" \
                "got HTTP $_st"
 
     # Plain cert → POST /sign/all must be 403.


### PR DESCRIPTION
Closes #175.

There is no supported way to mint a certificate without a running CA.
`openvox-ca-ctl generate` needs an admin client certificate, which needs a
running server, which needs a serving certificate. And because the CSR signing
path deliberately strips authorisation-arc OIDs, a `pp_cli_auth` certificate
cannot be obtained through the API at all.

The documented workaround — an `openssl` recipe in the migration guide — needs
raw CA key file access, so it is impossible under `ca_key_provider: openbao` or
`encrypt_ca_key`. Worse, it mints an **untracked** certificate: `-CAcreateserial`
allocates outside the CA and nothing writes the inventory, so the result never
appears in listings, is not swept by the expiry job, and cannot be revoked by
subject. The blessed way to create the most privileged credential in the system
produced one the CA could neither see nor revoke.

`openvox-ca generate` issues through the CA's own signing path instead, so the
certificate takes a serial from the CA's generator, lands in the inventory, and
is revocable and cleanable like any other. It reaches the key through the
configured provider, so it behaves identically whether that is a PEM file or
OpenBao Transit.

```bash
openvox-ca generate --certname web01.example.com --ttl 8760h \
  --key-out web01_key.pem > web01.crt

openvox-ca generate --certname admin-cli --ttl 8760h --pp-cli-auth \
  --key-out admin-cli_key.pem > admin-cli.crt
```

## Stacked on #160

Based on `feature/sub-ca-bootstrap`, which provides `resolveRuntime`,
`reportResolvedConfig`, `writePublicFile` and the offline-subcommands
documentation section this extends. **Review #160 first**; retarget to `main`
once it merges. This is a deliberate exception to CONTRIBUTING.md's
branch-off-`main` rule.

## Design decisions

**The auth-OID bypass is a closed enum, not a passthrough.** `AuthGrant` has
unexported fields and one constructor, so no value can arrive from a request
body, query parameter or config file. `Generate` keeps its old signature and
gains no extension parameter, so the HTTP handler cannot reach the seam without
someone editing `internal/api`. That is a guard against accident rather than
against a refactor, so a spec parses `internal/api`'s own sources and fails if
any of them names `AuthGrant`, `PpCliAuth`, `GenerateOptions` or
`GenerateWithOptions`. `openvox-ca-ctl generate` deliberately does **not** gain
`--pp-cli-auth`: that is precisely the network-reachable escalation the filter
exists to prevent.

**`--ttl` is required.** Rather than pick a default nobody agrees on, the
operator states the lifetime. There is no path through this command that
silently inherits the five-year built-in, which is a poor fit for a credential
this privileged.

**`--key-out` is required with `--pp-cli-auth` and with `--force`**, for
different reasons. The `<cadir>/private/` fallback writes to the local
filesystem whatever the backend, so on an ephemeral cadir an admin key ceases to
exist at the next restart while its certificate stays live in the shared
inventory. And that fallback writes *after* issuance, so under `--force` a
failure there would roll the new certificate back having already revoked the old
one — which cannot be undone.

**`--force` is not in the issue.** It was requested during planning. It revokes
the stored certificate's serial (not `LatestSerialForSubject`, which
`revoke.go` warns against for replacement paths) and fails closed if the revoke
fails, because proceeding would leave two live certificates for one subject.

## Changes beyond the command

- **`Generate` now takes the per-subject lock.** It was the only issuance path
  holding just `c.mu`, which coordinates nothing between processes. It also
  re-reads the CRL under that lock, so a subject revoked by another replica is
  no longer reported as still valid.
- **`validatePublicKey` hoisted into `issueLeafLocked`.** Its comment claimed to
  be "the issuance chokepoint", but it was a call site with a duplicate in
  `AutoRenew`. Now structural, and it runs before any serial is allocated.
  Note this moves `AutoRenew`'s rejection to after the subject lock is taken.
- **`StorageService.SupportsDistributedLocking` / `SupportsAtomicInventory`.**
  Deliberately not `backend.(storage.Locker)` — that assertion is true for
  SQLite and for overlay-over-filesystem, both of which are process-local, so it
  would tell an operator the opposite of the truth in exactly the configurations
  where it matters.
- **`NoBootstrap`**, so a mistyped `--cadir` cannot silently mint a fresh root.

A lock-contention `503` was added and then withdrawn, for the reasons #186
reached independently: every backend's `AcquireLock` opens with a plain
`sync.Mutex` that ignores the context, so same-process contention queues without
a deadline and then succeeds rather than erroring — and on the default
filesystem backend that is the only contention there is. Where it could fire,
`lockTimeout` and `WriteTimeout` are both 60s, so the client sees a reset rather
than the response. `500` stands, as on #186.

## Operational boundaries, documented

This is an offline command and the docs say so plainly. The per-subject lock is
real only on backends providing cross-process locking, and the inventory append
is atomic only on SQL backends — so everything except PostgreSQL and MySQL gets
a stop-the-server warning, including etcd and Redis. Running it beside a live
server on a blob backend can corrupt the inventory HMAC, after which the server
will not restart and there is no supported repair (#188).

Withdrawing a `pp_cli_auth` grant takes three steps, not one: revoke, restart
every replica, then check for other live serials — which current tooling may not
be able to revoke at all (#177). The banner and the docs both say this.

## Follow-ups

- #187 (same-host locking) and #188 (inventory-HMAC rebuild) were filed while
  planning this.
- The "Authorisation parity" prose on #164, #166 and #186 is falsified by this
  change (it says `pp_cli_auth` "must be signed offline with the CA private key"
  and is "unavailable when `ca_key_provider: openbao`"). Whichever merges first
  needs amending; not done here to avoid conflicting with three open branches.
- #173/#186 close the window where a revoked certificate can renew itself.
  Merging those first is preferable — this branch's operator-facing text
  describes the wider window that exists without them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

